### PR TITLE
Tool updates and color pipeline improvements

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,8 @@ import { useCanvasInteraction } from './useCanvasInteraction';
 import { useToolSettingsStore } from './tool-settings-store';
 import { drawShape } from '../tools/shape/shape';
 import { PixelBuffer } from '../engine/pixel-data';
+import { contextOptions } from '../engine/color-space';
+import { seedBitmapFromBlob } from '../engine/bitmap-cache';
 import { wrapWithSelectionMask } from './interactions/selection-mask-wrap';
 import { useCanvasRendering } from './useCanvasRendering';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
@@ -78,12 +80,14 @@ export function App() {
       const canvas = document.createElement('canvas');
       canvas.width = img.width;
       canvas.height = img.height;
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext('2d', contextOptions);
       if (ctx) {
         ctx.drawImage(img, 0, 0);
         const imageData = ctx.getImageData(0, 0, img.width, img.height);
         const name = file.name.replace(/\.[^.]+$/, '');
         openImageAsDocument(imageData, name);
+        const layerId = useEditorStore.getState().document.activeLayerId;
+        if (layerId) seedBitmapFromBlob(layerId, file);
       }
       URL.revokeObjectURL(url);
     };

--- a/src/app/MenuBar/menus/file-menu.ts
+++ b/src/app/MenuBar/menus/file-menu.ts
@@ -11,6 +11,9 @@ import {
 import { renderLayerContent } from '../../rendering/render-layers';
 import { addPngMetadata, addJpegComment } from '../../../utils/image-metadata';
 import { hasActiveAdjustments, applyAdjustmentsToImageData } from '../../../filters/image-adjustments';
+import { contextOptions, canvasColorSpace } from '../../../engine/color-space';
+import { getCachedBitmap, seedBitmapFromBlob } from '../../../engine/bitmap-cache';
+import { hasEnabledEffects } from '../../../layers/layer-model';
 import type { MenuDef } from './types';
 
 const METADATA_NOTE = 'Made with Lopsy — http://lopsy.art';
@@ -34,12 +37,17 @@ export function openFileFromDisk(): void {
       const canvas = document.createElement('canvas');
       canvas.width = img.width;
       canvas.height = img.height;
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext('2d', contextOptions);
       if (ctx) {
         ctx.drawImage(img, 0, 0);
         const imageData = ctx.getImageData(0, 0, img.width, img.height);
         const name = file.name.replace(/\.[^.]+$/, '');
         useEditorStore.getState().openImageAsDocument(imageData, name);
+        // Seed the bitmap cache from the original file so the rendering
+        // path uses the browser's native decoded bitmap rather than one
+        // rebuilt from the canvas-round-tripped ImageData.
+        const layerId = useEditorStore.getState().document.activeLayerId;
+        if (layerId) seedBitmapFromBlob(layerId, file);
       }
       URL.revokeObjectURL(url);
     };
@@ -54,7 +62,7 @@ export function exportCanvas(format: 'png' | 'jpeg'): void {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('2d', contextOptions);
   if (!ctx) return;
 
   // Fill background
@@ -68,8 +76,23 @@ export function exportCanvas(format: 'png' | 'jpeg'): void {
     if (!layer || !layer.visible) continue;
     const data = state.layerPixelData.get(layerId);
     if (!data) continue;
+
+    ctx.globalAlpha = layer.opacity;
+
+    // Use cached bitmap for layers without effects for color-correct export
+    const bitmap = getCachedBitmap(layerId);
+    const hasMask = layer.mask?.enabled;
+    if (bitmap && !hasEnabledEffects(layer.effects) && !hasMask) {
+      ctx.drawImage(bitmap, layer.x, layer.y);
+      continue;
+    }
+
     const { canvas: tempCanvas, ctx: tempCtx } = allocator.acquire(data.width, data.height);
-    tempCtx.putImageData(data, 0, 0);
+    if (bitmap && !layer.effects.colorOverlay.enabled) {
+      tempCtx.drawImage(bitmap, 0, 0);
+    } else {
+      tempCtx.putImageData(data, 0, 0);
+    }
 
     if (layer.effects.colorOverlay.enabled) {
       const overlaid = tempCtx.getImageData(0, 0, data.width, data.height);
@@ -77,7 +100,6 @@ export function exportCanvas(format: 'png' | 'jpeg'): void {
       tempCtx.putImageData(overlaid, 0, 0);
     }
 
-    ctx.globalAlpha = layer.opacity;
     renderOuterGlow(ctx, tempCanvas, layer, data, allocator);
     renderDropShadow(ctx, tempCanvas, layer, data, allocator);
     renderLayerContent(ctx, tempCanvas, layer, data, false, null, allocator);
@@ -97,8 +119,8 @@ export function exportCanvas(format: 'png' | 'jpeg'): void {
 
   const mimeType = format === 'png' ? 'image/png' : 'image/jpeg';
   const ext = format === 'png' ? 'png' : 'jpg';
-  canvas.toBlob(async (blob) => {
-    if (!blob) return;
+
+  const finishExport = async (blob: Blob) => {
     const tagged =
       format === 'png'
         ? await addPngMetadata(blob, { Software: 'Lopsy', Comment: METADATA_NOTE })
@@ -110,6 +132,24 @@ export function exportCanvas(format: 'png' | 'jpeg'): void {
     a.click();
     URL.revokeObjectURL(url);
     useEditorStore.getState().markClean();
+  };
+
+  // Prefer OffscreenCanvas.convertToBlob which passes colorSpace to the
+  // encoder, producing a color-space-aware blob.  Fall back to toBlob.
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const offscreen = new OffscreenCanvas(width, height);
+    const offCtx = offscreen.getContext('2d', contextOptions);
+    if (offCtx) {
+      offCtx.drawImage(canvas, 0, 0);
+      offscreen.convertToBlob({ type: mimeType, quality: 0.92, colorSpace: canvasColorSpace } as ImageEncodeOptions)
+        .then(finishExport);
+      return;
+    }
+  }
+
+  canvas.toBlob(async (blob) => {
+    if (!blob) return;
+    await finishExport(blob);
   }, mimeType, 0.92);
 }
 

--- a/src/app/StatusBar/StatusBar.module.css
+++ b/src/app/StatusBar/StatusBar.module.css
@@ -20,6 +20,10 @@
   color: var(--color-text-primary);
 }
 
+.spacer {
+  flex: 1;
+}
+
 .divider {
   width: 1px;
   height: 12px;

--- a/src/app/StatusBar/StatusBar.tsx
+++ b/src/app/StatusBar/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { canvasColorSpace } from '../../engine/color-space';
 import styles from './StatusBar.module.css';
 
 interface StatusBarProps {
@@ -7,6 +8,8 @@ interface StatusBarProps {
   docWidth: number;
   docHeight: number;
 }
+
+const colorSpaceLabel = canvasColorSpace === 'display-p3' ? 'Display P3' : 'sRGB';
 
 export function StatusBar({ zoom, cursorX, cursorY, docWidth, docHeight }: StatusBarProps) {
   return (
@@ -22,6 +25,8 @@ export function StatusBar({ zoom, cursorX, cursorY, docWidth, docHeight }: Statu
         <span className={styles.number}>{docWidth}</span> x{' '}
         <span className={styles.number}>{docHeight}</span> px
       </span>
+      <span className={styles.spacer} />
+      <span className={styles.item}>{colorSpaceLabel}</span>
     </div>
   );
 }

--- a/src/app/editor-store.ts
+++ b/src/app/editor-store.ts
@@ -5,6 +5,7 @@ import { createPixelDataSlice } from './store/pixel-data-slice';
 import { createHistorySlice } from './store/history-slice';
 import { createClipboardSlice } from './store/clipboard-slice';
 import { createDocumentSlice } from './store/document-slice';
+import { updateBitmapCache, clearBitmapCache, removeBitmapCache, setBitmapReadyCallback } from '../engine/bitmap-cache';
 import type { EditorState } from './store/types';
 
 export type { EditorState };
@@ -17,3 +18,38 @@ export const useEditorStore = create<EditorState>((...a) => ({
   ...createClipboardSlice(...a),
   ...createDocumentSlice(...a),
 }));
+
+// When a bitmap finishes building, bump renderVersion so the canvas repaints
+setBitmapReadyCallback(() => {
+  useEditorStore.getState().notifyRender();
+});
+
+// Watch for pixel data changes and keep the bitmap cache in sync
+let prevPixelData: Map<string, ImageData> = new Map();
+useEditorStore.subscribe((state) => {
+  const next = state.layerPixelData;
+  if (next === prevPixelData) return;
+
+  // Build bitmaps for new or changed entries
+  for (const [id, data] of next) {
+    if (prevPixelData.get(id) !== data) {
+      updateBitmapCache(id, data);
+    }
+  }
+  // Clean up removed layers
+  for (const id of prevPixelData.keys()) {
+    if (!next.has(id)) {
+      removeBitmapCache(id);
+    }
+  }
+  // Detect full document reset (all layer IDs changed)
+  if (next.size > 0 && prevPixelData.size > 0) {
+    let anyShared = false;
+    for (const id of next.keys()) {
+      if (prevPixelData.has(id)) { anyShared = true; break; }
+    }
+    if (!anyShared) clearBitmapCache();
+  }
+
+  prevPixelData = next;
+});

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -2,6 +2,8 @@ import type { MutableRefObject } from 'react';
 import type { Point } from '../../types';
 import { PixelBuffer } from '../../engine/pixel-data';
 import { getSelectionMaskValue } from '../../selection/selection';
+import { createImageData } from '../../engine/color-space';
+import { contextOptions } from '../../engine/color-space';
 import { snapPositionToGrid } from '../../tools/move/move';
 import { createTransformState } from '../../tools/transform/transform';
 import { useUIStore } from '../ui-store';
@@ -45,7 +47,7 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
       // rotation/scale applied so the floated pixels reflect
       // the transformed state (not the original orientation).
       const ptRef = persistentTransformRef.current;
-      const bCtx = ptRef.baseCanvas.getContext('2d');
+      const bCtx = ptRef.baseCanvas.getContext('2d', contextOptions);
       const w = ptRef.transformCanvas.width;
       const h = ptRef.transformCanvas.height;
       const currentXform = useUIStore.getState().transform;
@@ -54,7 +56,7 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
         const renderedCanvas = document.createElement('canvas');
         renderedCanvas.width = w;
         renderedCanvas.height = h;
-        const rCtx = renderedCanvas.getContext('2d')!;
+        const rCtx = renderedCanvas.getContext('2d', contextOptions)!;
         if (currentXform && currentXform.rotation !== 0 || currentXform && (currentXform.scaleX !== 1 || currentXform.scaleY !== 1)) {
           const origBounds = sel.bounds!;
           const cx = origBounds.x + origBounds.width / 2;
@@ -284,13 +286,13 @@ export function handleMoveUp(
     const txCanvas = document.createElement('canvas');
     txCanvas.width = w;
     txCanvas.height = h;
-    const txCtx = txCanvas.getContext('2d');
+    const txCtx = txCanvas.getContext('2d', contextOptions);
     const bCanvas = document.createElement('canvas');
     bCanvas.width = w;
     bCanvas.height = h;
-    const bCtx = bCanvas.getContext('2d');
+    const bCtx = bCanvas.getContext('2d', contextOptions);
     if (txCtx && bCtx) {
-      const shifted = new ImageData(w, h);
+      const shifted = createImageData(w, h);
       const ox = floatRef.offsetX;
       const oy = floatRef.offsetY;
       for (let y = 0; y < h; y++) {

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -8,6 +8,7 @@ import {
 } from '../../tools/transform/transform';
 import type { TransformState } from '../../tools/transform/transform';
 import { getSelectionMaskValue } from '../../selection/selection';
+import { createImageDataFromArray, contextOptions } from '../../engine/color-space';
 import { useUIStore } from '../ui-store';
 import { useEditorStore } from '../editor-store';
 import type { InteractionState, InteractionContext } from './interaction-types';
@@ -59,16 +60,16 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
     const txCanvas = document.createElement('canvas');
     txCanvas.width = w;
     txCanvas.height = h;
-    const txCtx = txCanvas.getContext('2d');
+    const txCtx = txCanvas.getContext('2d', contextOptions);
 
     const bCanvas = document.createElement('canvas');
     bCanvas.width = w;
     bCanvas.height = h;
-    const bCtx = bCanvas.getContext('2d');
+    const bCtx = bCanvas.getContext('2d', contextOptions);
 
     if (txCtx && bCtx) {
-      const floatedData = new ImageData(new Uint8ClampedArray(imageData.data), w, h);
-      const baseData = new ImageData(new Uint8ClampedArray(imageData.data), w, h);
+      const floatedData = createImageDataFromArray(new Uint8ClampedArray(imageData.data), w, h);
+      const baseData = createImageDataFromArray(new Uint8ClampedArray(imageData.data), w, h);
 
       for (let y = 0; y < h; y++) {
         for (let x = 0; x < w; x++) {
@@ -208,7 +209,7 @@ export function handleTransformMove(
     const rotatedCanvas = document.createElement('canvas');
     rotatedCanvas.width = w;
     rotatedCanvas.height = h;
-    const rotCtx = rotatedCanvas.getContext('2d');
+    const rotCtx = rotatedCanvas.getContext('2d', contextOptions);
     if (rotCtx) {
       rotCtx.save();
       rotCtx.translate(origCx + newTransform.translateX, origCy + newTransform.translateY);
@@ -219,9 +220,9 @@ export function handleTransformMove(
       rotCtx.restore();
 
       // Composite: base + rotated pixels clipped to selection mask
-      const baseData = state.baseCanvas.getContext('2d')!.getImageData(0, 0, w, h);
+      const baseData = state.baseCanvas.getContext('2d', contextOptions)!.getImageData(0, 0, w, h);
       const rotData = rotCtx.getImageData(0, 0, w, h);
-      const resultData = new ImageData(new Uint8ClampedArray(baseData.data), w, h);
+      const resultData = createImageDataFromArray(new Uint8ClampedArray(baseData.data), w, h);
 
       for (let py = 0; py < h; py++) {
         for (let px = 0; px < w; px++) {

--- a/src/app/rendering/render-layers.ts
+++ b/src/app/rendering/render-layers.ts
@@ -1,6 +1,7 @@
 import { getActiveMaskEditBuffer } from '../useCanvasInteraction';
 import type { CanvasAllocator } from '../../engine/effects-renderer';
 import type { Layer } from '../../types';
+import { createImageData } from '../../engine/color-space';
 
 export function renderLayerContent(
   ctx: CanvasRenderingContext2D,
@@ -14,7 +15,7 @@ export function renderLayerContent(
   if (layer.mask && layer.mask.enabled && !maskEditMode) {
     const { canvas: maskedCanvas, ctx: maskedCtx } = alloc.acquire(data.width, data.height);
     maskedCtx.drawImage(tempCanvas, 0, 0);
-    const maskImageData = new ImageData(layer.mask.width, layer.mask.height);
+    const maskImageData = createImageData(layer.mask.width, layer.mask.height);
     for (let i = 0; i < layer.mask.data.length; i++) {
       const idx = i * 4;
       const val = layer.mask.data[i] ?? 0;

--- a/src/app/shortcuts/edit-shortcuts.ts
+++ b/src/app/shortcuts/edit-shortcuts.ts
@@ -1,6 +1,8 @@
 import { useUIStore } from '../ui-store';
 import { useEditorStore } from '../editor-store';
 import { selectAll, invertSelectionAction } from '../MenuBar/menus/select-menu';
+import { contextOptions } from '../../engine/color-space';
+import { seedBitmapFromBlob } from '../../engine/bitmap-cache';
 
 export function handleEditShortcut(
   e: KeyboardEvent,
@@ -27,11 +29,13 @@ export function handleEditShortcut(
           const canvas = document.createElement('canvas');
           canvas.width = bitmap.width;
           canvas.height = bitmap.height;
-          const ctx = canvas.getContext('2d');
+          const ctx = canvas.getContext('2d', contextOptions);
           if (ctx) {
             ctx.drawImage(bitmap, 0, 0);
             const imageData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
             useEditorStore.getState().pasteImageData(imageData);
+            const layerId = useEditorStore.getState().document.activeLayerId;
+            if (layerId) seedBitmapFromBlob(layerId, blob);
           }
           bitmap.close();
           return;

--- a/src/app/store/actions/add-layer.ts
+++ b/src/app/store/actions/add-layer.ts
@@ -1,6 +1,7 @@
 import type { DocumentState } from '../../../types';
 import type { EditorState } from '../types';
 import { createRasterLayer } from '../../../layers/layer-model';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeAddLayer(
   doc: DocumentState,
@@ -12,7 +13,7 @@ export function computeAddLayer(
     height: doc.height,
   });
   const pixelData = new Map(layerPixelData);
-  pixelData.set(newLayer.id, new ImageData(newLayer.width, newLayer.height));
+  pixelData.set(newLayer.id, createImageData(newLayer.width, newLayer.height));
   return {
     document: {
       ...doc,

--- a/src/app/store/actions/create-document.ts
+++ b/src/app/store/actions/create-document.ts
@@ -1,5 +1,6 @@
 import type { EditorState, SelectionData } from '../types';
 import { createRasterLayer } from '../../../layers/layer-model';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeCreateDocument(
   width: number,
@@ -11,7 +12,7 @@ export function computeCreateDocument(
     ? { r: 0, g: 0, b: 0, a: 0 }
     : { r: 255, g: 255, b: 255, a: 1 };
   const pixelData = new Map<string, ImageData>();
-  const imgData = new ImageData(width, height);
+  const imgData = createImageData(width, height);
   if (!transparentBg) {
     for (let i = 0; i < imgData.data.length; i += 4) {
       imgData.data[i] = 255;

--- a/src/app/store/actions/crop-canvas.ts
+++ b/src/app/store/actions/crop-canvas.ts
@@ -1,6 +1,7 @@
 import type { DocumentState, Layer, Rect } from '../../../types';
 import type { EditorState } from '../types';
 import { cropLayerPixelData } from '../../../engine/canvas-ops';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeCropCanvas(
   doc: DocumentState,
@@ -31,7 +32,7 @@ export function computeCropCanvas(
     const oldData = layerPixelData.get(layer.id);
     const newData = oldData
       ? cropLayerPixelData(oldData, layer.x, layer.y, cx, cy, cw, ch)
-      : new ImageData(cw, ch);
+      : createImageData(cw, ch);
     pixelData.set(layer.id, newData);
     newLayers.push({ ...layer, x: 0, y: 0, width: cw, height: ch } as Layer);
   }

--- a/src/app/store/actions/flatten-image.ts
+++ b/src/app/store/actions/flatten-image.ts
@@ -2,6 +2,7 @@ import type { DocumentState } from '../../../types';
 import type { EditorState } from '../types';
 import { compositeOver } from '../../../engine/compositing';
 import { createRasterLayer } from '../../../layers/layer-model';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeFlattenImage(
   doc: DocumentState,
@@ -10,7 +11,7 @@ export function computeFlattenImage(
   if (doc.layers.length <= 1) return undefined;
 
   const { width, height, backgroundColor } = doc;
-  const result = new ImageData(width, height);
+  const result = createImageData(width, height);
   for (let i = 0; i < result.data.length; i += 4) {
     result.data[i] = backgroundColor.r;
     result.data[i + 1] = backgroundColor.g;

--- a/src/app/store/actions/merge-down.ts
+++ b/src/app/store/actions/merge-down.ts
@@ -3,6 +3,7 @@ import type { EditorState } from '../types';
 import { compositeOver } from '../../../engine/compositing';
 import { rasterizeEffectsToImageData } from '../../../engine/effects-renderer';
 import { hasEnabledEffects } from '../../../layers/layer-model';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeMergeDown(
   doc: DocumentState,
@@ -19,8 +20,8 @@ export function computeMergeDown(
   const bottomLayer = doc.layers.find((l) => l.id === belowId);
   if (!topLayer || !bottomLayer) return undefined;
 
-  let topData = layerPixelData.get(activeId) ?? new ImageData(doc.width, doc.height);
-  const bottomData = layerPixelData.get(belowId) ?? new ImageData(doc.width, doc.height);
+  let topData = layerPixelData.get(activeId) ?? createImageData(doc.width, doc.height);
+  const bottomData = layerPixelData.get(belowId) ?? createImageData(doc.width, doc.height);
 
   let topX = topLayer.x;
   let topY = topLayer.y;
@@ -32,7 +33,7 @@ export function computeMergeDown(
     topY += rasterized.offsetY;
   }
 
-  const result = new ImageData(bottomData.width, bottomData.height);
+  const result = createImageData(bottomData.width, bottomData.height);
   result.data.set(bottomData.data);
   compositeOver(
     topData.data, bottomData.data,

--- a/src/app/store/actions/rasterize-style.ts
+++ b/src/app/store/actions/rasterize-style.ts
@@ -2,6 +2,7 @@ import type { DocumentState, Layer } from '../../../types';
 import type { EditorState } from '../types';
 import { rasterizeEffectsToImageData } from '../../../engine/effects-renderer';
 import { hasEnabledEffects, DEFAULT_EFFECTS } from '../../../layers/layer-model';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeRasterizeStyle(
   doc: DocumentState,
@@ -12,7 +13,7 @@ export function computeRasterizeStyle(
   const layer = doc.layers.find((l) => l.id === activeId);
   if (!layer || !hasEnabledEffects(layer.effects)) return undefined;
 
-  const data = layerPixelData.get(activeId) ?? new ImageData(doc.width, doc.height);
+  const data = layerPixelData.get(activeId) ?? createImageData(doc.width, doc.height);
   const result = rasterizeEffectsToImageData(layer, data);
 
   const pixelData = new Map(layerPixelData);

--- a/src/app/store/actions/resize-canvas.ts
+++ b/src/app/store/actions/resize-canvas.ts
@@ -1,6 +1,7 @@
 import type { DocumentState, Layer } from '../../../types';
 import type { EditorState } from '../types';
 import { resizeCanvasPixelData } from '../../../engine/canvas-ops';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeResizeCanvas(
   doc: DocumentState,
@@ -27,7 +28,7 @@ export function computeResizeCanvas(
     const oldData = layerPixelData.get(layer.id);
     const newData = oldData
       ? resizeCanvasPixelData(oldData, layer.x, layer.y, newWidth, newHeight, offsetX, offsetY)
-      : new ImageData(newWidth, newHeight);
+      : createImageData(newWidth, newHeight);
     pixelData.set(layer.id, newData);
     newLayers.push({ ...layer, x: 0, y: 0, width: newWidth, height: newHeight } as Layer);
   }

--- a/src/app/store/actions/resize-image.ts
+++ b/src/app/store/actions/resize-image.ts
@@ -1,6 +1,7 @@
 import type { DocumentState, Layer } from '../../../types';
 import type { EditorState } from '../types';
 import { scalePixelData } from '../../../engine/canvas-ops';
+import { createImageData } from '../../../engine/color-space';
 
 export function computeResizeImage(
   doc: DocumentState,
@@ -28,7 +29,7 @@ export function computeResizeImage(
       if (!scaled) continue;
       pixelData.set(layer.id, scaled);
     } else {
-      pixelData.set(layer.id, new ImageData(newWidth, newHeight));
+      pixelData.set(layer.id, createImageData(newWidth, newHeight));
     }
     newLayers.push({
       ...layer,

--- a/src/app/store/clipboard-slice.ts
+++ b/src/app/store/clipboard-slice.ts
@@ -1,6 +1,7 @@
 import { cloneImageData } from '../../engine/canvas-ops';
 import { getSelectionMaskValue } from '../../selection/selection';
 import { createRasterLayer } from '../../layers/layer-model';
+import { createImageData } from '../../engine/color-space';
 import type { ClipboardData, SliceCreator } from './types';
 
 export interface ClipboardSlice {
@@ -30,7 +31,7 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
       const h = Math.round(b.height);
       const bx = Math.round(b.x);
       const by = Math.round(b.y);
-      const copied = new ImageData(w, h);
+      const copied = createImageData(w, h);
       for (let y = 0; y < h; y++) {
         for (let x = 0; x < w; x++) {
           const docX = bx + x;

--- a/src/app/store/pixel-data-slice.ts
+++ b/src/app/store/pixel-data-slice.ts
@@ -1,4 +1,6 @@
 import type { SliceCreator } from './types';
+import { createImageData } from '../../engine/color-space';
+import { updateBitmapCache } from '../../engine/bitmap-cache';
 
 export interface PixelDataSlice {
   layerPixelData: Map<string, ImageData>;
@@ -22,7 +24,7 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
     const layer = state.document.layers.find((l) => l.id === layerId);
     const width = layer?.type === 'raster' || layer?.type === 'shape' ? layer.width : state.document.width;
     const height = layer?.type === 'raster' || layer?.type === 'shape' ? layer.height : state.document.height;
-    const imageData = new ImageData(width, height);
+    const imageData = createImageData(width, height);
     const pixelData = new Map(state.layerPixelData);
     pixelData.set(layerId, imageData);
     set({ layerPixelData: pixelData });
@@ -36,6 +38,7 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
     const dirtyLayerIds = new Set(state.dirtyLayerIds);
     dirtyLayerIds.add(layerId);
     set({ layerPixelData: pixelData, dirtyLayerIds, renderVersion: state.renderVersion + 1 });
+    updateBitmapCache(layerId, data);
   },
 
   notifyRender: () => {

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -9,6 +9,9 @@ import { renderSelectionAnts, renderTransformHandles } from './rendering/render-
 import { renderPathOverlay, renderLassoPreview, renderCropPreview, renderGradientPreview, renderBrushCursor } from './rendering/render-overlays';
 import { renderGrid, renderRulers } from './rendering/render-grid';
 import { hasActiveAdjustments, applyAdjustmentsToImageData } from '../filters/image-adjustments';
+import { contextOptions } from '../engine/color-space';
+import { getCachedBitmap } from '../engine/bitmap-cache';
+import { hasEnabledEffects } from '../layers/layer-model';
 
 export { renderLayerContent } from './rendering/render-layers';
 
@@ -65,7 +68,7 @@ export function useCanvasRendering(
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     const container = containerRef.current;
@@ -107,8 +110,24 @@ export function useCanvasRendering(
       if (!data) continue;
 
       ctx.globalAlpha = layer.opacity;
+
+      // Fast path: draw cached ImageBitmap directly for layers with no
+      // effects or masks.  This avoids the putImageData → drawImage chain
+      // that can introduce color-management rounding.
+      const hasMask = layer.mask?.enabled && !maskEditMode;
+      const isMaskOverlay = maskEditMode && layer.mask && layer.id === activeLayerId;
+      const bitmap = getCachedBitmap(layer.id);
+      if (bitmap && !hasEnabledEffects(layer.effects) && !hasMask && !isMaskOverlay) {
+        ctx.drawImage(bitmap, layer.x, layer.y);
+        continue;
+      }
+
       const { canvas: tempCanvas, ctx: tempCtx } = allocator.acquire(data.width, data.height);
-      tempCtx.putImageData(data, 0, 0);
+      if (bitmap && !layer.effects.colorOverlay.enabled) {
+        tempCtx.drawImage(bitmap, 0, 0);
+      } else {
+        tempCtx.putImageData(data, 0, 0);
+      }
 
       if (layer.effects.colorOverlay.enabled) {
         const overlaid = tempCtx.getImageData(0, 0, data.width, data.height);

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@ import { useUIStore } from './ui-store';
 import { useEditorStore } from './editor-store';
 import { strokeCurrentPath } from './useCanvasInteraction';
 import { getSelectionMaskValue } from '../selection/selection';
+import { createImageData } from '../engine/color-space';
 import { handleToolShortcut, handleSizeShortcut, handleNudgeShortcut } from './shortcuts/tool-shortcuts';
 import { handleEditShortcut } from './shortcuts/edit-shortcuts';
 import { handleZoomShortcut } from './shortcuts/zoom-shortcuts';
@@ -103,7 +104,7 @@ function handleDeleteKey(): void {
     const layerData = editor.getOrCreateLayerPixelData(activeId);
     const layer = editor.document.layers.find((l) => l.id === activeId);
     if (!layer) return;
-    const result = new ImageData(layerData.width, layerData.height);
+    const result = createImageData(layerData.width, layerData.height);
     result.data.set(layerData.data);
     for (let y = 0; y < sel.maskHeight; y++) {
       for (let x = 0; x < sel.maskWidth; x++) {

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { rgbToHsv, hsvToRgb } from '../../utils/color';
+import { contextOptions } from '../../engine/color-space';
 import type { Color } from '../../types';
 import styles from './ColorPicker.module.css';
 
@@ -49,7 +50,7 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
     canvas.width = width;
     canvas.height = height;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     const hsv = hsvRef.current;
@@ -84,7 +85,7 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
     canvas.width = width;
     canvas.height = height;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     const grad = ctx.createLinearGradient(0, 0, width, 0);
@@ -118,7 +119,7 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
     canvas.width = width;
     canvas.height = height;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     const rgb = hsvToRgb(hsvRef.current);

--- a/src/engine/bitmap-cache.ts
+++ b/src/engine/bitmap-cache.ts
@@ -1,0 +1,85 @@
+/**
+ * Caches ImageBitmap objects derived from layer pixel data.
+ *
+ * Drawing an ImageBitmap via `ctx.drawImage(bitmap, ...)` gives the browser
+ * a single, direct color-managed path from pixel data to display.  This
+ * avoids the lossy `putImageData → drawImage` chain where the intermediate
+ * canvas can introduce rounding through premultiplied-alpha conversion and
+ * color-space re-interpretation.
+ */
+
+const cache = new Map<string, ImageBitmap>();
+const pending = new Set<string>();
+
+let notifyRender: (() => void) | null = null;
+
+/** Provide a callback the cache will invoke after a bitmap is ready. */
+export function setBitmapReadyCallback(cb: () => void): void {
+  notifyRender = cb;
+}
+
+/** Return the cached bitmap for a layer, or null if not yet available. */
+export function getCachedBitmap(layerId: string): ImageBitmap | null {
+  return cache.get(layerId) ?? null;
+}
+
+/** Schedule an async bitmap build for the given layer's ImageData. */
+export function updateBitmapCache(layerId: string, data: ImageData): void {
+  if (typeof createImageBitmap === 'undefined') return;
+
+  // Mark any in-flight build as stale so its result is discarded
+  pending.delete(layerId);
+  pending.add(layerId);
+
+  createImageBitmap(data).then((bitmap) => {
+    if (!pending.has(layerId)) {
+      bitmap.close();
+      return;
+    }
+    pending.delete(layerId);
+    const old = cache.get(layerId);
+    if (old) old.close();
+    cache.set(layerId, bitmap);
+    notifyRender?.();
+  });
+}
+
+/**
+ * Seed the cache with a bitmap built directly from the original image
+ * source (File/Blob).  This uses the browser's native image decoder —
+ * the same pipeline as `<img>` — so the bitmap preserves the source's
+ * full color fidelity without a canvas round-trip.
+ */
+export function seedBitmapFromBlob(layerId: string, blob: Blob): void {
+  if (typeof createImageBitmap === 'undefined') return;
+
+  pending.delete(layerId);
+  pending.add(layerId);
+
+  createImageBitmap(blob).then((bitmap) => {
+    if (!pending.has(layerId)) {
+      bitmap.close();
+      return;
+    }
+    pending.delete(layerId);
+    const old = cache.get(layerId);
+    if (old) old.close();
+    cache.set(layerId, bitmap);
+    notifyRender?.();
+  });
+}
+
+/** Remove a layer's cached bitmap (e.g. when the layer is deleted). */
+export function removeBitmapCache(layerId: string): void {
+  pending.delete(layerId);
+  const old = cache.get(layerId);
+  if (old) old.close();
+  cache.delete(layerId);
+}
+
+/** Clear the entire cache (e.g. when creating a new document). */
+export function clearBitmapCache(): void {
+  for (const bitmap of cache.values()) bitmap.close();
+  cache.clear();
+  pending.clear();
+}

--- a/src/engine/canvas-ops.ts
+++ b/src/engine/canvas-ops.ts
@@ -1,5 +1,7 @@
+import { createImageData, contextOptions } from './color-space';
+
 export function cloneImageData(data: ImageData): ImageData {
-  const copy = new ImageData(data.width, data.height);
+  const copy = createImageData(data.width, data.height);
   copy.data.set(data.data);
   return copy;
 }
@@ -13,7 +15,7 @@ export function cropLayerPixelData(
   cropW: number,
   cropH: number,
 ): ImageData {
-  const newData = new ImageData(cropW, cropH);
+  const newData = createImageData(cropW, cropH);
   for (let y = 0; y < cropH; y++) {
     for (let x = 0; x < cropW; x++) {
       const srcX = x + cropX - layerX;
@@ -39,7 +41,7 @@ export function resizeCanvasPixelData(
   offsetX: number,
   offsetY: number,
 ): ImageData {
-  const newData = new ImageData(newW, newH);
+  const newData = createImageData(newW, newH);
   const lx = layerX + offsetX;
   const ly = layerY + offsetY;
   for (let y = 0; y < oldData.height; y++) {
@@ -64,7 +66,7 @@ export function scalePixelData(
   newH: number,
 ): ImageData | null {
   const tmpCanvas = document.createElement('canvas');
-  const tmpCtx = tmpCanvas.getContext('2d');
+  const tmpCtx = tmpCanvas.getContext('2d', contextOptions);
   if (!tmpCtx) return null;
 
   tmpCanvas.width = oldData.width;
@@ -74,7 +76,7 @@ export function scalePixelData(
   const scaledCanvas = document.createElement('canvas');
   scaledCanvas.width = newW;
   scaledCanvas.height = newH;
-  const scaledCtx = scaledCanvas.getContext('2d');
+  const scaledCtx = scaledCanvas.getContext('2d', contextOptions);
   if (!scaledCtx) return null;
 
   scaledCtx.imageSmoothingEnabled = true;

--- a/src/engine/canvas-pool.ts
+++ b/src/engine/canvas-pool.ts
@@ -1,3 +1,5 @@
+import { contextOptions } from './color-space';
+
 export interface PooledCanvas {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -44,7 +46,7 @@ export class CanvasPool {
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) {
       throw new Error('Failed to get 2d context from canvas');
     }

--- a/src/engine/color-space.ts
+++ b/src/engine/color-space.ts
@@ -1,0 +1,62 @@
+/**
+ * Progressive enhancement for wide-gamut (Display P3) color.
+ *
+ * When the browser and display both support it, all canvases and ImageData
+ * objects are created in the 'display-p3' color space. Otherwise we fall
+ * back to the default 'srgb'. The rest of the engine is unaware of which
+ * gamut is active — it just uses these helpers instead of raw constructors.
+ */
+
+export type CanvasColorSpace = 'srgb' | 'display-p3';
+
+function detectColorSpace(): CanvasColorSpace {
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d', { colorSpace: 'display-p3' });
+    if (!ctx) return 'srgb';
+
+    // Verify the context actually accepted the color space by writing a P3
+    // red value (r > 1 in sRGB) and reading it back.  If the context
+    // silently fell back to sRGB the round-trip will clamp differently.
+    const img = new ImageData(1, 1, { colorSpace: 'display-p3' });
+    // P3 pure red: roughly (255, 0, 0) in P3 ≈ (255, ~29, ~12) in sRGB.
+    // If we write it and read back the same values the context honors P3.
+    img.data[0] = 255;
+    img.data[3] = 255;
+    ctx.putImageData(img, 0, 0);
+    const readBack = ctx.getImageData(0, 0, 1, 1);
+    if (readBack.colorSpace === 'display-p3') return 'display-p3';
+  } catch {
+    // colorSpace option not supported at all
+  }
+  return 'srgb';
+}
+
+/** The color space used for all canvases in this session. */
+export const canvasColorSpace: CanvasColorSpace = detectColorSpace();
+
+/** Options to spread into `canvas.getContext('2d', ...)`. */
+export const contextOptions: CanvasRenderingContext2DSettings = { colorSpace: canvasColorSpace };
+
+/** Create an ImageData in the active color space. */
+export function createImageData(width: number, height: number): ImageData {
+  return new ImageData(width, height, { colorSpace: canvasColorSpace });
+}
+
+/** Create an ImageData from existing pixel data in the active color space. */
+export function createImageDataFromArray(
+  data: Uint8ClampedArray,
+  width: number,
+  height?: number,
+): ImageData {
+  // Cast needed because TypeScript's ImageData constructor signature
+  // expects ArrayBuffer, but Uint8ClampedArray may back ArrayBufferLike
+  return new ImageData(data as Uint8ClampedArray<ArrayBuffer>, width, height, { colorSpace: canvasColorSpace });
+}
+
+/** Whether the session is using wide-gamut color. */
+export function isWideGamut(): boolean {
+  return canvasColorSpace === 'display-p3';
+}

--- a/src/engine/effects-renderer.ts
+++ b/src/engine/effects-renderer.ts
@@ -1,6 +1,7 @@
 import { canvasPool } from './canvas-pool';
 import type { PooledCanvas } from './canvas-pool';
 import type { Layer } from '../types';
+import { contextOptions } from './color-space';
 
 export class CanvasAllocator {
   private handles: PooledCanvas[] = [];
@@ -218,12 +219,12 @@ export function rasterizeEffectsToImageData(
   const destCanvas = document.createElement('canvas');
   destCanvas.width = outW;
   destCanvas.height = outH;
-  const destCtx = destCanvas.getContext('2d')!;
+  const destCtx = destCanvas.getContext('2d', contextOptions)!;
 
   const tempCanvas = document.createElement('canvas');
   tempCanvas.width = data.width;
   tempCanvas.height = data.height;
-  const tempCtx = tempCanvas.getContext('2d')!;
+  const tempCtx = tempCanvas.getContext('2d', contextOptions)!;
   tempCtx.putImageData(data, 0, 0);
 
   const fakeLayer = { ...layer, x: pad, y: pad } as Layer;

--- a/src/engine/pixel-data.ts
+++ b/src/engine/pixel-data.ts
@@ -1,4 +1,5 @@
 import type { Color, PixelSurface } from '../types/index';
+import { createImageData } from './color-space';
 
 export class PixelBuffer {
   readonly width: number;
@@ -75,7 +76,7 @@ export class PixelBuffer {
   }
 
   toImageData(): ImageData {
-    const imageData = new ImageData(this.width, this.height);
+    const imageData = createImageData(this.width, this.height);
     imageData.data.set(this.data);
     return imageData;
   }

--- a/src/panels/LayerPanel/LayerThumbnail.tsx
+++ b/src/panels/LayerPanel/LayerThumbnail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useEditorStore } from '../../app/editor-store';
+import { contextOptions } from '../../engine/color-space';
 import type { Layer } from '../../types';
 import styles from './LayerPanel.module.css';
 
@@ -10,7 +11,7 @@ export function LayerThumbnail({ layer }: { layer: Layer }) {
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     const thumbSize = 24;
@@ -26,7 +27,7 @@ export function LayerThumbnail({ layer }: { layer: Layer }) {
     const tempCanvas = document.createElement('canvas');
     tempCanvas.width = pixelData.width;
     tempCanvas.height = pixelData.height;
-    const tempCtx = tempCanvas.getContext('2d');
+    const tempCtx = tempCanvas.getContext('2d', contextOptions);
     if (!tempCtx) return;
     tempCtx.putImageData(pixelData, 0, 0);
 

--- a/src/panels/LayerPanel/MaskThumbnail.tsx
+++ b/src/panels/LayerPanel/MaskThumbnail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useEditorStore } from '../../app/editor-store';
+import { contextOptions } from '../../engine/color-space';
 import type { Layer } from '../../types';
 
 export function MaskThumbnail({ layer }: { layer: Layer }) {
@@ -10,7 +11,7 @@ export function MaskThumbnail({ layer }: { layer: Layer }) {
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !mask) return;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', contextOptions);
     if (!ctx) return;
 
     canvas.width = 20;

--- a/src/tools/path/path.ts
+++ b/src/tools/path/path.ts
@@ -1,4 +1,5 @@
 import type { Point, PixelSurface } from '../../types';
+import { contextOptions } from '../../engine/color-space';
 
 export interface PathAnchor {
   point: Point;
@@ -16,7 +17,7 @@ export function rasterizePath(
   const tempCanvas = document.createElement('canvas');
   tempCanvas.width = buf.width;
   tempCanvas.height = buf.height;
-  const ctx = tempCanvas.getContext('2d');
+  const ctx = tempCanvas.getContext('2d', contextOptions);
   if (!ctx) return;
 
   ctx.strokeStyle = `rgba(${color.r},${color.g},${color.b},${color.a})`;

--- a/src/tools/text/text.ts
+++ b/src/tools/text/text.ts
@@ -1,4 +1,5 @@
 import type { Point, PixelSurface } from '../../types';
+import { contextOptions } from '../../engine/color-space';
 
 export function renderText(
   buf: PixelSurface,
@@ -13,7 +14,7 @@ export function renderText(
   const tempCanvas = document.createElement('canvas');
   tempCanvas.width = buf.width;
   tempCanvas.height = buf.height;
-  const ctx = tempCanvas.getContext('2d');
+  const ctx = tempCanvas.getContext('2d', contextOptions);
   if (!ctx) return;
 
   ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;

--- a/src/utils/image-metadata.ts
+++ b/src/utils/image-metadata.ts
@@ -1,3 +1,5 @@
+import { isWideGamut } from '../engine/color-space';
+
 const crcTable = new Uint32Array(256);
 for (let n = 0; n < 256; n++) {
   let c = n;
@@ -51,6 +53,84 @@ function createPngSrgbChunk(): Uint8Array {
   return chunk;
 }
 
+/** Create a PNG iCCP chunk embedding a compressed ICC profile. */
+function createPngIccpChunk(profileName: string, iccProfile: Uint8Array): Uint8Array {
+  const enc = new TextEncoder();
+  const nameBytes = enc.encode(profileName);
+  // iCCP payload: profile name (null terminated) + compression method (0 = deflate) + compressed data
+  // Use uncompressed deflate (stored blocks) since we don't have zlib here
+  const compressed = deflateStored(iccProfile);
+  const payloadLen = nameBytes.length + 1 + 1 + compressed.length;
+
+  const typeAndPayload = new Uint8Array(4 + payloadLen);
+  typeAndPayload.set(enc.encode('iCCP'), 0);
+  let off = 4;
+  typeAndPayload.set(nameBytes, off);
+  off += nameBytes.length;
+  typeAndPayload[off++] = 0; // null terminator
+  typeAndPayload[off++] = 0; // compression method: deflate
+  typeAndPayload.set(compressed, off);
+
+  const chunk = new Uint8Array(4 + typeAndPayload.length + 4);
+  const view = new DataView(chunk.buffer);
+  view.setUint32(0, payloadLen);
+  chunk.set(typeAndPayload, 4);
+  view.setUint32(chunk.length - 4, crc32(typeAndPayload));
+  return chunk;
+}
+
+/** Wrap data in a valid deflate stream using stored (uncompressed) blocks. */
+function deflateStored(data: Uint8Array): Uint8Array {
+  // Zlib header (CM=8, CINFO=7, FCHECK for valid header)
+  const zlibHeader = new Uint8Array([0x78, 0x01]);
+  // Split into stored blocks of up to 65535 bytes
+  const maxBlock = 65535;
+  const blockCount = Math.ceil(data.length / maxBlock) || 1;
+  const blockHeaderSize = 5; // BFINAL/BTYPE + LEN + NLEN
+  const deflateSize = blockCount * blockHeaderSize + data.length;
+  const out = new Uint8Array(zlibHeader.length + deflateSize + 4); // +4 for Adler-32
+  out.set(zlibHeader, 0);
+  let pos = zlibHeader.length;
+  let remaining = data.length;
+  let srcOff = 0;
+
+  for (let i = 0; i < blockCount; i++) {
+    const isLast = i === blockCount - 1;
+    const len = Math.min(remaining, maxBlock);
+    out[pos++] = isLast ? 0x01 : 0x00; // BFINAL=1 for last, BTYPE=00 (stored)
+    out[pos++] = len & 0xff;
+    out[pos++] = (len >> 8) & 0xff;
+    out[pos++] = ~len & 0xff;
+    out[pos++] = (~len >> 8) & 0xff;
+    out.set(data.subarray(srcOff, srcOff + len), pos);
+    pos += len;
+    srcOff += len;
+    remaining -= len;
+  }
+
+  // Adler-32 checksum
+  let a = 1, b = 0;
+  for (let i = 0; i < data.length; i++) {
+    a = (a + data[i]!) % 65521;
+    b = (b + a) % 65521;
+  }
+  const adler = ((b << 16) | a) >>> 0;
+  out[pos++] = (adler >> 24) & 0xff;
+  out[pos++] = (adler >> 16) & 0xff;
+  out[pos++] = (adler >> 8) & 0xff;
+  out[pos++] = adler & 0xff;
+
+  return out.subarray(0, pos);
+}
+
+/** Create the PNG color profile chunk appropriate for the active color space. */
+function createPngColorChunk(): Uint8Array {
+  if (isWideGamut()) {
+    return createPngIccpChunk('Display P3', displayP3IccProfile);
+  }
+  return createPngSrgbChunk();
+}
+
 function findIhdrEnd(): number {
   // PNG signature is 8 bytes, IHDR chunk follows: 4 (length) + 4 (type) + 13 (data) + 4 (crc) = 25
   return 8 + 25;
@@ -62,11 +142,10 @@ export async function addPngMetadata(
 ): Promise<Blob> {
   const data = new Uint8Array(await blob.arrayBuffer());
 
-  // Insert sRGB chunk right after IHDR (before IDAT)
-  const srgbChunk = createPngSrgbChunk();
+  const colorChunk = createPngColorChunk();
 
   const chunks = Object.entries(entries).map(([k, v]) => createPngTextChunk(k, v));
-  const extra = srgbChunk.length + chunks.reduce((s, c) => s + c.length, 0);
+  const extra = colorChunk.length + chunks.reduce((s, c) => s + c.length, 0);
   const ihdrEnd = findIhdrEnd();
   const iend = data.length - 12;
   const result = new Uint8Array(data.length + extra);
@@ -75,9 +154,9 @@ export async function addPngMetadata(
   result.set(data.subarray(0, ihdrEnd), 0);
   let offset = ihdrEnd;
 
-  // sRGB chunk must come before IDAT
-  result.set(srgbChunk, offset);
-  offset += srgbChunk.length;
+  // Color profile chunk must come before IDAT
+  result.set(colorChunk, offset);
+  offset += colorChunk.length;
 
   // Copy everything between IHDR end and IEND
   result.set(data.subarray(ihdrEnd, iend), offset);
@@ -94,10 +173,7 @@ export async function addPngMetadata(
   return new Blob([result], { type: 'image/png' });
 }
 
-function buildMinimalSrgbIcc(): Uint8Array {
-  // Minimal ICC profile declaring sRGB color space
-  // Based on the ICC v2 specification for a minimal monitor RGB profile
-  const desc = 'sRGB';
+function buildMinimalIcc(desc: string): Uint8Array {
   const enc = new TextEncoder();
   const descBytes = enc.encode(desc);
 
@@ -209,7 +285,12 @@ function createJpegIccMarker(iccProfile: Uint8Array): Uint8Array {
   return marker;
 }
 
-const srgbIccProfile = buildMinimalSrgbIcc();
+const srgbIccProfile = buildMinimalIcc('sRGB');
+const displayP3IccProfile = buildMinimalIcc('Display P3');
+
+function getActiveIccProfile(): Uint8Array {
+  return isWideGamut() ? displayP3IccProfile : srgbIccProfile;
+}
 
 export async function addJpegComment(blob: Blob, comment: string): Promise<Blob> {
   const data = new Uint8Array(await blob.arrayBuffer());
@@ -225,7 +306,7 @@ export async function addJpegComment(blob: Blob, comment: string): Promise<Blob>
   commentMarker.set(bytes, 4);
 
   // Build ICC profile marker
-  const iccMarker = createJpegIccMarker(srgbIccProfile);
+  const iccMarker = createJpegIccMarker(getActiveIccProfile());
 
   // Insert both after SOI (first 2 bytes)
   const result = new Uint8Array(data.length + commentMarker.length + iccMarker.length);


### PR DESCRIPTION
## Summary
- Add Display P3 wide-gamut color support with automatic detection and sRGB fallback
- Add bitmap cache for color-correct rendering, avoiding putImageData color-management rounding
- Embed appropriate ICC profiles (sRGB or Display P3) in PNG/JPEG exports
- Display active color space in status bar
- Previous commits on this branch include: image adjustments panel, slider improvements, snap/grid defaults, favicon, viewport fitting, rotation fixes, color overlay effects, UI cleanup, shape tool overhaul, and many more foundational features

## Test plan
- [ ] Verify Display P3 is detected on wide-gamut displays (check status bar label)
- [ ] Verify sRGB fallback on non-P3 displays
- [ ] Export PNG and JPEG, confirm ICC profile is embedded (use `exiftool` or similar)
- [ ] Open an image with saturated colors, verify no color shifting during editing
- [ ] Check rendering performance is maintained with bitmap cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)