### PR TITLE
Fix Cloudflare Pages project name (no dots allowed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages project create lopsy.art --production-branch main
+          command: pages project create lopsy-art --production-branch main
         continue-on-error: true
 
       - name: Deploy to Cloudflare Pages
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=lopsy.art
+          command: pages deploy dist --project-name=lopsy-art


### PR DESCRIPTION
## Summary
- Change project name from `lopsy.art` to `lopsy-art` — Cloudflare doesn't allow dots in project names
- Custom domain `lopsy.art` can be added in Cloudflare Pages dashboard after first deploy

## Test plan
- [ ] Verify CI creates the project and deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)