### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+lopsy.art

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
 export default defineConfig({
+  base: '/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and deploy on push to main
- Add `public/CNAME` for custom domain `lopsy.art`
- Set Vite `base: '/'` for root-level serving

## Setup needed
1. In repo **Settings → Pages**, set source to **GitHub Actions**
2. Add `lopsy.art` as the custom domain
3. Configure DNS (CNAME → `theseamusjames.github.io` or A records to GitHub IPs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)