### PR TITLE
Add rasterize layer style and effect-aware merge down

### DIFF
--- a/e2e/rasterization-fix.spec.ts
+++ b/e2e/rasterization-fix.spec.ts
@@ -1,0 +1,631 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createDocument(page: Page, width = 400, height = 300, transparent = false) {
+  await page.evaluate(
+    ({ w, h, t }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { createDocument: (w: number, h: number, t: boolean) => void };
+      };
+      store.getState().createDocument(w, h, t);
+    },
+    { w: width, h: height, t: transparent },
+  );
+  await page.waitForTimeout(200);
+}
+
+async function getEditorState(page: Page) {
+  return page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => Record<string, unknown>;
+    };
+    const state = store.getState();
+    const doc = state.document as {
+      width: number;
+      height: number;
+      layers: Array<{
+        id: string;
+        name: string;
+        visible: boolean;
+        opacity: number;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        effects: {
+          dropShadow: { enabled: boolean };
+          stroke: { enabled: boolean };
+          outerGlow: { enabled: boolean };
+          innerGlow: { enabled: boolean };
+        };
+      }>;
+      layerOrder: string[];
+      activeLayerId: string;
+    };
+    return {
+      document: doc,
+      undoStack: (state.undoStack as unknown[]).length,
+      redoStack: (state.redoStack as unknown[]).length,
+    };
+  });
+}
+
+async function getUIState(page: Page) {
+  return page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__uiStore as {
+      getState: () => Record<string, unknown>;
+    };
+    const state = store.getState();
+    return {
+      showGrid: state.showGrid as boolean,
+      showGuides: state.showGuides as boolean,
+      showEffectsDrawer: state.showEffectsDrawer as boolean,
+    };
+  });
+}
+
+async function getSelectionState(page: Page) {
+  return page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => {
+        selection: {
+          active: boolean;
+          mask: Uint8ClampedArray | null;
+          maskWidth: number;
+          maskHeight: number;
+        };
+      };
+    };
+    const sel = store.getState().selection;
+    let selectedCount = 0;
+    if (sel.mask) {
+      for (let i = 0; i < sel.mask.length; i++) {
+        if ((sel.mask[i] ?? 0) > 0) selectedCount++;
+      }
+    }
+    return {
+      active: sel.active,
+      selectedPixelCount: selectedCount,
+      maskWidth: sel.maskWidth,
+      maskHeight: sel.maskHeight,
+    };
+  });
+}
+
+async function getPixelAt(page: Page, x: number, y: number, layerId?: string) {
+  return page.evaluate(
+    ({ x, y, lid }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { activeLayerId: string };
+          layerPixelData: Map<string, ImageData>;
+        };
+      };
+      const state = store.getState();
+      const id = lid ?? state.document.activeLayerId;
+      const data = state.layerPixelData.get(id);
+      if (!data) return { r: 0, g: 0, b: 0, a: 0 };
+      const idx = (y * data.width + x) * 4;
+      return {
+        r: data.data[idx] ?? 0,
+        g: data.data[idx + 1] ?? 0,
+        b: data.data[idx + 2] ?? 0,
+        a: data.data[idx + 3] ?? 0,
+      };
+    },
+    { x, y, lid: layerId ?? null },
+  );
+}
+
+async function paintRect(
+  page: Page,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  color: { r: number; g: number; b: number; a: number },
+  layerId?: string,
+) {
+  await page.evaluate(
+    ({ x, y, w, h, color, lid }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { activeLayerId: string };
+          getOrCreateLayerPixelData: (id: string) => ImageData;
+          updateLayerPixelData: (id: string, data: ImageData) => void;
+        };
+      };
+      const state = store.getState();
+      const id = lid ?? state.document.activeLayerId;
+      const data = state.getOrCreateLayerPixelData(id);
+      for (let py = y; py < y + h; py++) {
+        for (let px = x; px < x + w; px++) {
+          if (px < 0 || px >= data.width || py < 0 || py >= data.height) continue;
+          const idx = (py * data.width + px) * 4;
+          data.data[idx] = color.r;
+          data.data[idx + 1] = color.g;
+          data.data[idx + 2] = color.b;
+          data.data[idx + 3] = color.a;
+        }
+      }
+      state.updateLayerPixelData(id, data);
+    },
+    { x, y, w, h, color, lid: layerId ?? null },
+  );
+}
+
+async function addLayer(page: Page) {
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { addLayer: () => void };
+    };
+    store.getState().addLayer();
+  });
+}
+
+async function setActiveLayer(page: Page, layerId: string) {
+  await page.evaluate(
+    (id) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { setActiveLayer: (id: string) => void };
+      };
+      store.getState().setActiveLayer(id);
+    },
+    layerId,
+  );
+}
+
+async function enableEffect(page: Page, layerId: string, effectKey: string) {
+  await page.evaluate(
+    ({ lid, key }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; effects: Record<string, unknown> }> };
+          updateLayerEffects: (id: string, effects: Record<string, unknown>) => void;
+        };
+      };
+      const state = store.getState();
+      const layer = state.document.layers.find((l) => l.id === lid);
+      if (!layer) return;
+      const effects = { ...layer.effects };
+      const effect = effects[key] as Record<string, unknown>;
+      effects[key] = { ...effect, enabled: true };
+      state.updateLayerEffects(lid, effects);
+    },
+    { lid: layerId, key: effectKey },
+  );
+}
+
+async function setEffectProps(
+  page: Page,
+  layerId: string,
+  effectKey: string,
+  props: Record<string, unknown>,
+) {
+  await page.evaluate(
+    ({ lid, key, props }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; effects: Record<string, unknown> }> };
+          updateLayerEffects: (id: string, effects: Record<string, unknown>) => void;
+        };
+      };
+      const state = store.getState();
+      const layer = state.document.layers.find((l) => l.id === lid);
+      if (!layer) return;
+      const effects = { ...layer.effects };
+      const effect = effects[key] as Record<string, unknown>;
+      effects[key] = { ...effect, ...props, enabled: true };
+      state.updateLayerEffects(lid, effects);
+    },
+    { lid: layerId, key: effectKey, props },
+  );
+}
+
+async function getLayerPixelDataSize(page: Page, layerId: string) {
+  return page.evaluate(
+    (lid) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { layerPixelData: Map<string, ImageData> };
+      };
+      const data = store.getState().layerPixelData.get(lid);
+      if (!data) return { width: 0, height: 0 };
+      return { width: data.width, height: data.height };
+    },
+    layerId,
+  );
+}
+
+const isMac = process.platform === 'darwin';
+const mod = isMac ? 'Meta' : 'Control';
+
+// ---------------------------------------------------------------------------
+// Common setup
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(() => !!(window as unknown as Record<string, unknown>).__editorStore);
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { createDocument: (w: number, h: number, transparent: boolean) => void };
+    };
+    store.getState().createDocument(400, 300, false);
+  });
+  await page.waitForSelector('[data-testid="canvas-container"]');
+});
+
+// ===========================================================================
+// Rasterize Layer Style
+// ===========================================================================
+
+test.describe('Rasterize Layer Style', () => {
+  test('rasterize button is visible in effects drawer', async ({ page }) => {
+    await page.locator('button[title="Layer effects"]').click();
+    await page.waitForTimeout(100);
+
+    await expect(page.locator('text=Rasterize Layer Style')).toBeVisible();
+  });
+
+  test('rasterize button is disabled when no effects are enabled', async ({ page }) => {
+    await page.locator('button[title="Layer effects"]').click();
+    await page.waitForTimeout(100);
+
+    const btn = page.locator('button:has-text("Rasterize Layer Style")');
+    await expect(btn).toBeDisabled();
+  });
+
+  test('rasterize button is enabled when an effect is active', async ({ page }) => {
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    await enableEffect(page, layerId, 'stroke');
+
+    await page.locator('button[title="Layer effects"]').click();
+    await page.waitForTimeout(100);
+
+    const btn = page.locator('button:has-text("Rasterize Layer Style")');
+    await expect(btn).toBeEnabled();
+  });
+
+  test('rasterize bakes effects into pixel data and resets effects', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    await paintRect(page, 20, 20, 60, 60, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+
+    await setEffectProps(page, layerId, 'stroke', {
+      width: 4,
+      position: 'outside',
+      color: { r: 0, g: 255, b: 0, a: 1 },
+    });
+
+    const sizeBefore = await getLayerPixelDataSize(page, layerId);
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { rasterizeLayerStyle: () => void };
+      };
+      store.getState().rasterizeLayerStyle();
+    });
+
+    const afterState = await getEditorState(page);
+    const layer = afterState.document.layers.find((l) => l.id === layerId)!;
+
+    // Effects should be reset
+    expect(layer.effects.stroke.enabled).toBe(false);
+    expect(layer.effects.dropShadow.enabled).toBe(false);
+    expect(layer.effects.outerGlow.enabled).toBe(false);
+    expect(layer.effects.innerGlow.enabled).toBe(false);
+
+    // Pixel data should be larger (expanded by stroke padding)
+    const sizeAfter = await getLayerPixelDataSize(page, layerId);
+    expect(sizeAfter.width).toBeGreaterThan(sizeBefore.width);
+    expect(sizeAfter.height).toBeGreaterThan(sizeBefore.height);
+  });
+
+  test('rasterize is undoable', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    await paintRect(page, 20, 20, 60, 60, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+    await enableEffect(page, layerId, 'stroke');
+
+    const sizeBefore = await getLayerPixelDataSize(page, layerId);
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { rasterizeLayerStyle: () => void };
+      };
+      store.getState().rasterizeLayerStyle();
+    });
+
+    // Verify rasterized
+    const afterRasterize = await getEditorState(page);
+    expect(afterRasterize.document.layers.find((l) => l.id === layerId)!.effects.stroke.enabled).toBe(false);
+
+    // Undo
+    await page.keyboard.press(`${mod}+KeyZ`);
+
+    const afterUndo = await getEditorState(page);
+    const undoneLayer = afterUndo.document.layers.find((l) => l.id === layerId)!;
+    expect(undoneLayer.effects.stroke.enabled).toBe(true);
+
+    const sizeAfterUndo = await getLayerPixelDataSize(page, layerId);
+    expect(sizeAfterUndo.width).toBe(sizeBefore.width);
+    expect(sizeAfterUndo.height).toBe(sizeBefore.height);
+  });
+
+  test('rasterize does nothing when no effects are enabled', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+    const stateBefore = await getEditorState(page);
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { rasterizeLayerStyle: () => void };
+      };
+      store.getState().rasterizeLayerStyle();
+    });
+
+    const stateAfter = await getEditorState(page);
+    // No history entry should have been pushed
+    expect(stateAfter.undoStack).toBe(stateBefore.undoStack);
+  });
+});
+
+// ===========================================================================
+// Merge Down with Effects
+// ===========================================================================
+
+test.describe('Merge Down with Effects', () => {
+  test('merge down rasterizes effects from top layer into result', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    const s0 = await getEditorState(page);
+    const bgId = s0.document.layers[0]!.id;
+
+    await paintRect(page, 0, 0, 100, 100, { r: 255, g: 255, b: 255, a: 255 }, bgId);
+
+    await addLayer(page);
+    const s1 = await getEditorState(page);
+    const topId = s1.document.activeLayerId;
+
+    await paintRect(page, 30, 30, 40, 40, { r: 255, g: 0, b: 0, a: 255 }, topId);
+
+    // Enable stroke on top layer
+    await setEffectProps(page, topId, 'stroke', {
+      width: 4,
+      position: 'outside',
+      color: { r: 0, g: 0, b: 255, a: 1 },
+    });
+
+    // Merge down
+    await page.keyboard.press(`${mod}+KeyE`);
+
+    const after = await getEditorState(page);
+    expect(after.document.layers).toHaveLength(1);
+
+    // The red content should be present in merged result
+    const redPixel = await getPixelAt(page, 50, 50, bgId);
+    expect(redPixel.r).toBe(255);
+    expect(redPixel.g).toBe(0);
+    expect(redPixel.b).toBe(0);
+
+    // The blue stroke area (just outside the red rect) should have blue pixels
+    const strokePixel = await getPixelAt(page, 28, 50, bgId);
+    expect(strokePixel.b).toBeGreaterThan(0);
+    expect(strokePixel.a).toBe(255);
+  });
+
+  test('merge down without effects works normally', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    const s0 = await getEditorState(page);
+    const bgId = s0.document.layers[0]!.id;
+
+    await paintRect(page, 0, 0, 50, 50, { r: 255, g: 0, b: 0, a: 255 }, bgId);
+
+    await addLayer(page);
+    const s1 = await getEditorState(page);
+    const topId = s1.document.activeLayerId;
+
+    await paintRect(page, 25, 25, 50, 50, { r: 0, g: 0, b: 255, a: 255 }, topId);
+
+    await page.keyboard.press(`${mod}+KeyE`);
+
+    const after = await getEditorState(page);
+    expect(after.document.layers).toHaveLength(1);
+
+    const redPixel = await getPixelAt(page, 10, 10, bgId);
+    expect(redPixel.r).toBe(255);
+    expect(redPixel.b).toBe(0);
+
+    const bluePixel = await getPixelAt(page, 60, 60, bgId);
+    expect(bluePixel.b).toBe(255);
+    expect(bluePixel.r).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Cmd+Click Thumbnail to Select
+// ===========================================================================
+
+test.describe('Cmd+Click Thumbnail', () => {
+  test('cmd+click on layer thumbnail creates selection from alpha', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Paint a 40x40 rect at (30,30)
+    await paintRect(page, 30, 30, 40, 40, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+
+    // Cmd+click on the thumbnail
+    const thumbnail = page.locator('[class*="thumbnail"]').first();
+    await thumbnail.click({ modifiers: [isMac ? 'Meta' : 'Control'] });
+
+    const sel = await getSelectionState(page);
+    expect(sel.active).toBe(true);
+    // Should have selected ~1600 pixels (40x40)
+    expect(sel.selectedPixelCount).toBe(40 * 40);
+  });
+
+  test('cmd+click on empty layer creates no selection', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    const thumbnail = page.locator('[class*="thumbnail"]').first();
+    await thumbnail.click({ modifiers: [isMac ? 'Meta' : 'Control'] });
+
+    const sel = await getSelectionState(page);
+    // No opaque pixels, so no selection should be created
+    expect(sel.selectedPixelCount).toBe(0);
+  });
+
+  test('regular click on thumbnail does not create selection', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    await paintRect(page, 0, 0, 50, 50, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+
+    const thumbnail = page.locator('[class*="thumbnail"]').first();
+    await thumbnail.click();
+
+    const sel = await getSelectionState(page);
+    expect(sel.active).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Keyboard Shortcuts: Grid and Guides
+// ===========================================================================
+
+test.describe('Grid Toggle Shortcut', () => {
+  test('Cmd+quote toggles grid on', async ({ page }) => {
+    const before = await getUIState(page);
+    expect(before.showGrid).toBe(false);
+
+    await page.keyboard.press(`${mod}+'`);
+
+    const after = await getUIState(page);
+    expect(after.showGrid).toBe(true);
+  });
+
+  test('Cmd+quote toggles grid off again', async ({ page }) => {
+    await page.keyboard.press(`${mod}+'`);
+    const on = await getUIState(page);
+    expect(on.showGrid).toBe(true);
+
+    await page.keyboard.press(`${mod}+'`);
+    const off = await getUIState(page);
+    expect(off.showGrid).toBe(false);
+  });
+});
+
+test.describe('Guides Toggle Shortcut', () => {
+  test('Cmd+semicolon toggles guides state', async ({ page }) => {
+    const before = await getUIState(page);
+    const initialState = before.showGuides;
+
+    await page.keyboard.press(`${mod}+;`);
+
+    const after = await getUIState(page);
+    expect(after.showGuides).toBe(!initialState);
+  });
+
+  test('Cmd+semicolon toggles guides back after two presses', async ({ page }) => {
+    const before = await getUIState(page);
+    const initialState = before.showGuides;
+
+    await page.keyboard.press(`${mod}+;`);
+    const toggled = await getUIState(page);
+    expect(toggled.showGuides).toBe(!initialState);
+
+    await page.keyboard.press(`${mod}+;`);
+    const restored = await getUIState(page);
+    expect(restored.showGuides).toBe(initialState);
+  });
+});
+
+// ===========================================================================
+// Keyboard Shortcuts: Select All and Inverse
+// ===========================================================================
+
+test.describe('Select All Shortcut', () => {
+  test('Cmd+A selects the entire document', async ({ page }) => {
+    await page.keyboard.press(`${mod}+KeyA`);
+
+    const sel = await getSelectionState(page);
+    expect(sel.active).toBe(true);
+    // Entire document should be selected (400x300)
+    expect(sel.selectedPixelCount).toBe(400 * 300);
+  });
+});
+
+test.describe('Select Inverse Shortcut', () => {
+  test('Shift+Cmd+I inverts active selection', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    // Select all first
+    await page.keyboard.press(`${mod}+KeyA`);
+    const selAll = await getSelectionState(page);
+    expect(selAll.active).toBe(true);
+    expect(selAll.selectedPixelCount).toBe(100 * 100);
+
+    // Invert — all pixels were selected, so now none should be
+    await page.keyboard.press(`${mod}+Shift+KeyI`);
+
+    const selInv = await getSelectionState(page);
+    expect(selInv.active).toBe(true);
+    expect(selInv.selectedPixelCount).toBe(0);
+  });
+
+  test('Shift+Cmd+I does nothing without active selection', async ({ page }) => {
+    await page.keyboard.press(`${mod}+Shift+KeyI`);
+
+    const sel = await getSelectionState(page);
+    expect(sel.active).toBe(false);
+  });
+
+  test('partial selection inversion preserves complement', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    // Create a rectangular selection via store
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          setSelection: (
+            bounds: { x: number; y: number; width: number; height: number },
+            mask: Uint8ClampedArray,
+            maskWidth: number,
+            maskHeight: number,
+          ) => void;
+        };
+      };
+      const mask = new Uint8ClampedArray(100 * 100);
+      // Select top-left 50x50
+      for (let y = 0; y < 50; y++) {
+        for (let x = 0; x < 50; x++) {
+          mask[y * 100 + x] = 255;
+        }
+      }
+      store.getState().setSelection({ x: 0, y: 0, width: 50, height: 50 }, mask, 100, 100);
+    });
+
+    const before = await getSelectionState(page);
+    expect(before.active).toBe(true);
+    expect(before.selectedPixelCount).toBe(50 * 50);
+
+    // Invert
+    await page.keyboard.press(`${mod}+Shift+KeyI`);
+
+    const after = await getSelectionState(page);
+    expect(after.active).toBe(true);
+    // 10000 - 2500 = 7500 pixels should now be selected
+    expect(after.selectedPixelCount).toBe(100 * 100 - 50 * 50);
+  });
+});

--- a/src/app/MenuBar/menus/file-menu.ts
+++ b/src/app/MenuBar/menus/file-menu.ts
@@ -5,9 +5,9 @@ import {
   renderOuterGlow,
   renderInnerGlow,
   renderDropShadow,
-  renderLayerContent,
   renderStroke,
-} from '../../useCanvasRendering';
+} from '../../../engine/effects-renderer';
+import { renderLayerContent } from '../../useCanvasRendering';
 import { addPngMetadata, addJpegComment } from '../../../utils/image-metadata';
 import type { MenuDef } from './types';
 

--- a/src/app/editor-store.ts
+++ b/src/app/editor-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { DocumentState, Layer, LayerEffects, LayerMask, Rect, RasterLayer, ViewportState } from '../types';
 import { compositeOver } from '../engine/compositing';
 import { computeAlign, getContentBounds, type AlignEdge } from '../tools/move/move';
+import { CanvasAllocator, renderOuterGlow, renderDropShadow, renderInnerGlow, renderStroke } from '../engine/effects-renderer';
 
 interface SelectionData {
   active: boolean;
@@ -49,6 +50,66 @@ function clonePixelDataMapFull(map: Map<string, ImageData>): Map<string, ImageDa
   return clone;
 }
 
+function hasEnabledEffects(effects: LayerEffects): boolean {
+  return effects.dropShadow.enabled || effects.stroke.enabled ||
+    effects.outerGlow.enabled || effects.innerGlow.enabled;
+}
+
+function rasterizeEffectsToImageData(
+  layer: Layer,
+  data: ImageData,
+): { imageData: ImageData; offsetX: number; offsetY: number } {
+  const effects = layer.effects;
+
+  let pad = 0;
+  if (effects.outerGlow.enabled) {
+    pad = Math.max(pad, (effects.outerGlow.size + effects.outerGlow.spread) * 2);
+  }
+  if (effects.dropShadow.enabled) {
+    const s = effects.dropShadow;
+    pad = Math.max(pad, s.blur * 2 + Math.max(Math.abs(s.offsetX), Math.abs(s.offsetY)) + s.spread);
+  }
+  if (effects.innerGlow.enabled) {
+    pad = Math.max(pad, (effects.innerGlow.size + effects.innerGlow.spread) * 2);
+  }
+  if (effects.stroke.enabled) {
+    pad = Math.max(pad, effects.stroke.width + 1);
+  }
+  pad = Math.ceil(pad);
+
+  const outW = data.width + pad * 2;
+  const outH = data.height + pad * 2;
+
+  const destCanvas = document.createElement('canvas');
+  destCanvas.width = outW;
+  destCanvas.height = outH;
+  const destCtx = destCanvas.getContext('2d')!;
+
+  const tempCanvas = document.createElement('canvas');
+  tempCanvas.width = data.width;
+  tempCanvas.height = data.height;
+  const tempCtx = tempCanvas.getContext('2d')!;
+  tempCtx.putImageData(data, 0, 0);
+
+  const fakeLayer = { ...layer, x: pad, y: pad } as Layer;
+  const alloc = new CanvasAllocator();
+
+  destCtx.globalAlpha = 1;
+  renderOuterGlow(destCtx, tempCanvas, fakeLayer, data, alloc);
+  renderDropShadow(destCtx, tempCanvas, fakeLayer, data, alloc);
+  destCtx.drawImage(tempCanvas, pad, pad);
+  renderInnerGlow(destCtx, tempCanvas, fakeLayer, data, alloc);
+  renderStroke(destCtx, tempCanvas, fakeLayer, data, alloc);
+
+  alloc.releaseAll();
+
+  return {
+    imageData: destCtx.getImageData(0, 0, outW, outH),
+    offsetX: -pad,
+    offsetY: -pad,
+  };
+}
+
 interface ClipboardData {
   imageData: ImageData;
   offsetX: number;
@@ -84,6 +145,7 @@ interface EditorState {
   duplicateLayer: () => void;
   mergeDown: () => void;
   flattenImage: () => void;
+  rasterizeLayerStyle: () => void;
   updateLayerEffects: (id: string, effects: LayerEffects) => void;
   addLayerMask: (id: string) => void;
   removeLayerMask: (id: string) => void;
@@ -453,11 +515,21 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     if (!belowId) return;
     state.pushHistory('Merge Down');
 
-    const topData = state.getOrCreateLayerPixelData(activeId);
+    let topData = state.getOrCreateLayerPixelData(activeId);
     const bottomData = state.getOrCreateLayerPixelData(belowId);
     const topLayer = state.document.layers.find((l) => l.id === activeId);
     const bottomLayer = state.document.layers.find((l) => l.id === belowId);
     if (!topLayer || !bottomLayer) return;
+
+    let topX = topLayer.x;
+    let topY = topLayer.y;
+
+    if (hasEnabledEffects(topLayer.effects)) {
+      const rasterized = rasterizeEffectsToImageData(topLayer, topData);
+      topData = rasterized.imageData;
+      topX += rasterized.offsetX;
+      topY += rasterized.offsetY;
+    }
 
     // Composite top onto bottom
     const result = new ImageData(bottomData.width, bottomData.height);
@@ -466,7 +538,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       topData.data, bottomData.data,
       topData.width, topData.height,
       bottomData.width, bottomData.height,
-      topLayer.x - bottomLayer.x, topLayer.y - bottomLayer.y,
+      topX - bottomLayer.x, topY - bottomLayer.y,
       topLayer.opacity, result.data,
     );
 
@@ -557,6 +629,41 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       },
       renderVersion: state.renderVersion + 1,
     }));
+  },
+
+  rasterizeLayerStyle: () => {
+    const state = get();
+    const activeId = state.document.activeLayerId;
+    if (!activeId) return;
+    const layer = state.document.layers.find((l) => l.id === activeId);
+    if (!layer || !hasEnabledEffects(layer.effects)) return;
+
+    state.pushHistory('Rasterize Layer Style');
+
+    const data = state.getOrCreateLayerPixelData(activeId);
+    const result = rasterizeEffectsToImageData(layer, data);
+
+    const pixelData = new Map(state.layerPixelData);
+    pixelData.set(activeId, result.imageData);
+
+    set({
+      document: {
+        ...state.document,
+        layers: state.document.layers.map((l) =>
+          l.id === activeId
+            ? {
+                ...l,
+                x: l.x + result.offsetX,
+                y: l.y + result.offsetY,
+                effects: DEFAULT_EFFECTS,
+                ...(l.type === 'raster' ? { width: result.imageData.width, height: result.imageData.height } : {}),
+              } as Layer
+            : l,
+        ),
+      },
+      layerPixelData: pixelData,
+      renderVersion: state.renderVersion + 1,
+    });
   },
 
   addLayerMask: (id: string) => {

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -7,8 +7,7 @@ import { getBrushCursorInfo } from './useCanvasCursor';
 import { getHandlePositions } from '../tools/transform/transform';
 import type { TransformHandle, TransformState } from '../tools/transform/transform';
 import { traceSelectionContours } from '../selection/selection';
-import { canvasPool } from '../engine/canvas-pool';
-import type { PooledCanvas } from '../engine/canvas-pool';
+import { CanvasAllocator, renderOuterGlow, renderDropShadow, renderInnerGlow, renderStroke } from '../engine/effects-renderer';
 
 export function useCanvasRendering(
   canvasRef: RefObject<HTMLCanvasElement | null>,
@@ -147,22 +146,6 @@ export function useCanvasRendering(
 import type { Layer, Point, Rect } from '../types';
 import type { PathAnchor } from './ui-store';
 
-// Tracks pooled canvases acquired during a render pass so they can all be released at once
-export class CanvasAllocator {
-  private handles: PooledCanvas[] = [];
-
-  acquire(w: number, h: number): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D } {
-    const pooled = canvasPool.acquire(w, h);
-    this.handles.push(pooled);
-    return { canvas: pooled.canvas, ctx: pooled.ctx };
-  }
-
-  releaseAll(): void {
-    for (const h of this.handles) h.release();
-    this.handles.length = 0;
-  }
-}
-
 // Module-level allocator reused each frame
 const allocator = new CanvasAllocator();
 
@@ -173,54 +156,6 @@ interface SelectionData {
   maskHeight: number;
 }
 
-export function renderOuterGlow(
-  ctx: CanvasRenderingContext2D,
-  tempCanvas: HTMLCanvasElement,
-  layer: Layer,
-  data: ImageData,
-  alloc: CanvasAllocator,
-): void {
-  if (!layer.effects.outerGlow.enabled) return;
-  const glow = layer.effects.outerGlow;
-  const glowBlur = glow.size + glow.spread;
-  const pad = glowBlur * 2;
-  const { canvas: glowCanvas, ctx: glowCtx } = alloc.acquire(data.width + pad * 2, data.height + pad * 2);
-  glowCtx.filter = `blur(${glowBlur}px)`;
-  glowCtx.drawImage(tempCanvas, pad, pad);
-  glowCtx.globalCompositeOperation = 'source-in';
-  glowCtx.filter = 'none';
-  glowCtx.fillStyle = `rgba(${glow.color.r},${glow.color.g},${glow.color.b},${glow.opacity})`;
-  glowCtx.fillRect(0, 0, glowCanvas.width, glowCanvas.height);
-  ctx.drawImage(glowCanvas, layer.x - pad, layer.y - pad);
-}
-
-export function renderDropShadow(
-  ctx: CanvasRenderingContext2D,
-  tempCanvas: HTMLCanvasElement,
-  layer: Layer,
-  data: ImageData,
-  alloc: CanvasAllocator,
-): void {
-  if (!layer.effects.dropShadow.enabled) return;
-  const shadow = layer.effects.dropShadow;
-  const pad = shadow.blur * 2;
-  const { canvas: shadowCanvas, ctx: shadowCtx } = alloc.acquire(data.width + pad * 2, data.height + pad * 2);
-  if (shadow.spread > 0) {
-    const spreadScale = 1 + (shadow.spread / Math.max(data.width, data.height)) * 2;
-    const spreadOffsetX = pad + (data.width * (1 - spreadScale)) / 2;
-    const spreadOffsetY = pad + (data.height * (1 - spreadScale)) / 2;
-    shadowCtx.filter = `blur(${shadow.blur}px)`;
-    shadowCtx.drawImage(tempCanvas, spreadOffsetX, spreadOffsetY, data.width * spreadScale, data.height * spreadScale);
-  } else {
-    shadowCtx.filter = `blur(${shadow.blur}px)`;
-    shadowCtx.drawImage(tempCanvas, pad, pad);
-  }
-  shadowCtx.globalCompositeOperation = 'source-in';
-  shadowCtx.filter = 'none';
-  shadowCtx.fillStyle = `rgba(${shadow.color.r},${shadow.color.g},${shadow.color.b},${shadow.color.a})`;
-  shadowCtx.fillRect(0, 0, shadowCanvas.width, shadowCanvas.height);
-  ctx.drawImage(shadowCanvas, layer.x + shadow.offsetX - pad, layer.y + shadow.offsetY - pad);
-}
 
 export function renderLayerContent(
   ctx: CanvasRenderingContext2D,
@@ -279,179 +214,6 @@ export function renderLayerContent(
   }
 }
 
-export function renderInnerGlow(
-  ctx: CanvasRenderingContext2D,
-  tempCanvas: HTMLCanvasElement,
-  layer: Layer,
-  data: ImageData,
-  alloc: CanvasAllocator,
-): void {
-  if (!layer.effects.innerGlow.enabled) return;
-  const glow = layer.effects.innerGlow;
-  const glowBlur = glow.size + glow.spread;
-  const pad = glowBlur * 2;
-  const cw = data.width + pad * 2;
-  const ch = data.height + pad * 2;
-
-  // Build an eroded version of the layer content
-  const { canvas: erodeCanvas, ctx: erodeCtx } = alloc.acquire(cw, ch);
-  erodeCtx.filter = `blur(${glowBlur}px)`;
-  erodeCtx.drawImage(tempCanvas, pad, pad);
-  erodeCtx.filter = 'none';
-  erodeCtx.globalCompositeOperation = 'destination-in';
-  erodeCtx.filter = `blur(${glowBlur}px)`;
-  erodeCtx.drawImage(tempCanvas, pad, pad);
-  erodeCtx.filter = 'none';
-
-  // Start from original, subtract eroded to get inner border
-  const { canvas: glowCanvas, ctx: glowCtx } = alloc.acquire(cw, ch);
-  glowCtx.drawImage(tempCanvas, pad, pad);
-  glowCtx.globalCompositeOperation = 'destination-out';
-  glowCtx.drawImage(erodeCanvas, 0, 0);
-
-  // Color the remaining inner fringe
-  glowCtx.globalCompositeOperation = 'source-in';
-  glowCtx.fillStyle = `rgba(${glow.color.r},${glow.color.g},${glow.color.b},${glow.opacity})`;
-  glowCtx.fillRect(0, 0, cw, ch);
-
-  ctx.drawImage(glowCanvas, layer.x - pad, layer.y - pad);
-}
-
-export function renderStroke(
-  ctx: CanvasRenderingContext2D,
-  _tempCanvas: HTMLCanvasElement,
-  layer: Layer,
-  data: ImageData,
-  alloc: CanvasAllocator,
-): void {
-  if (!layer.effects.stroke.enabled) return;
-  const stroke = layer.effects.stroke;
-  const sw = stroke.width;
-  const pad = sw + 1;
-
-  // Build an alpha mask from the layer content
-  const srcData = data.data;
-  const w = data.width;
-  const h = data.height;
-
-  // Build a binary alpha mask (1 = opaque pixel)
-  const alpha = new Uint8Array(w * h);
-  for (let i = 0; i < w * h; i++) {
-    alpha[i] = (srcData[i * 4 + 3] ?? 0) >= 128 ? 1 : 0;
-  }
-
-  // Exact Euclidean Distance Transform (Felzenszwalb-Huttenlocher algorithm).
-  // Produces true circular distance contours for smooth strokes on any shape.
-  const distSqInside = new Float64Array(w * h);
-  const distSqOutside = new Float64Array(w * h);
-  const EDT_INF = 1e20;
-
-  for (let i = 0; i < w * h; i++) {
-    distSqInside[i] = alpha[i] ? EDT_INF : 0;
-    distSqOutside[i] = alpha[i] ? 0 : EDT_INF;
-  }
-
-  edt2d(distSqInside, w, h);
-  edt2d(distSqOutside, w, h);
-
-  // Compare against squared stroke width to avoid sqrt per pixel
-  const swSq = sw * sw;
-
-  // Build the stroke ImageData
-  const outW = w + pad * 2;
-  const outH = h + pad * 2;
-  const { canvas: strokeCanvas, ctx: strokeCtx } = alloc.acquire(outW, outH);
-  const strokeImg = strokeCtx.createImageData(outW, outH);
-  const sd = strokeImg.data;
-  const cr = stroke.color.r;
-  const cg = stroke.color.g;
-  const cb = stroke.color.b;
-  const ca = Math.round(stroke.color.a * 255);
-
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const idx = y * w + x;
-      let isStroke = false;
-
-      if (stroke.position === 'outside') {
-        isStroke = !alpha[idx] && distSqOutside[idx]! <= swSq;
-      } else if (stroke.position === 'inside') {
-        isStroke = !!alpha[idx] && distSqInside[idx]! <= swSq;
-      } else {
-        const halfSq = (sw / 2) * (sw / 2);
-        isStroke =
-          (!!alpha[idx] && distSqInside[idx]! <= halfSq) ||
-          (!alpha[idx] && distSqOutside[idx]! <= halfSq);
-      }
-
-      if (isStroke) {
-        const oi = ((y + pad) * outW + (x + pad)) * 4;
-        sd[oi] = cr;
-        sd[oi + 1] = cg;
-        sd[oi + 2] = cb;
-        sd[oi + 3] = ca;
-      }
-    }
-  }
-
-  strokeCtx.putImageData(strokeImg, 0, 0);
-  ctx.drawImage(strokeCanvas, layer.x - pad, layer.y - pad);
-}
-
-// Felzenszwalb-Huttenlocher 2D squared Euclidean distance transform (in-place).
-function edt2d(grid: Float64Array, w: number, h: number): void {
-  const maxDim = Math.max(w, h);
-  const f = new Float64Array(maxDim);
-  const d = new Float64Array(maxDim);
-  const v = new Int32Array(maxDim);
-  const z = new Float64Array(maxDim + 1);
-
-  // Transform columns
-  for (let x = 0; x < w; x++) {
-    for (let y = 0; y < h; y++) f[y] = grid[y * w + x]!;
-    edt1d(f, d, v, z, h);
-    for (let y = 0; y < h; y++) grid[y * w + x] = d[y]!;
-  }
-
-  // Transform rows
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) f[x] = grid[y * w + x]!;
-    edt1d(f, d, v, z, w);
-    for (let x = 0; x < w; x++) grid[y * w + x] = d[x]!;
-  }
-}
-
-function edt1d(
-  f: Float64Array,
-  d: Float64Array,
-  v: Int32Array,
-  z: Float64Array,
-  n: number,
-): void {
-  let k = 0;
-  v[0] = 0;
-  z[0] = -1e20;
-  z[1] = 1e20;
-
-  for (let q = 1; q < n; q++) {
-    const fq = f[q]! + q * q;
-    let s = (fq - (f[v[k]!]! + v[k]! * v[k]!)) / (2 * q - 2 * v[k]!);
-    while (s <= z[k]!) {
-      k--;
-      s = (fq - (f[v[k]!]! + v[k]! * v[k]!)) / (2 * q - 2 * v[k]!);
-    }
-    k++;
-    v[k] = q;
-    z[k] = s;
-    z[k + 1] = 1e20;
-  }
-
-  k = 0;
-  for (let q = 0; q < n; q++) {
-    while (z[k + 1]! < q) k++;
-    d[q] = (q - v[k]!) * (q - v[k]!) + f[v[k]!]!;
-  }
-}
 
 function renderSelectionAnts(
   ctx: CanvasRenderingContext2D,

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@ import { useUIStore } from './ui-store';
 import { useEditorStore } from './editor-store';
 import { useToolSettingsStore } from './tool-settings-store';
 import { strokeCurrentPath } from './useCanvasInteraction';
+import { selectAll, invertSelectionAction } from './MenuBar/menus/select-menu';
 
 interface KeyboardShortcutDeps {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -212,11 +213,25 @@ export function useKeyboardShortcuts({
         } else if (e.key === 'e') {
           e.preventDefault();
           useEditorStore.getState().mergeDown();
+        } else if (e.key === 'a') {
+          e.preventDefault();
+          selectAll();
+        } else if (e.key === 'i' || e.key === 'I') {
+          if (e.shiftKey) {
+            e.preventDefault();
+            invertSelectionAction();
+          }
         } else if (e.key === 'd') {
           e.preventDefault();
           useEditorStore.getState().clearSelection();
           useUIStore.getState().setTransform(null);
           clearPersistentTransform();
+        } else if (e.key === "'") {
+          e.preventDefault();
+          useUIStore.getState().toggleGrid();
+        } else if (e.key === ';') {
+          e.preventDefault();
+          useUIStore.getState().toggleGuides();
         } else if (e.key === 'z' || e.key === 'Z') {
           e.preventDefault();
           if (e.shiftKey) {

--- a/src/engine/effects-renderer.ts
+++ b/src/engine/effects-renderer.ts
@@ -1,0 +1,229 @@
+import { canvasPool } from './canvas-pool';
+import type { PooledCanvas } from './canvas-pool';
+import type { Layer } from '../types';
+
+export class CanvasAllocator {
+  private handles: PooledCanvas[] = [];
+
+  acquire(w: number, h: number): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D } {
+    const pooled = canvasPool.acquire(w, h);
+    this.handles.push(pooled);
+    return { canvas: pooled.canvas, ctx: pooled.ctx };
+  }
+
+  releaseAll(): void {
+    for (const h of this.handles) h.release();
+    this.handles.length = 0;
+  }
+}
+
+export function renderOuterGlow(
+  ctx: CanvasRenderingContext2D,
+  tempCanvas: HTMLCanvasElement,
+  layer: Layer,
+  data: ImageData,
+  alloc: CanvasAllocator,
+): void {
+  if (!layer.effects.outerGlow.enabled) return;
+  const glow = layer.effects.outerGlow;
+  const glowBlur = glow.size + glow.spread;
+  const pad = glowBlur * 2;
+  const { canvas: glowCanvas, ctx: glowCtx } = alloc.acquire(data.width + pad * 2, data.height + pad * 2);
+  glowCtx.filter = `blur(${glowBlur}px)`;
+  glowCtx.drawImage(tempCanvas, pad, pad);
+  glowCtx.globalCompositeOperation = 'source-in';
+  glowCtx.filter = 'none';
+  glowCtx.fillStyle = `rgba(${glow.color.r},${glow.color.g},${glow.color.b},${glow.opacity})`;
+  glowCtx.fillRect(0, 0, glowCanvas.width, glowCanvas.height);
+  ctx.drawImage(glowCanvas, layer.x - pad, layer.y - pad);
+}
+
+export function renderDropShadow(
+  ctx: CanvasRenderingContext2D,
+  tempCanvas: HTMLCanvasElement,
+  layer: Layer,
+  data: ImageData,
+  alloc: CanvasAllocator,
+): void {
+  if (!layer.effects.dropShadow.enabled) return;
+  const shadow = layer.effects.dropShadow;
+  const pad = shadow.blur * 2;
+  const { canvas: shadowCanvas, ctx: shadowCtx } = alloc.acquire(data.width + pad * 2, data.height + pad * 2);
+  if (shadow.spread > 0) {
+    const spreadScale = 1 + (shadow.spread / Math.max(data.width, data.height)) * 2;
+    const spreadOffsetX = pad + (data.width * (1 - spreadScale)) / 2;
+    const spreadOffsetY = pad + (data.height * (1 - spreadScale)) / 2;
+    shadowCtx.filter = `blur(${shadow.blur}px)`;
+    shadowCtx.drawImage(tempCanvas, spreadOffsetX, spreadOffsetY, data.width * spreadScale, data.height * spreadScale);
+  } else {
+    shadowCtx.filter = `blur(${shadow.blur}px)`;
+    shadowCtx.drawImage(tempCanvas, pad, pad);
+  }
+  shadowCtx.globalCompositeOperation = 'source-in';
+  shadowCtx.filter = 'none';
+  shadowCtx.fillStyle = `rgba(${shadow.color.r},${shadow.color.g},${shadow.color.b},${shadow.color.a})`;
+  shadowCtx.fillRect(0, 0, shadowCanvas.width, shadowCanvas.height);
+  ctx.drawImage(shadowCanvas, layer.x + shadow.offsetX - pad, layer.y + shadow.offsetY - pad);
+}
+
+export function renderInnerGlow(
+  ctx: CanvasRenderingContext2D,
+  tempCanvas: HTMLCanvasElement,
+  layer: Layer,
+  data: ImageData,
+  alloc: CanvasAllocator,
+): void {
+  if (!layer.effects.innerGlow.enabled) return;
+  const glow = layer.effects.innerGlow;
+  const glowBlur = glow.size + glow.spread;
+  const pad = glowBlur * 2;
+  const cw = data.width + pad * 2;
+  const ch = data.height + pad * 2;
+
+  const { canvas: erodeCanvas, ctx: erodeCtx } = alloc.acquire(cw, ch);
+  erodeCtx.filter = `blur(${glowBlur}px)`;
+  erodeCtx.drawImage(tempCanvas, pad, pad);
+  erodeCtx.filter = 'none';
+  erodeCtx.globalCompositeOperation = 'destination-in';
+  erodeCtx.filter = `blur(${glowBlur}px)`;
+  erodeCtx.drawImage(tempCanvas, pad, pad);
+  erodeCtx.filter = 'none';
+
+  const { canvas: glowCanvas, ctx: glowCtx } = alloc.acquire(cw, ch);
+  glowCtx.drawImage(tempCanvas, pad, pad);
+  glowCtx.globalCompositeOperation = 'destination-out';
+  glowCtx.drawImage(erodeCanvas, 0, 0);
+
+  glowCtx.globalCompositeOperation = 'source-in';
+  glowCtx.fillStyle = `rgba(${glow.color.r},${glow.color.g},${glow.color.b},${glow.opacity})`;
+  glowCtx.fillRect(0, 0, cw, ch);
+
+  ctx.drawImage(glowCanvas, layer.x - pad, layer.y - pad);
+}
+
+export function renderStroke(
+  ctx: CanvasRenderingContext2D,
+  _tempCanvas: HTMLCanvasElement,
+  layer: Layer,
+  data: ImageData,
+  alloc: CanvasAllocator,
+): void {
+  if (!layer.effects.stroke.enabled) return;
+  const stroke = layer.effects.stroke;
+  const sw = stroke.width;
+  const pad = sw + 1;
+
+  const srcData = data.data;
+  const w = data.width;
+  const h = data.height;
+
+  const alpha = new Uint8Array(w * h);
+  for (let i = 0; i < w * h; i++) {
+    alpha[i] = (srcData[i * 4 + 3] ?? 0) >= 128 ? 1 : 0;
+  }
+
+  const distSqInside = new Float64Array(w * h);
+  const distSqOutside = new Float64Array(w * h);
+  const EDT_INF = 1e20;
+
+  for (let i = 0; i < w * h; i++) {
+    distSqInside[i] = alpha[i] ? EDT_INF : 0;
+    distSqOutside[i] = alpha[i] ? 0 : EDT_INF;
+  }
+
+  edt2d(distSqInside, w, h);
+  edt2d(distSqOutside, w, h);
+
+  const swSq = sw * sw;
+
+  const outW = w + pad * 2;
+  const outH = h + pad * 2;
+  const { canvas: strokeCanvas, ctx: strokeCtx } = alloc.acquire(outW, outH);
+  const strokeImg = strokeCtx.createImageData(outW, outH);
+  const sd = strokeImg.data;
+  const cr = stroke.color.r;
+  const cg = stroke.color.g;
+  const cb = stroke.color.b;
+  const ca = Math.round(stroke.color.a * 255);
+
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const idx = y * w + x;
+      let isStroke = false;
+
+      if (stroke.position === 'outside') {
+        isStroke = !alpha[idx] && distSqOutside[idx]! <= swSq;
+      } else if (stroke.position === 'inside') {
+        isStroke = !!alpha[idx] && distSqInside[idx]! <= swSq;
+      } else {
+        const halfSq = (sw / 2) * (sw / 2);
+        isStroke =
+          (!!alpha[idx] && distSqInside[idx]! <= halfSq) ||
+          (!alpha[idx] && distSqOutside[idx]! <= halfSq);
+      }
+
+      if (isStroke) {
+        const oi = ((y + pad) * outW + (x + pad)) * 4;
+        sd[oi] = cr;
+        sd[oi + 1] = cg;
+        sd[oi + 2] = cb;
+        sd[oi + 3] = ca;
+      }
+    }
+  }
+
+  strokeCtx.putImageData(strokeImg, 0, 0);
+  ctx.drawImage(strokeCanvas, layer.x - pad, layer.y - pad);
+}
+
+function edt2d(grid: Float64Array, w: number, h: number): void {
+  const maxDim = Math.max(w, h);
+  const f = new Float64Array(maxDim);
+  const d = new Float64Array(maxDim);
+  const v = new Int32Array(maxDim);
+  const z = new Float64Array(maxDim + 1);
+
+  for (let x = 0; x < w; x++) {
+    for (let y = 0; y < h; y++) f[y] = grid[y * w + x]!;
+    edt1d(f, d, v, z, h);
+    for (let y = 0; y < h; y++) grid[y * w + x] = d[y]!;
+  }
+
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) f[x] = grid[y * w + x]!;
+    edt1d(f, d, v, z, w);
+    for (let x = 0; x < w; x++) grid[y * w + x] = d[x]!;
+  }
+}
+
+function edt1d(
+  f: Float64Array,
+  d: Float64Array,
+  v: Int32Array,
+  z: Float64Array,
+  n: number,
+): void {
+  let k = 0;
+  v[0] = 0;
+  z[0] = -1e20;
+  z[1] = 1e20;
+
+  for (let q = 1; q < n; q++) {
+    const fq = f[q]! + q * q;
+    let s = (fq - (f[v[k]!]! + v[k]! * v[k]!)) / (2 * q - 2 * v[k]!);
+    while (s <= z[k]!) {
+      k--;
+      s = (fq - (f[v[k]!]! + v[k]! * v[k]!)) / (2 * q - 2 * v[k]!);
+    }
+    k++;
+    v[k] = q;
+    z[k] = s;
+    z[k + 1] = 1e20;
+  }
+
+  k = 0;
+  for (let q = 0; q < n; q++) {
+    while (z[k + 1]! < q) k++;
+    d[q] = (q - v[k]!) * (q - v[k]!) + f[v[k]!]!;
+  }
+}

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
@@ -31,10 +31,16 @@
 }
 
 .effectList {
+  display: flex;
+  flex-direction: column;
   width: 150px;
   flex-shrink: 0;
   border-right: 1px solid var(--color-border-subtle);
   overflow-y: auto;
+}
+
+.effectListSpacer {
+  flex: 1;
 }
 
 .effectRow {
@@ -153,6 +159,28 @@
   color: var(--color-text-disabled);
   padding: var(--space-4);
   text-align: center;
+}
+
+.rasterizeBtn {
+  margin: 0 var(--space-2) var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.rasterizeBtn:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.rasterizeBtn:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .hint {

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -178,6 +178,7 @@ export function LayerEffectsPanel() {
   const activeLayerId = useEditorStore((s) => s.document.activeLayerId);
   const layers = useEditorStore((s) => s.document.layers);
   const updateLayerEffects = useEditorStore((s) => s.updateLayerEffects);
+  const rasterizeLayerStyle = useEditorStore((s) => s.rasterizeLayerStyle);
   const setShowEffectsDrawer = useUIStore((s) => s.setShowEffectsDrawer);
 
   const [selectedEffect, setSelectedEffect] = useState<EffectKey>('dropShadow');
@@ -222,6 +223,10 @@ export function LayerEffectsPanel() {
   const stroke = effects?.stroke;
   const outerGlow = effects?.outerGlow;
   const innerGlow = effects?.innerGlow;
+
+  const hasAnyEffect = !!(
+    shadow?.enabled || stroke?.enabled || outerGlow?.enabled || innerGlow?.enabled
+  );
 
   function renderForm() {
     if (!effects) return null;
@@ -284,6 +289,15 @@ export function LayerEffectsPanel() {
               </div>
             );
           })}
+          <div className={styles.effectListSpacer} />
+          <button
+            type="button"
+            className={styles.rasterizeBtn}
+            disabled={!hasAnyEffect}
+            onClick={rasterizeLayerStyle}
+          >
+            Rasterize Layer Style
+          </button>
         </div>
         <div className={styles.effectForm}>
           {renderForm() ?? (

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -112,6 +112,35 @@ export function LayerPanel({
   const showEffectsDrawer = useUIStore((s) => s.showEffectsDrawer);
   const setShowEffectsDrawer = useUIStore((s) => s.setShowEffectsDrawer);
 
+  const handleThumbnailCmdClick = useCallback((e: React.MouseEvent, layerId: string) => {
+    if (!(e.metaKey || e.ctrlKey)) return;
+    e.stopPropagation();
+    const editorState = useEditorStore.getState();
+    const layer = editorState.document.layers.find((l) => l.id === layerId);
+    if (!layer) return;
+    const pixelData = editorState.layerPixelData.get(layerId);
+    if (!pixelData) return;
+
+    const { width: docW, height: docH } = editorState.document;
+    const selMask = new Uint8ClampedArray(docW * docH);
+    for (let y = 0; y < pixelData.height; y++) {
+      for (let x = 0; x < pixelData.width; x++) {
+        const alpha = pixelData.data[(y * pixelData.width + x) * 4 + 3] ?? 0;
+        if (alpha < 1) continue;
+        const docX = x + layer.x;
+        const docY = y + layer.y;
+        if (docX >= 0 && docX < docW && docY >= 0 && docY < docH) {
+          selMask[docY * docW + docX] = alpha;
+        }
+      }
+    }
+    const bounds = selectionBounds(selMask, docW, docH);
+    if (bounds) {
+      editorState.setSelection(bounds, selMask, docW, docH);
+      useUIStore.getState().setTransform(createTransformState(bounds));
+    }
+  }, []);
+
   const handleConvertMaskToMarquee = useCallback((layerId: string) => {
     const editorState = useEditorStore.getState();
     const layer = editorState.document.layers.find((l) => l.id === layerId);
@@ -216,7 +245,10 @@ export function LayerPanel({
               >
                 <GripVertical size={12} />
               </span>
-              <div className={styles.thumbnail}>
+              <div
+                className={styles.thumbnail}
+                onClick={(e) => handleThumbnailCmdClick(e, layer.id)}
+              >
                 <LayerThumbnail layer={layer} />
               </div>
               <span className={styles.name}>{layer.name}</span>


### PR DESCRIPTION
## Summary
- Add `rasterizeLayerStyle` action that bakes layer effects (stroke, drop shadow, glow) into pixel data and resets effects to defaults
- Update `mergeDown` to automatically rasterize effects on the top layer before compositing, so effects are preserved in the merged result
- Add "Rasterize Layer Style" button to the bottom of the layer effects panel (disabled when no effects are active)
- Add Cmd+click on layer thumbnail to create a marquee selection from the layer's alpha channel
- Wire up missing keyboard shortcuts: Cmd+' (grid toggle), Cmd+; (guides toggle), Cmd+A (select all), Shift+Cmd+I (select inverse)
- Extract effect render functions into `src/engine/effects-renderer.ts` to resolve circular dependency

## Test plan
- [x] 19 new e2e tests added in `e2e/rasterization-fix.spec.ts` — all passing
- [ ] Manually verify rasterize button appears at bottom of effects panel and is disabled/enabled correctly
- [ ] Manually verify merge down with effects bakes stroke/shadow/glow into merged result
- [ ] Manually verify Cmd+click on layer thumbnail creates selection
- [ ] Manually verify Cmd+' toggles grid, Cmd+; toggles guides
- [ ] Manually verify Cmd+A selects all, Shift+Cmd+I inverts selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)