### PR TITLE
Add tool-aware cursors and shift-click line drawing

### DIFF
--- a/src/app/App.module.css
+++ b/src/app/App.module.css
@@ -29,8 +29,40 @@
   cursor: crosshair;
 }
 
+.canvasNone {
+  cursor: none;
+}
+
+.canvasMove {
+  cursor: move;
+}
+
+.canvasText {
+  cursor: text;
+}
+
 .canvasGrab {
   cursor: grab;
+}
+
+.canvasPointer {
+  cursor: pointer;
+}
+
+.canvasNwseResize {
+  cursor: nwse-resize;
+}
+
+.canvasNsResize {
+  cursor: ns-resize;
+}
+
+.canvasNeswResize {
+  cursor: nesw-resize;
+}
+
+.canvasEwResize {
+  cursor: ew-resize;
 }
 
 .canvas canvas {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,6 +16,7 @@ import { useEditorStore } from './editor-store';
 import { useCanvasInteraction } from './useCanvasInteraction';
 import { useCanvasRendering } from './useCanvasRendering';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+import { useCanvasCursor } from './useCanvasCursor';
 import styles from './App.module.css';
 
 export function App() {
@@ -129,6 +130,9 @@ export function App() {
   // Canvas interaction (drawing tools)
   const { handleToolDown, handleToolMove, handleToolUp, clearPersistentTransform } = useCanvasInteraction(screenToCanvas, containerRef);
 
+  // Cursor management
+  const { updateHoveredHandle } = useCanvasCursor(containerRef, isPanning, isSpaceDown);
+
   // Keyboard shortcuts (extracted to useKeyboardShortcuts)
   useKeyboardShortcuts({
     canvasRef,
@@ -158,10 +162,11 @@ export function App() {
         const dy = e.clientY - panStartRef.current.y;
         setPan(panStartRef.current.panX + dx, panStartRef.current.panY + dy);
       } else {
+        updateHoveredHandle(canvasPos);
         handleToolMove(e);
       }
     },
-    [isPanning, screenToCanvas, setPan, handleToolMove],
+    [isPanning, screenToCanvas, setPan, handleToolMove, updateHoveredHandle],
   );
 
   const handleMouseDown = useCallback(
@@ -251,7 +256,7 @@ export function App() {
         <div
           ref={containerRef}
           data-testid="canvas-container"
-          className={`${styles.canvas} ${isPanning || isSpaceDown ? styles.canvasGrab : styles.canvasCrosshair}`}
+          className={styles.canvas}
           onMouseMove={handleMouseMove}
           onMouseDown={handleMouseDown}
           onMouseUp={handleMouseUp}

--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect } from 'react';
+import type { RefObject } from 'react';
+import { useUIStore } from './ui-store';
+import { useEditorStore } from './editor-store';
+import { useToolSettingsStore } from './tool-settings-store';
+import { hitTestHandle, getCursorForHandle } from '../tools/transform/transform';
+import type { TransformHandle } from '../tools/transform/transform';
+import type { ToolId, Point } from '../types';
+import styles from './App.module.css';
+
+type BrushTool = 'brush' | 'pencil' | 'eraser' | 'stamp' | 'dodge';
+
+const BRUSH_TOOLS: ReadonlySet<string> = new Set<BrushTool>([
+  'brush',
+  'pencil',
+  'eraser',
+  'stamp',
+  'dodge',
+]);
+
+function isBrushTool(tool: ToolId): tool is BrushTool {
+  return BRUSH_TOOLS.has(tool);
+}
+
+function getToolSize(tool: BrushTool, settings: ReturnType<typeof useToolSettingsStore.getState>): number {
+  switch (tool) {
+    case 'brush':
+    case 'dodge':
+      return settings.brushSize;
+    case 'pencil':
+      return settings.pencilSize;
+    case 'eraser':
+      return settings.eraserSize;
+    case 'stamp':
+      return settings.stampSize;
+  }
+}
+
+function getCursorClassForTool(tool: ToolId): string {
+  switch (tool) {
+    case 'move':
+      return styles.canvasMove ?? '';
+    case 'text':
+      return styles.canvasText ?? '';
+    case 'brush':
+    case 'pencil':
+    case 'eraser':
+    case 'stamp':
+    case 'dodge':
+      return styles.canvasNone ?? '';
+    case 'marquee-rect':
+    case 'marquee-ellipse':
+    case 'lasso':
+    case 'lasso-poly':
+    case 'wand':
+    case 'fill':
+    case 'gradient':
+    case 'eyedropper':
+    case 'shape':
+    case 'crop':
+    case 'path':
+      return styles.canvasCrosshair ?? '';
+    default:
+      return styles.canvasCrosshair ?? '';
+  }
+}
+
+const HANDLE_CURSOR_MAP: Record<string, string> = {
+  'nwse-resize': styles.canvasNwseResize ?? '',
+  'ns-resize': styles.canvasNsResize ?? '',
+  'nesw-resize': styles.canvasNeswResize ?? '',
+  'ew-resize': styles.canvasEwResize ?? '',
+  'crosshair': styles.canvasCrosshair ?? '',
+};
+
+function getCursorClassForHandle(handle: TransformHandle): string {
+  const cursorValue = getCursorForHandle(handle);
+  return HANDLE_CURSOR_MAP[cursorValue] ?? styles.canvasPointer ?? '';
+}
+
+export function useCanvasCursor(
+  containerRef: RefObject<HTMLDivElement | null>,
+  isPanning: boolean,
+  isSpaceDown: boolean,
+): {
+  updateHoveredHandle: (canvasPos: Point) => void;
+} {
+  const activeTool = useUIStore((s) => s.activeTool);
+  const hoveredHandle = useUIStore((s) => s.activeTransformHandle);
+  const transform = useUIStore((s) => s.transform);
+  const selectionActive = useEditorStore((s) => s.selection.active);
+
+  // Compute cursor class
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let cursorClass: string;
+
+    if (isPanning || isSpaceDown) {
+      cursorClass = styles.canvasGrab ?? '';
+    } else if (hoveredHandle) {
+      cursorClass = getCursorClassForHandle(hoveredHandle);
+    } else {
+      cursorClass = getCursorClassForTool(activeTool);
+    }
+
+    // Remove all cursor classes, then add the current one
+    const allCursorClasses = [
+      styles.canvasCrosshair,
+      styles.canvasNone,
+      styles.canvasMove,
+      styles.canvasText,
+      styles.canvasGrab,
+      styles.canvasPointer,
+      styles.canvasNwseResize,
+      styles.canvasNsResize,
+      styles.canvasNeswResize,
+      styles.canvasEwResize,
+    ].filter(Boolean) as string[];
+
+    container.classList.remove(...allCursorClasses);
+    if (cursorClass) {
+      container.classList.add(cursorClass);
+    }
+  }, [containerRef, isPanning, isSpaceDown, activeTool, hoveredHandle, transform, selectionActive]);
+
+  // Hit test transform handles on hover
+  const updateHoveredHandle = useCallback(
+    (canvasPos: Point) => {
+      const uiState = useUIStore.getState();
+      const editorState = useEditorStore.getState();
+      const currentTransform = uiState.transform;
+
+      if (currentTransform && editorState.selection.active) {
+        const handleRadius = 8 / editorState.viewport.zoom;
+        const hit = hitTestHandle(canvasPos, currentTransform, handleRadius);
+        if (hit !== uiState.activeTransformHandle) {
+          uiState.setActiveTransformHandle(hit);
+        }
+      } else if (uiState.activeTransformHandle !== null) {
+        uiState.setActiveTransformHandle(null);
+      }
+    },
+    [],
+  );
+
+  return { updateHoveredHandle };
+}
+
+export interface BrushCursorInfo {
+  readonly size: number;
+  readonly shape: 'circle' | 'square';
+}
+
+export function getBrushCursorInfo(tool: ToolId): BrushCursorInfo | null {
+  if (!isBrushTool(tool)) return null;
+  const settings = useToolSettingsStore.getState();
+  return {
+    size: getToolSize(tool, settings),
+    shape: tool === 'pencil' ? 'square' : 'circle',
+  };
+}

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -164,6 +164,9 @@ export function useCanvasInteraction(
   const stampSourceRef = useRef<Point | null>(null);
   const stampOffsetRef = useRef<Point | null>(null);
 
+  // Last paint endpoint for shift-click line drawing (layer-local coords)
+  const lastPaintPointRef = useRef<{ point: Point; layerId: string } | null>(null);
+
   const handleToolDown = useCallback(
     (e: React.MouseEvent) => {
       if (e.button !== 0) return;
@@ -472,6 +475,12 @@ export function useCanvasInteraction(
         case 'brush':
         case 'pencil':
         case 'eraser': {
+          // Shift+click: draw a line from the last paint point to here
+          const shiftLine = e.shiftKey
+            && lastPaintPointRef.current
+            && lastPaintPointRef.current.layerId === activeLayerId;
+          const lineFrom = shiftLine ? lastPaintPointRef.current!.point : layerPos;
+
           const maskEditMode = useUIStore.getState().maskEditMode;
           if (maskEditMode && activeLayer.mask) {
             editorState.pushHistory();
@@ -500,16 +509,32 @@ export function useCanvasInteraction(
               const hardness = toolSettings.brushHardness / 100;
               const opacity = toolSettings.brushOpacity / 100;
               const stamp = generateBrushStamp(size, hardness);
-              applyBrushDab(maskBuf, layerPos, stamp, size, maskColor, opacity, 1);
+              if (shiftLine) {
+                const spacing = Math.max(1, size * 0.25);
+                const pts = interpolatePoints(lineFrom, layerPos, spacing);
+                for (const pt of pts) {
+                  applyBrushDab(maskBuf, pt, stamp, size, maskColor, opacity, 1);
+                }
+              } else {
+                applyBrushDab(maskBuf, layerPos, stamp, size, maskColor, opacity, 1);
+              }
             } else if (activeTool === 'pencil') {
               const size = toolSettings.pencilSize;
-              drawPencilLine(maskBuf, layerPos, layerPos, maskColor, size);
+              drawPencilLine(maskBuf, lineFrom, layerPos, maskColor, size);
             } else {
               const size = toolSettings.eraserSize;
               const hardness = 0.8;
               const opacity = toolSettings.eraserOpacity / 100;
               const stamp = generateEraserStamp(size, hardness);
-              applyBrushDab(maskBuf, layerPos, stamp, size, maskColor, opacity, 1);
+              if (shiftLine) {
+                const spacing = Math.max(1, size * 0.25);
+                const pts = interpolatePoints(lineFrom, layerPos, spacing);
+                for (const pt of pts) {
+                  applyBrushDab(maskBuf, pt, stamp, size, maskColor, opacity, 1);
+                }
+              } else {
+                applyBrushDab(maskBuf, layerPos, stamp, size, maskColor, opacity, 1);
+              }
             }
 
             activeMaskEditBuffer = { layerId: activeLayerId, buf: maskBuf, maskWidth: activeLayer.mask.width, maskHeight: activeLayer.mask.height };
@@ -538,18 +563,34 @@ export function useCanvasInteraction(
             const stamp = generateBrushStamp(size, hardness);
             const color = useUIStore.getState().foregroundColor;
             useUIStore.getState().addRecentColor(color);
-            applyBrushDab(paintSurface, layerPos, stamp, size, color, opacity, 1);
+            if (shiftLine) {
+              const spacing = Math.max(1, size * 0.25);
+              const pts = interpolatePoints(lineFrom, layerPos, spacing);
+              for (const pt of pts) {
+                applyBrushDab(paintSurface, pt, stamp, size, color, opacity, 1);
+              }
+            } else {
+              applyBrushDab(paintSurface, layerPos, stamp, size, color, opacity, 1);
+            }
           } else if (activeTool === 'pencil') {
             const color = useUIStore.getState().foregroundColor;
             useUIStore.getState().addRecentColor(color);
             const size = toolSettings.pencilSize;
-            drawPencilLine(paintSurface, layerPos, layerPos, color, size);
+            drawPencilLine(paintSurface, lineFrom, layerPos, color, size);
           } else {
             const size = toolSettings.eraserSize;
             const hardness = 0.8;
             const opacity = toolSettings.eraserOpacity / 100;
             const stamp = generateEraserStamp(size, hardness);
-            applyEraserDab(paintSurface, layerPos, stamp, size, opacity);
+            if (shiftLine) {
+              const spacing = Math.max(1, size * 0.25);
+              const pts = interpolatePoints(lineFrom, layerPos, spacing);
+              for (const pt of pts) {
+                applyEraserDab(paintSurface, pt, stamp, size, opacity);
+              }
+            } else {
+              applyEraserDab(paintSurface, layerPos, stamp, size, opacity);
+            }
           }
 
           editorState.updateLayerPixelData(activeLayerId, pixelBuffer.toImageData());
@@ -629,7 +670,18 @@ export function useCanvasInteraction(
           const dodgeMode = toolSettings.dodgeMode;
           const exposure = toolSettings.dodgeExposure / 100;
           const dodgeSize = toolSettings.brushSize;
-          applyDodgeBurn(paintSurface, layerPos, dodgeSize, dodgeMode, exposure);
+          const dodgeShiftLine = e.shiftKey
+            && lastPaintPointRef.current
+            && lastPaintPointRef.current.layerId === activeLayerId;
+          if (dodgeShiftLine) {
+            const spacing = Math.max(1, dodgeSize * 0.25);
+            const pts = interpolatePoints(lastPaintPointRef.current!.point, layerPos, spacing);
+            for (const pt of pts) {
+              applyDodgeBurn(paintSurface, pt, dodgeSize, dodgeMode, exposure);
+            }
+          } else {
+            applyDodgeBurn(paintSurface, layerPos, dodgeSize, dodgeMode, exposure);
+          }
           editorState.updateLayerPixelData(activeLayerId, pixelBuffer.toImageData());
           stateRef.current = {
             drawing: true,
@@ -705,8 +757,19 @@ export function useCanvasInteraction(
             layerStartY: activeLayer.y,
             ...DEFAULT_TRANSFORM_FIELDS,
           };
-          // Apply initial dab
-          applyStampDab(paintSurface, pixelBuffer, layerPos, stampOffsetRef.current, toolSettings.stampSize);
+          // Shift+click: stamp a line from the last paint point
+          const stampShiftLine = e.shiftKey
+            && lastPaintPointRef.current
+            && lastPaintPointRef.current.layerId === activeLayerId;
+          if (stampShiftLine) {
+            const spacing = Math.max(1, toolSettings.stampSize * 0.25);
+            const pts = interpolatePoints(lastPaintPointRef.current!.point, layerPos, spacing);
+            for (const pt of pts) {
+              applyStampDab(paintSurface, pixelBuffer, pt, stampOffsetRef.current, toolSettings.stampSize);
+            }
+          } else {
+            applyStampDab(paintSurface, pixelBuffer, layerPos, stampOffsetRef.current, toolSettings.stampSize);
+          }
           editorState.updateLayerPixelData(activeLayerId, pixelBuffer.toImageData());
           break;
         }
@@ -1329,6 +1392,12 @@ export function useCanvasInteraction(
         useEditorStore.getState().cropCanvas(cropRect);
       }
       useUIStore.getState().setCropRect(null);
+    }
+
+    // Save last paint point for shift+click line drawing
+    const paintTools: ReadonlySet<ToolId> = new Set(['brush', 'pencil', 'eraser', 'dodge', 'stamp']);
+    if (state.tool && paintTools.has(state.tool) && state.lastPoint && state.layerId) {
+      lastPaintPointRef.current = { point: state.lastPoint, layerId: state.layerId };
     }
 
     // Clear active transform handle

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState, type RefObject } from 'react';
 import { useEditorStore } from './editor-store';
 import { useUIStore } from './ui-store';
+import { useToolSettingsStore } from './tool-settings-store';
 import { getActiveMaskEditBuffer } from './useCanvasInteraction';
+import { getBrushCursorInfo } from './useCanvasCursor';
 import { getHandlePositions } from '../tools/transform/transform';
 import type { TransformHandle, TransformState } from '../tools/transform/transform';
 import { traceSelectionContours } from '../selection/selection';
@@ -24,6 +26,12 @@ export function useCanvasRendering(
   const transform = useUIStore((s) => s.transform);
   const gradientPreview = useUIStore((s) => s.gradientPreview);
   const maskEditMode = useUIStore((s) => s.maskEditMode);
+  const activeTool = useUIStore((s) => s.activeTool);
+  const cursorPosition = useUIStore((s) => s.cursorPosition);
+  const brushSize = useToolSettingsStore((s) => s.brushSize);
+  const pencilSize = useToolSettingsStore((s) => s.pencilSize);
+  const eraserSize = useToolSettingsStore((s) => s.eraserSize);
+  const stampSize = useToolSettingsStore((s) => s.stampSize);
 
   const [antPhase, setAntPhase] = useState(0);
   const antFrameRef = useRef(0);
@@ -110,9 +118,14 @@ export function useCanvasRendering(
     renderCropPreview(ctx, cropRect, doc.width, doc.height, viewport.zoom);
     renderGradientPreview(ctx, gradientPreview, viewport.zoom);
 
+    const brushCursor = getBrushCursorInfo(activeTool);
+    if (brushCursor !== null) {
+      renderBrushCursor(ctx, cursorPosition, brushCursor.size, viewport.zoom, brushCursor.shape);
+    }
+
     ctx.restore();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [doc, viewport, layers, renderVersion, selection, pathAnchors, lassoPoints, cropRect, transform, maskEditMode, activeLayerId, gradientPreview, antPhase]);
+  }, [doc, viewport, layers, renderVersion, selection, pathAnchors, lassoPoints, cropRect, transform, maskEditMode, activeLayerId, gradientPreview, antPhase, activeTool, cursorPosition, brushSize, pencilSize, eraserSize, stampSize]);
 }
 
 // --- Helper render functions ---
@@ -708,6 +721,64 @@ function renderGradientPreview(
     ctx.fill();
     ctx.strokeStyle = '#000000';
     ctx.lineWidth = 1 / zoom;
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function renderBrushCursor(
+  ctx: CanvasRenderingContext2D,
+  position: Point,
+  size: number,
+  zoom: number,
+  shape: 'circle' | 'square',
+): void {
+  const half = size / 2;
+
+  ctx.save();
+
+  // Draw a crosshair at center for very small brushes
+  if (size * zoom < 4) {
+    const crossSize = 5 / zoom;
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 1.5 / zoom;
+    ctx.beginPath();
+    ctx.moveTo(position.x - crossSize, position.y);
+    ctx.lineTo(position.x + crossSize, position.y);
+    ctx.moveTo(position.x, position.y - crossSize);
+    ctx.lineTo(position.x, position.y + crossSize);
+    ctx.stroke();
+
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = 0.75 / zoom;
+    ctx.beginPath();
+    ctx.moveTo(position.x - crossSize, position.y);
+    ctx.lineTo(position.x + crossSize, position.y);
+    ctx.moveTo(position.x, position.y - crossSize);
+    ctx.lineTo(position.x, position.y + crossSize);
+    ctx.stroke();
+  } else if (shape === 'square') {
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.6)';
+    ctx.lineWidth = 1.5 / zoom;
+    ctx.strokeRect(position.x - half, position.y - half, size, size);
+
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
+    ctx.lineWidth = 0.75 / zoom;
+    ctx.strokeRect(position.x - half, position.y - half, size, size);
+  } else {
+    // Outer dark ring
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.6)';
+    ctx.lineWidth = 1.5 / zoom;
+    ctx.beginPath();
+    ctx.arc(position.x, position.y, half, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // Inner light ring
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
+    ctx.lineWidth = 0.75 / zoom;
+    ctx.beginPath();
+    ctx.arc(position.x, position.y, half, 0, Math.PI * 2);
     ctx.stroke();
   }
 


### PR DESCRIPTION
Show brush shape outline (circle or square) for brush, pencil, eraser, stamp, and dodge tools. Use move cursor for move tool, text cursor for text tool, and resize cursors when hovering transform handles. Add shift-click support to draw straight lines between paint strokes.