### PR TITLE
Fix Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=lopsy-art
+          command: pages deploy dist --project-name=lopsy.art


### PR DESCRIPTION
## Summary
- Switch deployment from GitHub Pages to Cloudflare Pages
- Fix TypeScript build errors blocking CI
- Fix Cloudflare Pages project name (`lopsy-art` → `lopsy.art`)

## Test plan
- [ ] Verify CI build passes
- [ ] Verify Cloudflare Pages deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)