### PR TITLE
Add Cloudflare Pages project creation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,14 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Create Cloudflare Pages project (if needed)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create lopsy.art --production-branch main
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Summary
- Add a `pages project create` step before deploy with `continue-on-error: true`
- Creates the `lopsy.art` project on first run, silently no-ops after that
- Fixes: `Project not found [code: 8000007]`

## Test plan
- [ ] Verify CI creates the project and deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)