### PR TITLE
Add canvas guides and layer blend modes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -74,6 +74,13 @@ export function App() {
   const pendingShapeClick = useUIStore((s) => s.pendingShapeClick);
   const setPendingShapeClick = useUIStore((s) => s.setPendingShapeClick);
 
+  const showRulers = useUIStore((s) => s.showRulers);
+  const showGuides = useUIStore((s) => s.showGuides);
+  const guides = useUIStore((s) => s.guides);
+  const addGuide = useUIStore((s) => s.addGuide);
+  const setHoveredGuide = useUIStore((s) => s.setHoveredGuide);
+  const setRulerHover = useUIStore((s) => s.setRulerHover);
+
   const [isPanning, setIsPanning] = useState(false);
   const [isSpaceDown, setIsSpaceDown] = useState(false);
   const panStartRef = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
@@ -218,6 +225,20 @@ export function App() {
     });
   }, []);
 
+  const RULER_SIZE = 20;
+
+  // Find a guide whose position matches the cursor's document-space coordinate
+  const findGuideAtCursor = useCallback(
+    (docX: number, docY: number): string | null => {
+      for (const guide of guides) {
+        if (guide.orientation === 'vertical' && guide.position === docX) return guide.id;
+        if (guide.orientation === 'horizontal' && guide.position === docY) return guide.id;
+      }
+      return null;
+    },
+    [guides],
+  );
+
   // Mouse handlers
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
@@ -229,6 +250,37 @@ export function App() {
       const canvasPos = screenToCanvas(screenX, screenY);
       flushCursorPosition(canvasPos);
 
+      // Ruler hover for guide placement
+      // Guide hover detection — always runs so playhead updates
+      if (showGuides && !isPanning) {
+        setHoveredGuide(findGuideAtCursor(canvasPos.x, canvasPos.y));
+      }
+
+      if (showRulers && showGuides && !isPanning) {
+        const isOnHorizontalRuler = screenY < RULER_SIZE && screenX > RULER_SIZE;
+        const isOnVerticalRuler = screenX < RULER_SIZE && screenY > RULER_SIZE;
+
+        if (isOnHorizontalRuler) {
+          setRulerHover({
+            orientation: 'vertical',
+            position: canvasPos.x,
+            screenX,
+            screenY,
+          });
+          return;
+        } else if (isOnVerticalRuler) {
+          setRulerHover({
+            orientation: 'horizontal',
+            position: canvasPos.y,
+            screenX,
+            screenY,
+          });
+          return;
+        } else {
+          setRulerHover(null);
+        }
+      }
+
       if (isPanning) {
         const dx = e.clientX - panStartRef.current.x;
         const dy = e.clientY - panStartRef.current.y;
@@ -238,7 +290,7 @@ export function App() {
         handleToolMove(e);
       }
     },
-    [isPanning, screenToCanvas, setPan, handleToolMove, updateHoveredHandle, flushCursorPosition],
+    [isPanning, screenToCanvas, setPan, handleToolMove, updateHoveredHandle, flushCursorPosition, showRulers, showGuides, setRulerHover, setHoveredGuide, findGuideAtCursor],
   );
 
   const handleMouseDown = useCallback(
@@ -252,17 +304,49 @@ export function App() {
           panY: viewport.panY,
         };
         e.preventDefault();
-      } else {
-        handleToolDown(e);
+        return;
       }
+
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (rect && showRulers && showGuides && e.button === 0) {
+        const screenX = e.clientX - rect.left;
+        const screenY = e.clientY - rect.top;
+        const isOnHorizontalRuler = screenY < RULER_SIZE && screenX > RULER_SIZE;
+        const isOnVerticalRuler = screenX < RULER_SIZE && screenY > RULER_SIZE;
+
+        const canvasPos = screenToCanvas(screenX, screenY);
+
+        // Clicking on the ruler at an existing guide's position removes it
+        if (isOnHorizontalRuler || isOnVerticalRuler) {
+          const guideId = findGuideAtCursor(canvasPos.x, canvasPos.y);
+          if (guideId) {
+            useUIStore.getState().removeGuide(guideId);
+          } else if (isOnHorizontalRuler) {
+            addGuide('vertical', canvasPos.x);
+          } else {
+            addGuide('horizontal', canvasPos.y);
+          }
+          setRulerHover(null);
+          return;
+        }
+      }
+
+      handleToolDown(e);
     },
-    [isSpaceDown, viewport.panX, viewport.panY, handleToolDown],
+    [isSpaceDown, viewport.panX, viewport.panY, handleToolDown, showRulers, showGuides, screenToCanvas, addGuide, setRulerHover, findGuideAtCursor],
   );
 
   const handleMouseUp = useCallback((e: React.MouseEvent) => {
     setIsPanning(false);
     handleToolUp(e);
   }, [handleToolUp]);
+
+  const handleMouseLeave = useCallback((e: React.MouseEvent) => {
+    setIsPanning(false);
+    handleToolUp(e);
+    setRulerHover(null);
+    setHoveredGuide(null);
+  }, [handleToolUp, setRulerHover, setHoveredGuide]);
 
   const handleWheel = useCallback(
     (e: React.WheelEvent) => {
@@ -295,7 +379,7 @@ export function App() {
     if (!parentRect) return;
     const top = bottomRect.top - parentRect.top;
     drawer.style.top = `${top}px`;
-    drawer.style.bottom = '0';
+    drawer.style.height = `${bottom.offsetHeight}px`;
   }, [showEffectsDrawer, colorPanelCollapsed]);
 
   const showModal = !documentReady || showNewDocumentModal;
@@ -339,90 +423,92 @@ export function App() {
           onMouseMove={handleMouseMove}
           onMouseDown={handleMouseDown}
           onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseUp}
+          onMouseLeave={handleMouseLeave}
           onWheel={handleWheel}
         >
           <canvas ref={canvasRef} />
           <canvas ref={overlayCanvasRef} className={styles.overlayCanvas} />
           <CanvasRenderer canvasRef={canvasRef} containerRef={containerRef} overlayCanvasRef={overlayCanvasRef} />
         </div>
-        {(visiblePanels.size > 0 || showEffectsDrawer) && <div className={styles.sidebarArea}>
+        <div className={styles.sidebarArea}>
           {showEffectsDrawer && (
             <div className={styles.effectsDrawer} ref={effectsDrawerRef}>
               <LayerEffectsPanel />
             </div>
           )}
-          <div className={styles.sidebar}>
-            <div className={styles.sidebarScroll}>
-              {visiblePanels.has('info') && (
-                <PanelContainer
-                  title="Info"
-                  collapsed={infoPanelCollapsed}
-                  onToggle={() => setInfoPanelCollapsed(!infoPanelCollapsed)}
-                >
-                  <InfoPanel collapsed={infoPanelCollapsed} />
-                </PanelContainer>
-              )}
-              {visiblePanels.has('color') && (
-                <PanelContainer
-                  title="Color"
-                  collapsed={colorPanelCollapsed}
-                  onToggle={() => setColorPanelCollapsed(!colorPanelCollapsed)}
-                >
-                  <ColorPanel
-                    foregroundColor={foregroundColor}
-                    backgroundColor={backgroundColor}
-                    recentColors={recentColors}
-                    onForegroundChange={setForegroundColor}
-                    onBackgroundChange={setBackgroundColor}
-                    onSwap={swapColors}
+          {visiblePanels.size > 0 && (
+            <div className={styles.sidebar}>
+              <div className={styles.sidebarScroll}>
+                {visiblePanels.has('info') && (
+                  <PanelContainer
+                    title="Info"
+                    collapsed={infoPanelCollapsed}
+                    onToggle={() => setInfoPanelCollapsed(!infoPanelCollapsed)}
+                  >
+                    <InfoPanel collapsed={infoPanelCollapsed} />
+                  </PanelContainer>
+                )}
+                {visiblePanels.has('color') && (
+                  <PanelContainer
+                    title="Color"
                     collapsed={colorPanelCollapsed}
-                  />
-                </PanelContainer>
-              )}
-              {visiblePanels.has('history') && (
-                <PanelContainer
-                  title="History"
-                  collapsed={historyPanelCollapsed}
-                  onToggle={() => setHistoryPanelCollapsed(!historyPanelCollapsed)}
-                >
-                  <HistoryPanel collapsed={historyPanelCollapsed} />
-                </PanelContainer>
-              )}
-              {visiblePanels.has('adjustments') && (
-                <PanelContainer
-                  title="Adjustments"
-                  collapsed={adjustmentsPanelCollapsed}
-                  onToggle={() => setAdjustmentsPanelCollapsed(!adjustmentsPanelCollapsed)}
-                >
-                  {!adjustmentsPanelCollapsed && <AdjustmentsPanel />}
-                </PanelContainer>
-              )}
-            </div>
-            <div className={styles.sidebarBottom} ref={sidebarBottomRef}>
-              {visiblePanels.has('layers') && (
-                <PanelContainer
-                  title="Layers"
-                  collapsed={layersPanelCollapsed}
-                  onToggle={() => setLayersPanelCollapsed(!layersPanelCollapsed)}
-                >
-                  <LayerPanel
-                    layers={[...layers]}
-                    activeLayerId={activeLayerId}
-                    onSelectLayer={handleSelectLayer}
-                    onToggleVisibility={toggleLayerVisibility}
-                    onAddLayer={addLayer}
-                    onRemoveLayer={removeLayer}
-                    onReorderLayer={moveLayer}
-                    onUpdateOpacity={updateLayerOpacity}
+                    onToggle={() => setColorPanelCollapsed(!colorPanelCollapsed)}
+                  >
+                    <ColorPanel
+                      foregroundColor={foregroundColor}
+                      backgroundColor={backgroundColor}
+                      recentColors={recentColors}
+                      onForegroundChange={setForegroundColor}
+                      onBackgroundChange={setBackgroundColor}
+                      onSwap={swapColors}
+                      collapsed={colorPanelCollapsed}
+                    />
+                  </PanelContainer>
+                )}
+                {visiblePanels.has('history') && (
+                  <PanelContainer
+                    title="History"
+                    collapsed={historyPanelCollapsed}
+                    onToggle={() => setHistoryPanelCollapsed(!historyPanelCollapsed)}
+                  >
+                    <HistoryPanel collapsed={historyPanelCollapsed} />
+                  </PanelContainer>
+                )}
+                {visiblePanels.has('adjustments') && (
+                  <PanelContainer
+                    title="Adjustments"
+                    collapsed={adjustmentsPanelCollapsed}
+                    onToggle={() => setAdjustmentsPanelCollapsed(!adjustmentsPanelCollapsed)}
+                  >
+                    {!adjustmentsPanelCollapsed && <AdjustmentsPanel />}
+                  </PanelContainer>
+                )}
+              </div>
+              <div className={styles.sidebarBottom} ref={sidebarBottomRef}>
+                {visiblePanels.has('layers') && (
+                  <PanelContainer
+                    title="Layers"
                     collapsed={layersPanelCollapsed}
-                  />
-                </PanelContainer>
-              )}
+                    onToggle={() => setLayersPanelCollapsed(!layersPanelCollapsed)}
+                  >
+                    <LayerPanel
+                      layers={[...layers]}
+                      activeLayerId={activeLayerId}
+                      onSelectLayer={handleSelectLayer}
+                      onToggleVisibility={toggleLayerVisibility}
+                      onAddLayer={addLayer}
+                      onRemoveLayer={removeLayer}
+                      onReorderLayer={moveLayer}
+                      onUpdateOpacity={updateLayerOpacity}
+                      collapsed={layersPanelCollapsed}
+                    />
+                  </PanelContainer>
+                )}
+              </div>
             </div>
-          </div>
+          )}
           <PanelToolbar />
-        </div>}
+        </div>
       </div>
       <StatusBar />
     </div>

--- a/src/app/rendering/render-guides.ts
+++ b/src/app/rendering/render-guides.ts
@@ -1,0 +1,184 @@
+import type { Guide, RulerHover } from '../ui-store';
+
+const RULER_SIZE = 20;
+const GUIDE_COLOR = 'rgba(0, 180, 255, 0.7)';
+const GUIDE_ACTIVE_COLOR = 'rgba(0, 220, 255, 1)';
+const PLAYHEAD_HOVER_COLOR = 'rgba(255, 255, 255, 0.9)';
+const PLAYHEAD_SELECTED_COLOR = 'rgba(255, 255, 255, 1)';
+const PLAYHEAD_COLOR = 'rgba(0, 180, 255, 0.9)';
+const TOOLTIP_BG = 'rgba(0, 0, 0, 0.8)';
+const TOOLTIP_TEXT = '#ffffff';
+const PLAYHEAD_SIZE = 6;
+
+/**
+ * Render guide lines on the canvas in document-space.
+ * Called inside the document-space transform.
+ */
+export function renderGuides(
+  ctx: CanvasRenderingContext2D,
+  guides: readonly Guide[],
+  selectedGuideId: string | null,
+  docWidth: number,
+  docHeight: number,
+  zoom: number,
+): void {
+  for (const guide of guides) {
+    const isSelected = guide.id === selectedGuideId;
+    ctx.strokeStyle = isSelected ? GUIDE_ACTIVE_COLOR : GUIDE_COLOR;
+    ctx.lineWidth = 1 / zoom;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    if (guide.orientation === 'vertical') {
+      ctx.moveTo(guide.position, 0);
+      ctx.lineTo(guide.position, docHeight);
+    } else {
+      ctx.moveTo(0, guide.position);
+      ctx.lineTo(docWidth, guide.position);
+    }
+    ctx.stroke();
+  }
+}
+
+/**
+ * Render a preview guide line when hovering over the ruler.
+ * Called inside the document-space transform.
+ */
+export function renderGuidePreview(
+  ctx: CanvasRenderingContext2D,
+  rulerHover: RulerHover,
+  docWidth: number,
+  docHeight: number,
+  zoom: number,
+): void {
+  ctx.strokeStyle = PLAYHEAD_COLOR;
+  ctx.lineWidth = 1 / zoom;
+  ctx.setLineDash([4 / zoom, 4 / zoom]);
+  ctx.beginPath();
+  if (rulerHover.orientation === 'vertical') {
+    ctx.moveTo(rulerHover.position, 0);
+    ctx.lineTo(rulerHover.position, docHeight);
+  } else {
+    ctx.moveTo(0, rulerHover.position);
+    ctx.lineTo(docWidth, rulerHover.position);
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
+}
+
+/**
+ * Render playhead indicators on the rulers and tooltip for hover state.
+ * Called in screen-space (after the document transform is restored).
+ */
+export function renderGuideRulerOverlays(
+  ctx: CanvasRenderingContext2D,
+  guides: readonly Guide[],
+  selectedGuideId: string | null,
+  hoveredGuideId: string | null,
+  rulerHover: RulerHover | null,
+  canvasWidth: number,
+  canvasHeight: number,
+  viewport: { panX: number; panY: number; zoom: number },
+  docWidth: number,
+  docHeight: number,
+): void {
+  const { panX, panY, zoom } = viewport;
+  const originX = panX + canvasWidth / 2 - (docWidth / 2) * zoom;
+  const originY = panY + canvasHeight / 2 - (docHeight / 2) * zoom;
+
+  // Draw playhead triangles on rulers for placed guides
+  for (const guide of guides) {
+    const isSelected = guide.id === selectedGuideId;
+    const isHovered = guide.id === hoveredGuideId;
+    ctx.fillStyle = isSelected ? PLAYHEAD_SELECTED_COLOR : isHovered ? PLAYHEAD_HOVER_COLOR : GUIDE_COLOR;
+
+    if (guide.orientation === 'vertical') {
+      const screenX = originX + guide.position * zoom;
+      if (screenX < RULER_SIZE || screenX > canvasWidth) continue;
+      // Triangle pointing down on horizontal ruler
+      ctx.beginPath();
+      ctx.moveTo(screenX, RULER_SIZE);
+      ctx.lineTo(screenX - PLAYHEAD_SIZE, RULER_SIZE - PLAYHEAD_SIZE * 1.5);
+      ctx.lineTo(screenX + PLAYHEAD_SIZE, RULER_SIZE - PLAYHEAD_SIZE * 1.5);
+      ctx.closePath();
+      ctx.fill();
+    } else {
+      const screenY = originY + guide.position * zoom;
+      if (screenY < RULER_SIZE || screenY > canvasHeight) continue;
+      // Triangle pointing right on vertical ruler
+      ctx.beginPath();
+      ctx.moveTo(RULER_SIZE, screenY);
+      ctx.lineTo(RULER_SIZE - PLAYHEAD_SIZE * 1.5, screenY - PLAYHEAD_SIZE);
+      ctx.lineTo(RULER_SIZE - PLAYHEAD_SIZE * 1.5, screenY + PLAYHEAD_SIZE);
+      ctx.closePath();
+      ctx.fill();
+    }
+  }
+
+  // Draw hover playhead + tooltip (skip if hovering an existing guide)
+  if (rulerHover && !hoveredGuideId) {
+    ctx.fillStyle = PLAYHEAD_COLOR;
+
+    if (rulerHover.orientation === 'vertical') {
+      const screenX = originX + rulerHover.position * zoom;
+      if (screenX >= RULER_SIZE && screenX <= canvasWidth) {
+        // Playhead triangle
+        ctx.beginPath();
+        ctx.moveTo(screenX, RULER_SIZE);
+        ctx.lineTo(screenX - PLAYHEAD_SIZE, RULER_SIZE - PLAYHEAD_SIZE * 1.5);
+        ctx.lineTo(screenX + PLAYHEAD_SIZE, RULER_SIZE - PLAYHEAD_SIZE * 1.5);
+        ctx.closePath();
+        ctx.fill();
+
+        // Tooltip
+        drawTooltip(ctx, Math.round(rulerHover.position).toString(), screenX, RULER_SIZE + 4, canvasWidth, canvasHeight);
+      }
+    } else {
+      const screenY = originY + rulerHover.position * zoom;
+      if (screenY >= RULER_SIZE && screenY <= canvasHeight) {
+        // Playhead triangle
+        ctx.beginPath();
+        ctx.moveTo(RULER_SIZE, screenY);
+        ctx.lineTo(RULER_SIZE - PLAYHEAD_SIZE * 1.5, screenY - PLAYHEAD_SIZE);
+        ctx.lineTo(RULER_SIZE - PLAYHEAD_SIZE * 1.5, screenY + PLAYHEAD_SIZE);
+        ctx.closePath();
+        ctx.fill();
+
+        // Tooltip
+        drawTooltip(ctx, Math.round(rulerHover.position).toString(), RULER_SIZE + 4, screenY, canvasWidth, canvasHeight);
+      }
+    }
+  }
+}
+
+function drawTooltip(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  canvasWidth: number,
+  canvasHeight: number,
+): void {
+  ctx.save();
+  ctx.font = '11px Inter, sans-serif';
+  const metrics = ctx.measureText(text);
+  const padding = 4;
+  const tooltipW = metrics.width + padding * 2;
+  const tooltipH = 16;
+
+  // Keep tooltip on screen
+  let tx = x;
+  let ty = y;
+  if (tx + tooltipW > canvasWidth) tx = canvasWidth - tooltipW;
+  if (ty + tooltipH > canvasHeight) ty = canvasHeight - tooltipH;
+
+  ctx.fillStyle = TOOLTIP_BG;
+  ctx.beginPath();
+  ctx.roundRect(tx, ty, tooltipW, tooltipH, 3);
+  ctx.fill();
+
+  ctx.fillStyle = TOOLTIP_TEXT;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, tx + padding, ty + tooltipH / 2);
+  ctx.restore();
+}

--- a/src/app/store/actions/layer-property-updates.test.ts
+++ b/src/app/store/actions/layer-property-updates.test.ts
@@ -5,6 +5,7 @@ import {
   computeSetActiveLayer,
   computeToggleVisibility,
   computeUpdateOpacity,
+  computeUpdateBlendMode,
   computeUpdatePosition,
   computeUpdateEffects,
   computeToggleMask,
@@ -80,6 +81,16 @@ describe('computeUpdateOpacity', () => {
     const result = computeUpdateOpacity(doc, layerId, 0.5);
     const layer = result.document!.layers.find((l) => l.id === layerId)!;
     expect(layer.opacity).toBe(0.5);
+  });
+});
+
+describe('computeUpdateBlendMode', () => {
+  it('sets blend mode', () => {
+    const doc = makeDoc();
+    const layerId = doc.layers[0]!.id;
+    const result = computeUpdateBlendMode(doc, layerId, 'multiply');
+    const layer = result.document!.layers.find((l) => l.id === layerId)!;
+    expect(layer.blendMode).toBe('multiply');
   });
 });
 

--- a/src/app/store/actions/layer-property-updates.ts
+++ b/src/app/store/actions/layer-property-updates.ts
@@ -1,4 +1,4 @@
-import type { DocumentState, Layer, LayerEffects } from '../../../types';
+import type { BlendMode, DocumentState, Layer, LayerEffects } from '../../../types';
 import type { EditorState } from '../types';
 
 export function computeSetActiveLayer(
@@ -34,6 +34,21 @@ export function computeUpdateOpacity(
       ...doc,
       layers: doc.layers.map((l) =>
         l.id === id ? ({ ...l, opacity } as Layer) : l,
+      ),
+    },
+  };
+}
+
+export function computeUpdateBlendMode(
+  doc: DocumentState,
+  id: string,
+  blendMode: BlendMode,
+): Partial<EditorState> {
+  return {
+    document: {
+      ...doc,
+      layers: doc.layers.map((l) =>
+        l.id === id ? ({ ...l, blendMode } as Layer) : l,
       ),
     },
   };

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -1,4 +1,4 @@
-import type { LayerEffects, Layer, Rect } from '../../types';
+import type { BlendMode, LayerEffects, Layer, Rect } from '../../types';
 import type { AlignEdge } from '../../tools/move/move';
 import { createRasterLayer } from '../../layers/layer-model';
 import { sparseToImageData } from '../../engine/canvas-ops';
@@ -7,6 +7,7 @@ import { getEngine } from '../../engine-wasm/engine-state';
 import { uploadLayerPixels } from '../../engine-wasm/wasm-bridge';
 import { invalidateBitmapCache } from '../../engine/bitmap-cache';
 import type { SliceCreator, SparseLayerEntry } from './types';
+import { useUIStore } from '../ui-store';
 
 import { computeCreateDocument } from './actions/create-document';
 import { computeOpenImage } from './actions/open-image';
@@ -27,6 +28,7 @@ import {
   computeSetActiveLayer,
   computeToggleVisibility,
   computeUpdateOpacity,
+  computeUpdateBlendMode,
   computeUpdatePosition,
   computeUpdateEffects,
   computeToggleMask,
@@ -104,6 +106,7 @@ export interface DocumentSlice {
   setActiveLayer: (id: string) => void;
   toggleLayerVisibility: (id: string) => void;
   updateLayerOpacity: (id: string, opacity: number) => void;
+  updateLayerBlendMode: (id: string, blendMode: BlendMode) => void;
   moveLayer: (fromIndex: number, toIndex: number) => void;
   updateLayerPosition: (id: string, x: number, y: number) => void;
   alignLayer: (edge: AlignEdge) => void;
@@ -131,6 +134,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     if (result.layerPixelData && result.document) {
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);
     }
+    useUIStore.getState().clearGuides();
   },
 
   openImageAsDocument: (imageData, name) => {
@@ -139,6 +143,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     if (result.layerPixelData && result.document) {
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);
     }
+    useUIStore.getState().clearGuides();
   },
 
   addLayer: () => {
@@ -168,6 +173,10 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
 
   updateLayerOpacity: (id, opacity) => {
     set(computeUpdateOpacity(get().document, id, opacity));
+  },
+
+  updateLayerBlendMode: (id, blendMode) => {
+    set(computeUpdateBlendMode(get().document, id, blendMode));
   },
 
   moveLayer: (fromIndex, toIndex) => {

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from 'zustand';
-import type { DocumentState, LayerEffects, Rect, ViewportState } from '../../types';
+import type { BlendMode, DocumentState, LayerEffects, Rect, ViewportState } from '../../types';
 import type { AlignEdge } from '../../tools/move/move';
 
 export interface SelectionData {
@@ -69,6 +69,7 @@ export interface EditorState {
   setActiveLayer: (id: string) => void;
   toggleLayerVisibility: (id: string) => void;
   updateLayerOpacity: (id: string, opacity: number) => void;
+  updateLayerBlendMode: (id: string, blendMode: BlendMode) => void;
   moveLayer: (fromIndex: number, toIndex: number) => void;
   updateLayerPosition: (id: string, x: number, y: number) => void;
   alignLayer: (edge: AlignEdge) => void;

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -11,6 +11,19 @@ export interface PathAnchor {
   handleOut: Point | null;
 }
 
+export interface Guide {
+  id: string;
+  orientation: 'horizontal' | 'vertical';
+  position: number;
+}
+
+export interface RulerHover {
+  orientation: 'horizontal' | 'vertical';
+  position: number;
+  screenX: number;
+  screenY: number;
+}
+
 const MAX_RECENT_COLORS = 20;
 
 function colorsEqual(a: Color, b: Color): boolean {
@@ -73,6 +86,16 @@ interface UIState {
   adjustmentsEnabled: boolean;
   setAdjustments: (adj: ImageAdjustments) => void;
   setAdjustmentsEnabled: (enabled: boolean) => void;
+  guides: Guide[];
+  selectedGuideId: string | null;
+  hoveredGuideId: string | null;
+  rulerHover: RulerHover | null;
+  addGuide: (orientation: 'horizontal' | 'vertical', position: number) => void;
+  removeGuide: (id: string) => void;
+  selectGuide: (id: string | null) => void;
+  setHoveredGuide: (id: string | null) => void;
+  setRulerHover: (hover: RulerHover | null) => void;
+  clearGuides: () => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -175,4 +198,21 @@ export const useUIStore = create<UIState>((set) => ({
   setCropRect: (rect) => set({ cropRect: rect }),
   setTransform: (transform) => set({ transform }),
   setActiveTransformHandle: (handle) => set({ activeTransformHandle: handle }),
+  guides: [],
+  selectedGuideId: null,
+  hoveredGuideId: null,
+  rulerHover: null,
+  addGuide: (orientation, position) =>
+    set((state) => ({
+      guides: [...state.guides, { id: crypto.randomUUID(), orientation, position }],
+    })),
+  removeGuide: (id) =>
+    set((state) => ({
+      guides: state.guides.filter((g) => g.id !== id),
+      selectedGuideId: state.selectedGuideId === id ? null : state.selectedGuideId,
+    })),
+  selectGuide: (id) => set({ selectedGuideId: id }),
+  setHoveredGuide: (id) => set({ hoveredGuideId: id }),
+  setRulerHover: (hover) => set({ rulerHover: hover }),
+  clearGuides: () => set({ guides: [], selectedGuideId: null }),
 }));

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -21,6 +21,7 @@ import {
 import { renderGrid, renderRulers } from './rendering/render-grid';
 import { renderSelectionAnts, renderTransformHandles } from './rendering/render-selection';
 import { renderPathOverlay, renderLassoPreview, renderCropPreview, renderGradientPreview, renderBrushCursor } from './rendering/render-overlays';
+import { renderGuides, renderGuidePreview, renderGuideRulerOverlays } from './rendering/render-guides';
 import { contextOptions } from '../engine/color-space';
 import { clearFrameCache } from '../engine-wasm/gpu-pixel-access';
 import { getActiveMaskEditBuffer } from './interactions/mask-buffer';
@@ -73,6 +74,11 @@ function renderFrameGpu(
   const cropRect = uiState.cropRect;
   const transform = uiState.transform;
   const gradientPreview = uiState.gradientPreview;
+  const showGuides = uiState.showGuides;
+  const guides = uiState.guides;
+  const selectedGuideId = uiState.selectedGuideId;
+  const hoveredGuideId = uiState.hoveredGuideId;
+  const rulerHover = uiState.rulerHover;
 
   syncDocumentSize(engine, doc.width, doc.height);
   syncBackgroundColor(engine, doc.backgroundColor.r, doc.backgroundColor.g, doc.backgroundColor.b, doc.backgroundColor.a);
@@ -130,10 +136,20 @@ function renderFrameGpu(
       renderBrushCursor(overlayCtx, cursorPosition, size, viewport.zoom, brushCursorInfo.shape);
     }
 
+    if (showGuides) {
+      renderGuides(overlayCtx, guides, selectedGuideId, doc.width, doc.height, viewport.zoom);
+      if (rulerHover && !hoveredGuideId) {
+        renderGuidePreview(overlayCtx, rulerHover, doc.width, doc.height, viewport.zoom);
+      }
+    }
+
     overlayCtx.restore();
 
     if (showRulers) {
       renderRulers(overlayCtx, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height, cursorPosition);
+      if (showGuides) {
+        renderGuideRulerOverlays(overlayCtx, guides, selectedGuideId, hoveredGuideId, rulerHover, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height);
+      }
     }
   }
 }

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
@@ -24,6 +24,37 @@
   color: var(--color-text-secondary);
 }
 
+.blendModeRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.blendModeSelect {
+  flex: 1;
+  height: 24px;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+  cursor: pointer;
+  outline: none;
+}
+
+.blendModeSelect:hover {
+  border-color: var(--color-border-strong);
+}
+
+.blendModeSelect:focus {
+  border-color: var(--color-accent);
+}
+
 .split {
   display: flex;
   flex: 1;

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -3,7 +3,7 @@ import { X } from 'lucide-react';
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
 import { IconButton } from '../../components/IconButton/IconButton';
-import type { LayerEffects } from '../../types';
+import type { BlendMode, LayerEffects } from '../../types';
 import { DropShadowForm } from './DropShadowForm';
 import { StrokeForm } from './StrokeForm';
 import { GlowForm } from './GlowForm';
@@ -11,6 +11,53 @@ import { ColorOverlayForm } from './ColorOverlayForm';
 import styles from './LayerEffectsPanel.module.css';
 
 type EffectKey = 'dropShadow' | 'stroke' | 'outerGlow' | 'innerGlow' | 'colorOverlay';
+
+const BLEND_MODE_GROUPS: { label: string; modes: { value: BlendMode; label: string }[] }[] = [
+  {
+    label: 'Normal',
+    modes: [{ value: 'normal', label: 'Normal' }],
+  },
+  {
+    label: 'Darken',
+    modes: [
+      { value: 'darken', label: 'Darken' },
+      { value: 'multiply', label: 'Multiply' },
+      { value: 'color-burn', label: 'Color Burn' },
+    ],
+  },
+  {
+    label: 'Lighten',
+    modes: [
+      { value: 'lighten', label: 'Lighten' },
+      { value: 'screen', label: 'Screen' },
+      { value: 'color-dodge', label: 'Color Dodge' },
+    ],
+  },
+  {
+    label: 'Contrast',
+    modes: [
+      { value: 'overlay', label: 'Overlay' },
+      { value: 'soft-light', label: 'Soft Light' },
+      { value: 'hard-light', label: 'Hard Light' },
+    ],
+  },
+  {
+    label: 'Comparative',
+    modes: [
+      { value: 'difference', label: 'Difference' },
+      { value: 'exclusion', label: 'Exclusion' },
+    ],
+  },
+  {
+    label: 'Composite',
+    modes: [
+      { value: 'hue', label: 'Hue' },
+      { value: 'saturation', label: 'Saturation' },
+      { value: 'color', label: 'Color' },
+      { value: 'luminosity', label: 'Luminosity' },
+    ],
+  },
+];
 
 const EFFECT_LIST: { key: EffectKey; label: string }[] = [
   { key: 'dropShadow', label: 'Drop Shadow' },
@@ -24,6 +71,7 @@ export function LayerEffectsPanel() {
   const activeLayerId = useEditorStore((s) => s.document.activeLayerId);
   const layers = useEditorStore((s) => s.document.layers);
   const updateLayerEffects = useEditorStore((s) => s.updateLayerEffects);
+  const updateLayerBlendMode = useEditorStore((s) => s.updateLayerBlendMode);
   const rasterizeLayerStyle = useEditorStore((s) => s.rasterizeLayerStyle);
   const setShowEffectsDrawer = useUIStore((s) => s.setShowEffectsDrawer);
 
@@ -47,6 +95,15 @@ export function LayerEffectsPanel() {
       update({ [key]: { ...current, enabled: !current.enabled } });
     },
     [effects, update],
+  );
+
+  const handleBlendModeChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      if (!activeLayerId) return;
+      useEditorStore.getState().pushHistory('Change Blend Mode');
+      updateLayerBlendMode(activeLayerId, e.target.value as BlendMode);
+    },
+    [activeLayerId, updateLayerBlendMode],
   );
 
   if (!activeLayer) {
@@ -114,6 +171,24 @@ export function LayerEffectsPanel() {
           label="Close effects"
           onClick={() => setShowEffectsDrawer(false)}
         />
+      </div>
+      <div className={styles.blendModeRow}>
+        <span className={styles.fieldLabel}>Blend</span>
+        <select
+          className={styles.blendModeSelect}
+          value={activeLayer.blendMode}
+          onChange={handleBlendModeChange}
+        >
+          {BLEND_MODE_GROUPS.map((group) => (
+            <optgroup key={group.label} label={group.label}>
+              {group.modes.map((mode) => (
+                <option key={mode.value} value={mode.value}>
+                  {mode.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
       </div>
       <div className={styles.split}>
         <div className={styles.effectList}>

--- a/src/panels/LayerPanel/LayerPanel.module.css
+++ b/src/panels/LayerPanel/LayerPanel.module.css
@@ -5,10 +5,8 @@
 }
 
 .list {
-  flex: 1;
   overflow-y: auto;
-  min-height: 200px;
-  max-height: 250px;
+  height: 250px;
 }
 
 .listCollapsed {

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -138,8 +138,10 @@ export function LayerPanel({
                 className={`${styles.effectsBtn} ${showEffectsDrawer && layer.id === activeLayerId ? styles.effectsBtnActive : ''}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onSelectLayer(layer.id);
-                  if (!showEffectsDrawer) {
+                  if (showEffectsDrawer && layer.id === activeLayerId) {
+                    setShowEffectsDrawer(false);
+                  } else {
+                    onSelectLayer(layer.id);
                     setShowEffectsDrawer(true);
                   }
                 }}


### PR DESCRIPTION
## Summary
- **Canvas guides**: Click rulers to place horizontal/vertical guides; click again to remove. Guides render as overlay lines with hover preview and persist until cleared.
- **Blend mode selector**: Added grouped blend mode dropdown (Normal, Darken, Lighten, Contrast, Comparative, Composite) to the Layer Effects panel.
- **Layer panel fixes**: Fixed layer list to 250px height, matched effects drawer height to layers panel, and made effects icon toggle the panel closed on re-click.

## Test plan
- [ ] Open a document and verify ruler click places a guide line on the canvas
- [ ] Click the same ruler position again to remove the guide
- [ ] Open the Layer Effects panel and change blend mode — verify it applies to the layer
- [ ] Verify the effects panel height matches the layers panel
- [ ] Click the effects icon on the active layer twice — panel should open then close

🤖 Generated with [Claude Code](https://claude.com/claude-code)