### PR TITLE
Fix transparent strip on right/bottom canvas edges

### DIFF
--- a/src/app/editor-store.ts
+++ b/src/app/editor-store.ts
@@ -827,10 +827,16 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   cropCanvas: (rect: Rect) => {
     const state = get();
     state.pushHistory('Crop Canvas');
-    const cx = Math.round(rect.x);
-    const cy = Math.round(rect.y);
-    const cw = Math.round(rect.width);
-    const ch = Math.round(rect.height);
+    const docW = state.document.width;
+    const docH = state.document.height;
+    const x1 = Math.max(0, Math.round(rect.x));
+    const y1 = Math.max(0, Math.round(rect.y));
+    const x2 = Math.min(docW, Math.round(rect.x + rect.width));
+    const y2 = Math.min(docH, Math.round(rect.y + rect.height));
+    const cx = x1;
+    const cy = y1;
+    const cw = x2 - x1;
+    const ch = y2 - y1;
     if (cw <= 0 || ch <= 0) return;
 
     const pixelData = new Map<string, ImageData>();

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -1176,12 +1176,15 @@ export function useCanvasInteraction(
 
         case 'crop': {
           if (!state.startPoint) break;
-          const cx = Math.min(state.startPoint.x, canvasPos.x);
-          const cy = Math.min(state.startPoint.y, canvasPos.y);
-          const cw = Math.abs(canvasPos.x - state.startPoint.x);
-          const ch = Math.abs(canvasPos.y - state.startPoint.y);
+          const edDoc = useEditorStore.getState().document;
+          const x1 = Math.max(0, Math.min(state.startPoint.x, canvasPos.x));
+          const y1 = Math.max(0, Math.min(state.startPoint.y, canvasPos.y));
+          const x2 = Math.min(edDoc.width, Math.max(state.startPoint.x, canvasPos.x));
+          const y2 = Math.min(edDoc.height, Math.max(state.startPoint.y, canvasPos.y));
+          const cw = x2 - x1;
+          const ch = y2 - y1;
           if (cw > 0 && ch > 0) {
-            useUIStore.getState().setCropRect({ x: cx, y: cy, width: cw, height: ch });
+            useUIStore.getState().setCropRect({ x: x1, y: y1, width: cw, height: ch });
             useEditorStore.getState().notifyRender();
           }
           break;

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -75,13 +75,16 @@ export function useCanvasRendering(
     ctx.scale(viewport.zoom, viewport.zoom);
     ctx.translate(-doc.width / 2, -doc.height / 2);
 
-    // Checkerboard for transparency
+    // Checkerboard for transparency — clamp tile size at document edges
+    // so tiles don't extend past the document bounds
     const checkSize = 8;
     for (let y = 0; y < doc.height; y += checkSize) {
+      const tileH = Math.min(checkSize, doc.height - y);
       for (let x = 0; x < doc.width; x += checkSize) {
+        const tileW = Math.min(checkSize, doc.width - x);
         const isLight = ((x / checkSize) + (y / checkSize)) % 2 === 0;
         ctx.fillStyle = isLight ? '#ffffff' : '#cccccc';
-        ctx.fillRect(x, y, checkSize, checkSize);
+        ctx.fillRect(x, y, tileW, tileH);
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix checkerboard transparency tiles overflowing past document bounds when dimensions aren't multiples of 8px, creating a visible strip on the right and bottom edges
- Clamp crop tool rect to document bounds so the crop preview and result can't extend past the canvas

## Test plan
- [ ] Open an image with dimensions that aren't multiples of 8 (e.g. 750px tall) — no transparent strip should appear at edges
- [ ] Crop an image and verify no transparent strip appears after cropping
- [ ] Drag crop selection past document edges — preview should clamp to bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)