### PR TITLE
Fix wand and fill for offset layers

### DIFF
--- a/src/app/MenuBar/menus/edit-menu.ts
+++ b/src/app/MenuBar/menus/edit-menu.ts
@@ -2,6 +2,7 @@ import { useEditorStore } from '../../editor-store';
 import { useUIStore } from '../../ui-store';
 import { PixelBuffer } from '../../../engine/pixel-data';
 import { getSelectionMaskValue } from '../../../selection/selection';
+import type { Layer } from '../../../types/layers';
 import type { MenuDef } from './types';
 
 export function fillSelection(): void {
@@ -13,18 +14,35 @@ export function fillSelection(): void {
 
   state.pushHistory();
   const imageData = state.getOrCreateLayerPixelData(activeId);
-  const buf = PixelBuffer.fromImageData(imageData);
+  let buf = PixelBuffer.fromImageData(imageData);
   const color = useUIStore.getState().foregroundColor;
   const sel = state.selection;
 
   if (sel.active && sel.mask) {
+    const { width: docW, height: docH } = state.document;
+    const needsExpand =
+      layer.x !== 0 || layer.y !== 0 ||
+      buf.width < docW || buf.height < docH;
+
+    if (needsExpand) {
+      buf = expandLayerToCanvas(buf, layer.x, layer.y, docW, docH);
+      useEditorStore.setState({
+        document: {
+          ...state.document,
+          layers: state.document.layers.map((l) =>
+            l.id === activeId
+              ? { ...l, x: 0, y: 0, width: docW, height: docH } as Layer
+              : l,
+          ),
+        },
+        renderVersion: state.renderVersion + 1,
+      });
+    }
+
     for (let y = 0; y < sel.maskHeight; y++) {
       for (let x = 0; x < sel.maskWidth; x++) {
         if (getSelectionMaskValue(sel, x, y) > 0) {
-          const lx = x - layer.x;
-          const ly = y - layer.y;
-          if (lx < 0 || lx >= buf.width || ly < 0 || ly >= buf.height) continue;
-          buf.setPixel(lx, ly, color);
+          buf.setPixel(x, y, color);
         }
       }
     }
@@ -32,6 +50,30 @@ export function fillSelection(): void {
     buf.fill(color);
   }
   state.updateLayerPixelData(activeId, buf.toImageData());
+}
+
+function expandLayerToCanvas(
+  buf: PixelBuffer,
+  layerX: number,
+  layerY: number,
+  canvasWidth: number,
+  canvasHeight: number,
+): PixelBuffer {
+  const expanded = new PixelBuffer(canvasWidth, canvasHeight);
+  const src = buf.rawData;
+  const dst = expanded.rawData;
+  for (let y = 0; y < buf.height; y++) {
+    const dy = y + layerY;
+    if (dy < 0 || dy >= canvasHeight) continue;
+    const srcRow = y * buf.width * 4;
+    const dstStart = (dy * canvasWidth + Math.max(0, layerX)) * 4;
+    const srcStart = srcRow + Math.max(0, -layerX) * 4;
+    const copyWidth = Math.min(buf.width, canvasWidth - layerX) - Math.max(0, -layerX);
+    if (copyWidth > 0) {
+      dst.set(src.subarray(srcStart, srcStart + copyWidth * 4), dstStart);
+    }
+  }
+  return expanded;
 }
 
 export const editMenu: MenuDef = {

--- a/src/app/interactions/selection-handlers.ts
+++ b/src/app/interactions/selection-handlers.ts
@@ -6,6 +6,7 @@ import { useEditorStore } from '../editor-store';
 import { useToolSettingsStore } from '../tool-settings-store';
 import { createRectSelection, createEllipseSelection, selectionBounds } from '../../selection/selection';
 import { floodFill } from '../../tools/fill/fill';
+import { OffsetSurface } from '../../engine/pixel-data';
 import { createPolygonMask } from '../../tools/lasso/lasso';
 import { createTransformState } from '../../tools/transform/transform';
 import { snapPositionToGrid } from '../../tools/move/move';
@@ -14,7 +15,7 @@ export function handleSelectionDown(
   ctx: InteractionContext,
   tool: 'marquee-rect' | 'marquee-ellipse' | 'wand' | 'lasso',
 ): InteractionState | undefined {
-  const { canvasPos, layerPos, activeLayerId, activeLayer, pixelBuffer } = ctx;
+  const { canvasPos, activeLayerId, activeLayer, pixelBuffer } = ctx;
 
   if (tool === 'marquee-rect' || tool === 'marquee-ellipse') {
     useUIStore.getState().setTransform(null);
@@ -40,13 +41,12 @@ export function handleSelectionDown(
     const wandContiguous = toolSettings.wandContiguous;
     const editorState = useEditorStore.getState();
     const { width: docW, height: docH } = editorState.document;
-    const wandPixels = floodFill(pixelBuffer, layerPos.x, layerPos.y, { r: 0, g: 0, b: 0, a: 0 }, wandTolerance, wandContiguous);
+    const canvasSurface = new OffsetSurface(pixelBuffer, docW, docH, activeLayer.x, activeLayer.y);
+    const wandPixels = floodFill(canvasSurface, canvasPos.x, canvasPos.y, { r: 0, g: 0, b: 0, a: 0 }, wandTolerance, wandContiguous);
     const wandMask = new Uint8ClampedArray(docW * docH);
     for (const pt of wandPixels) {
-      const mx = pt.x + activeLayer.x;
-      const my = pt.y + activeLayer.y;
-      if (mx >= 0 && mx < docW && my >= 0 && my < docH) {
-        wandMask[my * docW + mx] = 255;
+      if (pt.x >= 0 && pt.x < docW && pt.y >= 0 && pt.y < docH) {
+        wandMask[pt.y * docW + pt.x] = 255;
       }
     }
     const wandBounds = selectionBounds(wandMask, docW, docH);

--- a/src/engine/pixel-data.ts
+++ b/src/engine/pixel-data.ts
@@ -88,6 +88,36 @@ export class PixelBuffer {
 }
 
 /**
+ * Read-only surface that projects a layer's pixels into canvas/document
+ * coordinate space. Pixels outside the layer bounds read as transparent.
+ * Used by the wand tool so flood-fill covers the full canvas, not just
+ * the layer's pixel buffer.
+ */
+export class OffsetSurface implements PixelSurface {
+  readonly width: number;
+  readonly height: number;
+  private readonly inner: PixelBuffer;
+  private readonly layerX: number;
+  private readonly layerY: number;
+
+  constructor(inner: PixelBuffer, canvasWidth: number, canvasHeight: number, layerX: number, layerY: number) {
+    this.inner = inner;
+    this.width = canvasWidth;
+    this.height = canvasHeight;
+    this.layerX = layerX;
+    this.layerY = layerY;
+  }
+
+  getPixel(x: number, y: number): Color {
+    return this.inner.getPixel(x - this.layerX, y - this.layerY);
+  }
+
+  setPixel(_x: number, _y: number, _color: Color): void {
+    // read-only; wand only needs getPixel
+  }
+}
+
+/**
  * Wraps a PixelBuffer so that setPixel only writes to pixels
  * inside the selection mask. Coordinates are in layer-local space;
  * layerX/layerY offset them into document/mask space.


### PR DESCRIPTION
## Summary
- **Wand selection** now covers the full canvas when a layer is offset, not just the layer's pixel buffer bounds. Adds `OffsetSurface` to project layer pixels into canvas coordinates.
- **Fill selection** (Edit > Fill) expands the layer buffer to canvas size when the selection extends beyond layer bounds, so the entire selected area gets filled.
- Fixes the bug where moving a layer then wand-selecting transparent area would leave an unfilled strip at the canvas edge.

## Test plan
- [ ] Create a new image, add a layer, draw a small shape in the middle
- [ ] Move the layer up ~100px with the move tool
- [ ] Magic wand at (1,1) to select transparent area — should select the entire transparent region including below the layer
- [ ] Edit > Fill — entire canvas should be one solid color with no white strip at the bottom
- [ ] Verify undo restores the original state correctly
- [ ] Verify wand still works correctly on layers that haven't been moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)