### PR TITLE
Add new document modal and disable browser zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Loppsy</title>
   </head>
   <body>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { ToolSettingsPanel } from '../panels/ToolSettingsPanel/ToolSettingsPanel
 import { PanelContainer } from '../panels/PanelContainer/PanelContainer';
 import { MenuBar } from './MenuBar/MenuBar';
 import { StatusBar } from './StatusBar/StatusBar';
+import { NewDocumentModal } from '../components/NewDocumentModal/NewDocumentModal';
 import { useUIStore } from './ui-store';
 import { useEditorStore } from './editor-store';
 import { useCanvasInteraction, strokeCurrentPath } from './useCanvasInteraction';
@@ -44,10 +45,41 @@ export function App() {
   const cropRect = useUIStore((s) => s.cropRect);
   const transform = useUIStore((s) => s.transform);
 
+  const documentReady = useEditorStore((s) => s.documentReady);
+  const createDocument = useEditorStore((s) => s.createDocument);
+  const openImageAsDocument = useEditorStore((s) => s.openImageAsDocument);
+  const showNewDocumentModal = useUIStore((s) => s.showNewDocumentModal);
+  const setShowNewDocumentModal = useUIStore((s) => s.setShowNewDocumentModal);
+
   const [cursorPos, setCursorPos] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const [isSpaceDown, setIsSpaceDown] = useState(false);
   const panStartRef = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
+
+  const handleCreateDocument = useCallback((width: number, height: number, background: 'white' | 'transparent') => {
+    createDocument(width, height, background === 'transparent');
+    setShowNewDocumentModal(false);
+  }, [createDocument, setShowNewDocumentModal]);
+
+  const handleOpenFile = useCallback((file: File) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.drawImage(img, 0, 0);
+        const imageData = ctx.getImageData(0, 0, img.width, img.height);
+        const name = file.name.replace(/\.[^.]+$/, '');
+        openImageAsDocument(imageData, name);
+      }
+      URL.revokeObjectURL(url);
+    };
+    img.src = url;
+    setShowNewDocumentModal(false);
+  }, [openImageAsDocument, setShowNewDocumentModal]);
 
   // Render canvas
   useEffect(() => {
@@ -571,8 +603,28 @@ export function App() {
   const [toolSettingsCollapsed, setToolSettingsCollapsed] = useState(false);
   const [colorPanelCollapsed, setColorPanelCollapsed] = useState(false);
 
+  const showModal = !documentReady || showNewDocumentModal;
+
+  if (!documentReady) {
+    return (
+      <div className={styles.app}>
+        <NewDocumentModal
+          onCreateDocument={handleCreateDocument}
+          onOpenFile={handleOpenFile}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.app}>
+      {showModal && (
+        <NewDocumentModal
+          onCreateDocument={handleCreateDocument}
+          onOpenFile={handleOpenFile}
+          onCancel={() => setShowNewDocumentModal(false)}
+        />
+      )}
       <div className={styles.header}>
         <MenuBar />
       </div>

--- a/src/app/MenuBar/MenuBar.tsx
+++ b/src/app/MenuBar/MenuBar.tsx
@@ -123,13 +123,50 @@ function fillSelection() {
   state.updateLayerPixelData(activeId, buf.toImageData());
 }
 
+function openFileFromDisk(): void {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = 'image/*';
+  input.onchange = () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.drawImage(img, 0, 0);
+        const imageData = ctx.getImageData(0, 0, img.width, img.height);
+        const name = file.name.replace(/\.[^.]+$/, '');
+        useEditorStore.getState().openImageAsDocument(imageData, name);
+      }
+      URL.revokeObjectURL(url);
+    };
+    img.src = url;
+  };
+  input.click();
+}
+
 function getMenus(): MenuDef[] {
   return [
     {
       label: 'File',
       items: [
-        { label: 'New', shortcut: '\u2318N', disabled: true },
-        { label: 'Open...', shortcut: '\u2318O', disabled: true },
+        {
+          label: 'New',
+          shortcut: '\u2318N',
+          action: () => {
+            useUIStore.getState().setShowNewDocumentModal(true);
+          },
+        },
+        {
+          label: 'Open...',
+          shortcut: '\u2318O',
+          action: () => openFileFromDisk(),
+        },
         { separator: true, label: '' },
         { label: 'Save', shortcut: '\u2318S', disabled: true },
         { label: 'Save As...', shortcut: '\u21E7\u2318S', disabled: true },

--- a/src/app/editor-store.ts
+++ b/src/app/editor-store.ts
@@ -32,6 +32,11 @@ interface EditorState {
   redoStack: HistorySnapshot[];
   renderVersion: number;
   selection: SelectionData;
+  documentReady: boolean;
+
+  // Document creation
+  createDocument: (width: number, height: number, transparentBg: boolean) => void;
+  openImageAsDocument: (imageData: ImageData, name: string) => void;
 
   // Document mutations
   addLayer: () => void;
@@ -118,6 +123,95 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   redoStack: [],
   renderVersion: 0,
   selection: { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 },
+  documentReady: false,
+
+  createDocument: (width: number, height: number, transparentBg: boolean) => {
+    const bgLayer: RasterLayer = {
+      id: generateId(),
+      name: 'Background',
+      type: 'raster',
+      visible: true,
+      locked: false,
+      opacity: 1,
+      blendMode: 'normal',
+      x: 0,
+      y: 0,
+      clipToBelow: false,
+      maskId: null,
+      width,
+      height,
+    };
+    const bgColor = transparentBg
+      ? { r: 0, g: 0, b: 0, a: 0 }
+      : { r: 255, g: 255, b: 255, a: 1 };
+    const pixelData = new Map<string, ImageData>();
+    const imgData = new ImageData(width, height);
+    if (!transparentBg) {
+      for (let i = 0; i < imgData.data.length; i += 4) {
+        imgData.data[i] = 255;
+        imgData.data[i + 1] = 255;
+        imgData.data[i + 2] = 255;
+        imgData.data[i + 3] = 255;
+      }
+    }
+    pixelData.set(bgLayer.id, imgData);
+    set({
+      document: {
+        id: generateId(),
+        name: 'Untitled',
+        width,
+        height,
+        layers: [bgLayer],
+        layerOrder: [bgLayer.id],
+        activeLayerId: bgLayer.id,
+        backgroundColor: bgColor,
+      },
+      layerPixelData: pixelData,
+      undoStack: [],
+      redoStack: [],
+      renderVersion: 0,
+      selection: { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 },
+      documentReady: true,
+    });
+  },
+
+  openImageAsDocument: (imageData: ImageData, name: string) => {
+    const layer: RasterLayer = {
+      id: generateId(),
+      name: 'Background',
+      type: 'raster',
+      visible: true,
+      locked: false,
+      opacity: 1,
+      blendMode: 'normal',
+      x: 0,
+      y: 0,
+      clipToBelow: false,
+      maskId: null,
+      width: imageData.width,
+      height: imageData.height,
+    };
+    const pixelData = new Map<string, ImageData>();
+    pixelData.set(layer.id, imageData);
+    set({
+      document: {
+        id: generateId(),
+        name,
+        width: imageData.width,
+        height: imageData.height,
+        layers: [layer],
+        layerOrder: [layer.id],
+        activeLayerId: layer.id,
+        backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+      },
+      layerPixelData: pixelData,
+      undoStack: [],
+      redoStack: [],
+      renderVersion: 0,
+      selection: { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 },
+      documentReady: true,
+    });
+  },
 
   addLayer: () => {
     const state = get();

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -22,6 +22,8 @@ interface UIState {
   cropRect: { x: number; y: number; width: number; height: number } | null;
   transform: TransformState | null;
   activeTransformHandle: TransformHandle | null;
+  showNewDocumentModal: boolean;
+  setShowNewDocumentModal: (show: boolean) => void;
   setActiveTool: (tool: ToolId) => void;
   setForegroundColor: (color: Color) => void;
   setBackgroundColor: (color: Color) => void;
@@ -56,6 +58,8 @@ export const useUIStore = create<UIState>((set) => ({
   cropRect: null,
   transform: null,
   activeTransformHandle: null,
+  showNewDocumentModal: false,
+  setShowNewDocumentModal: (show) => set({ showNewDocumentModal: show }),
 
   setActiveTool: (tool) => {
     // Clear path when switching away from path tool

--- a/src/components/NewDocumentModal/NewDocumentModal.module.css
+++ b/src/components/NewDocumentModal/NewDocumentModal.module.css
@@ -1,0 +1,246 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+}
+
+.modal {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.header {
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header h2 {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.body {
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.presets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.presetsLabel {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.presetGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+}
+
+.presetButton {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.presetButton:hover {
+  background: var(--color-bg-hover);
+}
+
+.presetButtonActive {
+  border-color: var(--color-accent);
+  background: var(--color-accent-subtle);
+}
+
+.presetName {
+  display: block;
+  font-weight: 500;
+}
+
+.presetDims {
+  display: block;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+.dimensions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.dimensionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+}
+
+.fieldLabel {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.fieldInput {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.fieldInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.unitSelect {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  min-width: 80px;
+}
+
+.unitSelect:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.dpiRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.bgRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.bgOption {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.bgSwatch {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-strong);
+}
+
+.bgSwatchWhite {
+  background: #ffffff;
+}
+
+.bgSwatchTransparent {
+  background: repeating-conic-gradient(#cccccc 0% 25%, #ffffff 0% 50%) 50% / 8px 8px;
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid var(--color-border-subtle);
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.footerRight {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.openFileButton {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.openFileButton:hover {
+  background: var(--color-bg-hover);
+}
+
+.createButton {
+  background: var(--color-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-5);
+  color: #ffffff;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.createButton:hover {
+  background: var(--color-accent-hover);
+}
+
+.createButton:active {
+  background: var(--color-accent-active);
+}

--- a/src/components/NewDocumentModal/NewDocumentModal.tsx
+++ b/src/components/NewDocumentModal/NewDocumentModal.tsx
@@ -1,0 +1,223 @@
+import { useState, useCallback } from 'react';
+import styles from './NewDocumentModal.module.css';
+
+type Unit = 'px' | 'in';
+type BackgroundType = 'white' | 'transparent';
+
+interface Preset {
+  name: string;
+  width: number;
+  height: number;
+  unit: Unit;
+  dpi: number;
+}
+
+const PRESETS: Preset[] = [
+  { name: 'Web 1080p', width: 1920, height: 1080, unit: 'px', dpi: 72 },
+  { name: 'Web 720p', width: 1280, height: 720, unit: 'px', dpi: 72 },
+  { name: 'Instagram Post', width: 1080, height: 1080, unit: 'px', dpi: 72 },
+  { name: 'US Letter', width: 8.5, height: 11, unit: 'in', dpi: 300 },
+  { name: 'A4', width: 8.27, height: 11.69, unit: 'in', dpi: 300 },
+  { name: '4K UHD', width: 3840, height: 2160, unit: 'px', dpi: 72 },
+];
+
+function toPixels(value: number, unit: Unit, dpi: number): number {
+  if (unit === 'in') return Math.round(value * dpi);
+  return Math.round(value);
+}
+
+interface NewDocumentModalProps {
+  onCreateDocument: (width: number, height: number, background: BackgroundType) => void;
+  onOpenFile: (file: File) => void;
+  onCancel?: () => void;
+}
+
+export function NewDocumentModal({ onCreateDocument, onOpenFile, onCancel }: NewDocumentModalProps) {
+  const [width, setWidth] = useState('1920');
+  const [height, setHeight] = useState('1080');
+  const [unit, setUnit] = useState<Unit>('px');
+  const [dpi, setDpi] = useState('72');
+  const [background, setBackground] = useState<BackgroundType>('white');
+  const [activePreset, setActivePreset] = useState<number>(0);
+
+  const handlePresetClick = useCallback((index: number) => {
+    const preset = PRESETS[index];
+    if (!preset) return;
+    setActivePreset(index);
+    setWidth(String(preset.width));
+    setHeight(String(preset.height));
+    setUnit(preset.unit);
+    setDpi(String(preset.dpi));
+  }, []);
+
+  const handleUnitChange = useCallback((newUnit: Unit) => {
+    const currentDpi = parseInt(dpi, 10) || 72;
+    const wNum = parseFloat(width) || 0;
+    const hNum = parseFloat(height) || 0;
+
+    if (unit === 'px' && newUnit === 'in') {
+      setWidth((wNum / currentDpi).toFixed(2));
+      setHeight((hNum / currentDpi).toFixed(2));
+    } else if (unit === 'in' && newUnit === 'px') {
+      setWidth(String(Math.round(wNum * currentDpi)));
+      setHeight(String(Math.round(hNum * currentDpi)));
+    }
+    setUnit(newUnit);
+    setActivePreset(-1);
+  }, [unit, dpi, width, height]);
+
+  const handleCreate = useCallback(() => {
+    const wNum = parseFloat(width) || 1;
+    const hNum = parseFloat(height) || 1;
+    const dpiNum = parseInt(dpi, 10) || 72;
+    const pxW = Math.max(1, Math.min(16384, toPixels(wNum, unit, dpiNum)));
+    const pxH = Math.max(1, Math.min(16384, toPixels(hNum, unit, dpiNum)));
+    onCreateDocument(pxW, pxH, background);
+  }, [width, height, unit, dpi, background, onCreateDocument]);
+
+  const handleOpenFile = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (file) onOpenFile(file);
+    };
+    input.click();
+  }, [onOpenFile]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleCreate();
+    } else if (e.key === 'Escape' && onCancel) {
+      e.preventDefault();
+      onCancel();
+    }
+  }, [handleCreate, onCancel]);
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal} onKeyDown={handleKeyDown}>
+        <div className={styles.header}>
+          <h2>New Document</h2>
+        </div>
+        <div className={styles.body}>
+          <div className={styles.presets}>
+            <span className={styles.presetsLabel}>Presets</span>
+            <div className={styles.presetGrid}>
+              {PRESETS.map((preset, i) => (
+                <button
+                  key={preset.name}
+                  className={`${styles.presetButton} ${i === activePreset ? styles.presetButtonActive : ''}`}
+                  onClick={() => handlePresetClick(i)}
+                >
+                  <span className={styles.presetName}>{preset.name}</span>
+                  <span className={styles.presetDims}>
+                    {preset.width} × {preset.height} {preset.unit}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <hr className={styles.divider} />
+
+          <div className={styles.dimensions}>
+            <div className={styles.dimensionRow}>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel}>Width</label>
+                <input
+                  className={styles.fieldInput}
+                  type="number"
+                  min="1"
+                  step={unit === 'in' ? '0.01' : '1'}
+                  value={width}
+                  onChange={(e) => { setWidth(e.target.value); setActivePreset(-1); }}
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel}>Height</label>
+                <input
+                  className={styles.fieldInput}
+                  type="number"
+                  min="1"
+                  step={unit === 'in' ? '0.01' : '1'}
+                  value={height}
+                  onChange={(e) => { setHeight(e.target.value); setActivePreset(-1); }}
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel}>Unit</label>
+                <select
+                  className={styles.unitSelect}
+                  value={unit}
+                  onChange={(e) => handleUnitChange(e.target.value as Unit)}
+                >
+                  <option value="px">Pixels</option>
+                  <option value="in">Inches</option>
+                </select>
+              </div>
+            </div>
+
+            {unit === 'in' && (
+              <div className={styles.dpiRow}>
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>Resolution (DPI)</label>
+                  <input
+                    className={styles.fieldInput}
+                    type="number"
+                    min="1"
+                    max="1200"
+                    value={dpi}
+                    onChange={(e) => { setDpi(e.target.value); setActivePreset(-1); }}
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className={styles.bgRow}>
+              <span className={styles.fieldLabel}>Background</span>
+              <label className={styles.bgOption}>
+                <input
+                  type="radio"
+                  name="bg"
+                  checked={background === 'white'}
+                  onChange={() => setBackground('white')}
+                />
+                <span className={`${styles.bgSwatch} ${styles.bgSwatchWhite}`} />
+                White
+              </label>
+              <label className={styles.bgOption}>
+                <input
+                  type="radio"
+                  name="bg"
+                  checked={background === 'transparent'}
+                  onChange={() => setBackground('transparent')}
+                />
+                <span className={`${styles.bgSwatch} ${styles.bgSwatchTransparent}`} />
+                Transparent
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.footer}>
+          <button className={styles.openFileButton} onClick={handleOpenFile}>
+            Open File…
+          </button>
+          <div className={styles.footerRight}>
+            {onCancel && (
+              <button className={styles.openFileButton} onClick={onCancel}>
+                Cancel
+              </button>
+            )}
+            <button className={styles.createButton} onClick={handleCreate}>
+              Create
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,13 @@ if (import.meta.env.DEV) {
   (window as unknown as Record<string, unknown>).__uiStore = useUIStore;
 }
 
+// Prevent browser zoom so Ctrl+wheel and pinch gestures only affect the canvas
+document.addEventListener('wheel', (e) => {
+  if (e.ctrlKey || e.metaKey) e.preventDefault();
+}, { passive: false });
+document.addEventListener('gesturestart', (e) => e.preventDefault());
+document.addEventListener('gesturechange', (e) => e.preventDefault());
+
 const root = document.getElementById('root');
 if (!root) {
   throw new Error('Root element not found');


### PR DESCRIPTION
## Summary
- Add a startup modal for document creation with presets (Web 1080p, 720p, Instagram Post, US Letter, A4, 4K UHD), custom px/in dimensions with DPI, and white/transparent background options
- Wire File > New to show the modal and File > Open to load local images as documents
- Prevent browser zoom (Ctrl+wheel, pinch gestures) so zoom controls only affect the canvas

## Test plan
- [ ] Verify the modal appears on app startup instead of a default 800x600 canvas
- [ ] Click presets and confirm dimensions update correctly
- [ ] Toggle between px/in units and verify conversion
- [ ] Create documents with both white and transparent backgrounds
- [ ] Open a local image file via the modal and via File > Open
- [ ] File > New shows the modal with Cancel/Escape to dismiss
- [ ] Ctrl+scroll zooms the canvas, not the browser page
- [ ] Pinch-to-zoom on trackpad does not zoom the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)