### PR TITLE
fix(move): only move content pixels and preserve off-canvas data

### DIFF
--- a/e2e/move-layer.spec.ts
+++ b/e2e/move-layer.spec.ts
@@ -1,0 +1,473 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  createDocument,
+  waitForStore,
+  paintCircle,
+  paintRect,
+  getEditorState,
+  addLayer,
+  withEditorStore,
+} from './helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates what handleMoveDown does: expand → crop → move by delta.
+ * This mirrors the real move tool behavior (crop to content first).
+ */
+async function moveLayerContent(
+  page: Page,
+  layerId: string,
+  dx: number,
+  dy: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ id, dx, dy }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; x: number; y: number }> };
+          pushHistory: (label?: string) => void;
+          expandLayerForEditing: (id: string) => ImageData;
+          cropLayerToContent: (id: string) => void;
+          updateLayerPosition: (id: string, x: number, y: number) => void;
+        };
+      };
+      const state = store.getState();
+      state.pushHistory('Move');
+      state.expandLayerForEditing(id);
+      state.cropLayerToContent(id);
+      const layer = store.getState().document.layers.find((l) => l.id === id);
+      state.updateLayerPosition(id, (layer?.x ?? 0) + dx, (layer?.y ?? 0) + dy);
+    },
+    { id: layerId, dx, dy },
+  );
+}
+
+/**
+ * Get pixel from the expanded (editing) buffer, accounting for layer offset.
+ */
+async function getPixelAtCanvasPos(
+  page: Page,
+  canvasX: number,
+  canvasY: number,
+  layerId: string,
+): Promise<{ r: number; g: number; b: number; a: number }> {
+  return page.evaluate(
+    ({ x, y, lid }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; x: number; y: number }> };
+          expandLayerForEditing: (id: string) => ImageData;
+        };
+      };
+      const state = store.getState();
+      const data = state.expandLayerForEditing(lid);
+      const layer = store.getState().document.layers.find((l) => l.id === lid);
+      const lx = layer?.x ?? 0;
+      const ly = layer?.y ?? 0;
+      const bx = x - lx;
+      const by = y - ly;
+      if (bx < 0 || bx >= data.width || by < 0 || by >= data.height) {
+        return { r: 0, g: 0, b: 0, a: 0 };
+      }
+      const idx = (by * data.width + bx) * 4;
+      return {
+        r: data.data[idx] ?? 0,
+        g: data.data[idx + 1] ?? 0,
+        b: data.data[idx + 2] ?? 0,
+        a: data.data[idx + 3] ?? 0,
+      };
+    },
+    { x: canvasX, y: canvasY, lid: layerId },
+  );
+}
+
+/**
+ * Simulates what handleMoveDown does at mousedown: expand → crop.
+ * Does NOT move the layer — this is just the "click to start drag" step.
+ */
+async function simulateMoveMouseDown(
+  page: Page,
+  layerId: string,
+): Promise<void> {
+  await page.evaluate(
+    (lid) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          pushHistory: (label?: string) => void;
+          expandLayerForEditing: (id: string) => ImageData;
+          cropLayerToContent: (id: string) => void;
+        };
+      };
+      const state = store.getState();
+      state.pushHistory('Move');
+      state.expandLayerForEditing(lid);
+      state.cropLayerToContent(lid);
+    },
+    layerId,
+  );
+}
+
+/**
+ * Get the layer's current position and dimensions from the store.
+ */
+async function getLayerBounds(
+  page: Page,
+  layerId: string,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  return page.evaluate(
+    (lid) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; x: number; y: number; width: number; height: number }> };
+        };
+      };
+      const layer = store.getState().document.layers.find((l) => l.id === lid);
+      return { x: layer?.x ?? 0, y: layer?.y ?? 0, width: layer?.width ?? 0, height: layer?.height ?? 0 };
+    },
+    layerId,
+  );
+}
+
+async function docToScreen(page: Page, docX: number, docY: number) {
+  return page.evaluate(
+    ({ docX, docY }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number };
+          viewport: { zoom: number; panX: number; panY: number };
+        };
+      };
+      const state = store.getState();
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      if (!container) return { x: 0, y: 0 };
+      const rect = container.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      const screenX =
+        (docX - state.document.width / 2) * state.viewport.zoom +
+        state.viewport.panX +
+        cx;
+      const screenY =
+        (docY - state.document.height / 2) * state.viewport.zoom +
+        state.viewport.panY +
+        cy;
+      return { x: rect.left + screenX, y: rect.top + screenY };
+    },
+    { docX, docY },
+  );
+}
+
+async function drawStroke(
+  page: Page,
+  fromDoc: { x: number; y: number },
+  toDoc: { x: number; y: number },
+  steps = 10,
+) {
+  const start = await docToScreen(page, fromDoc.x, fromDoc.y);
+  const end = await docToScreen(page, toDoc.x, toDoc.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps });
+  await page.mouse.up();
+  await page.waitForTimeout(100);
+}
+
+async function setToolSetting(page: Page, setter: string, value: unknown) {
+  await page.evaluate(
+    ({ setter, value }) => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => Record<string, (v: unknown) => void>;
+      };
+      store.getState()[setter]!(value);
+    },
+    { setter, value },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await waitForStore(page);
+});
+
+test.describe('Move Layer — content only', () => {
+  test('moving a layer does not move transparent pixels', async ({ page }) => {
+    // 400×300 transparent document
+    await createDocument(page, 400, 300, true);
+    await addLayer(page);
+    // Wait for the GPU engine to sync the new layer
+    await page.waitForTimeout(200);
+
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Paint a circle in the center (radius 50)
+    await paintCircle(page, 200, 150, 50, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+
+    // Move the layer 100px south-east (simulating the move tool)
+    await moveLayerContent(page, layerId, 100, 100);
+
+    // After move, the layer should only cover the circle's content bounds
+    // shifted by (100, 100). The rest of the canvas should be accessible
+    // for painting.
+    const layerAfter = await withEditorStore(page, (s) => {
+      const doc = s.document as { layers: Array<{ id: string; x: number; y: number; width: number; height: number }> };
+      return doc.layers.find((l) => l.id === (s.document as { activeLayerId: string }).activeLayerId);
+    });
+
+    // The layer's position should reflect the moved content bounds, not the
+    // full canvas
+    expect(layerAfter!.x).toBeGreaterThan(0);
+    expect(layerAfter!.y).toBeGreaterThan(0);
+    // Content dimensions should be roughly the circle's bounding box, not the canvas
+    expect(layerAfter!.width).toBeLessThan(400);
+    expect(layerAfter!.height).toBeLessThan(300);
+
+    // Expanding the layer for editing should still give us access to the
+    // full canvas area — verify we can read/write at (5, 5) which is far
+    // from the moved circle
+    const topLeftPixel = await getPixelAtCanvasPos(page, 5, 5, layerId);
+    expect(topLeftPixel.a).toBe(0); // transparent — no content here
+
+    // The circle should be at its new position (~300, ~250)
+    const circlePixel = await getPixelAtCanvasPos(page, 300, 250, layerId);
+    expect(circlePixel.r).toBe(255);
+    expect(circlePixel.a).toBe(255);
+  });
+
+  test('content moved off-canvas is preserved', async ({ page }) => {
+    // 400×300 transparent document
+    await createDocument(page, 400, 300, true);
+    await addLayer(page);
+
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Paint a circle near the right edge
+    await paintCircle(page, 350, 150, 40, { r: 0, g: 255, b: 0, a: 255 }, layerId);
+
+    // Move 100px right — pushes part of the circle off-canvas
+    await moveLayerContent(page, layerId, 100, 0);
+
+    // Expand for editing — the buffer should be larger than the canvas
+    // to preserve off-canvas content
+    const bufferInfo = await page.evaluate((lid) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number; layers: Array<{ id: string; x: number; y: number; width: number; height: number }> };
+          expandLayerForEditing: (id: string) => ImageData;
+        };
+      };
+      const state = store.getState();
+      const data = state.expandLayerForEditing(lid);
+      const layer = store.getState().document.layers.find((l) => l.id === lid);
+      return {
+        bufferWidth: data.width,
+        bufferHeight: data.height,
+        layerX: layer?.x ?? 0,
+        layerY: layer?.y ?? 0,
+        docWidth: state.document.width,
+      };
+    }, layerId);
+
+    // The buffer should extend beyond the canvas width to preserve the
+    // off-canvas portion of the circle
+    expect(bufferInfo.bufferWidth).toBeGreaterThan(bufferInfo.docWidth);
+
+    // Read a pixel that's off-canvas (at canvas x=430, within the circle)
+    const offCanvasPixel = await getPixelAtCanvasPos(page, 450, 150, layerId);
+    expect(offCanvasPixel.g).toBe(255);
+    expect(offCanvasPixel.a).toBe(255);
+
+    // Now move it back on-canvas and verify content is intact
+    await moveLayerContent(page, layerId, -100, 0);
+    const restoredPixel = await getPixelAtCanvasPos(page, 350, 150, layerId);
+    expect(restoredPixel.g).toBe(255);
+    expect(restoredPixel.a).toBe(255);
+  });
+
+  test('mousedown with move tool does not snap off-canvas content back', async ({ page }) => {
+    // 400×300 transparent document
+    await createDocument(page, 400, 300, true);
+    await addLayer(page);
+
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Paint a 100×100 square in the center
+    await paintRect(page, 150, 100, 100, 100, { r: 255, g: 0, b: 0, a: 255 }, layerId);
+
+    // Move the square so only 1×1 px is visible at the top-left corner.
+    // Content bounds after crop are roughly (150,100)–(249,199).
+    // We want the bottom-right pixel at canvas (0,0), so shift by
+    // -(249, 199) = (-249, -199).  That puts content origin at (-249,-199)
+    // and the last pixel at (0, 0).
+    // Use a delta that puts the bottom-right corner at (0,0):
+    //   newX = 150 + dx => dx such that newX + 99 = 0 => newX = -99 => dx = -249
+    //   newY = 100 + dy => dy such that newY + 99 = 0 => newY = -99 => dy = -199
+    await moveLayerContent(page, layerId, -249, -199);
+
+    const boundsAfterMove = await getLayerBounds(page, layerId);
+    // Content should be mostly off-canvas
+    expect(boundsAfterMove.x).toBeLessThan(0);
+    expect(boundsAfterMove.y).toBeLessThan(0);
+
+    const posBeforeClick = { x: boundsAfterMove.x, y: boundsAfterMove.y };
+
+    // Simulate a move-tool mousedown (expand → crop) without dragging.
+    // BUG: this used to snap the content back on-canvas because
+    // sparse offsets were stale.
+    await simulateMoveMouseDown(page, layerId);
+
+    const boundsAfterClick = await getLayerBounds(page, layerId);
+
+    // The layer position should be unchanged — content must NOT snap back
+    expect(boundsAfterClick.x).toBe(posBeforeClick.x);
+    expect(boundsAfterClick.y).toBe(posBeforeClick.y);
+    expect(boundsAfterClick.width).toBe(boundsAfterMove.width);
+    expect(boundsAfterClick.height).toBe(boundsAfterMove.height);
+  });
+
+  test('GPU-painted brush content does not snap back on move mousedown', async ({ page }) => {
+    // 400×300 transparent document
+    await createDocument(page, 400, 300, true);
+    await addLayer(page);
+
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Draw a spiral-like shape in the center using the brush tool (GPU path).
+    // This is the critical difference from the paintRect test: brush strokes
+    // live on the GPU, so JS has no pixel data until readback.
+    await page.keyboard.press('b');
+    await setToolSetting(page, 'setBrushSize', 10);
+    await setToolSetting(page, 'setBrushOpacity', 100);
+    await drawStroke(page, { x: 200, y: 100 }, { x: 250, y: 150 }, 15);
+    await drawStroke(page, { x: 250, y: 150 }, { x: 200, y: 200 }, 15);
+    await drawStroke(page, { x: 200, y: 200 }, { x: 150, y: 150 }, 15);
+    await drawStroke(page, { x: 150, y: 150 }, { x: 200, y: 130 }, 15);
+
+    // Move the brush content mostly off-canvas via the store (simulating
+    // the move tool's expand → crop → reposition flow).
+    await moveLayerContent(page, layerId, -350, -250);
+
+    const boundsAfterMove = await getLayerBounds(page, layerId);
+    // Content should be mostly off-canvas
+    expect(boundsAfterMove.x).toBeLessThan(0);
+    expect(boundsAfterMove.y).toBeLessThan(0);
+
+    const posBeforeClick = { x: boundsAfterMove.x, y: boundsAfterMove.y };
+
+    // Simulate a second move-tool mousedown (expand → crop). With GPU-
+    // painted content, the expand reads from GPU or sparse/dense cache.
+    // BUG: content snapped back on-canvas because the expand used stale
+    // sparse offsets or failed to preserve off-canvas data.
+    await simulateMoveMouseDown(page, layerId);
+
+    const boundsAfterClick = await getLayerBounds(page, layerId);
+
+    // The layer position must NOT change — content stays off-canvas
+    expect(boundsAfterClick.x).toBe(posBeforeClick.x);
+    expect(boundsAfterClick.y).toBe(posBeforeClick.y);
+    expect(boundsAfterClick.width).toBe(boundsAfterMove.width);
+    expect(boundsAfterClick.height).toBe(boundsAfterMove.height);
+  });
+
+  test('brush click after move does not snap layer back', async ({ page }) => {
+    // Exact user scenario: draw spiral → move to bottom-right → brush click
+    await createDocument(page, 400, 300, true);
+    await addLayer(page);
+
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // 1. Draw a square with the brush tool (GPU path)
+    await page.keyboard.press('b');
+    await setToolSetting(page, 'setBrushSize', 8);
+    await setToolSetting(page, 'setBrushOpacity', 100);
+    await drawStroke(page, { x: 150, y: 100 }, { x: 250, y: 100 }, 15);
+    await drawStroke(page, { x: 250, y: 100 }, { x: 250, y: 200 }, 15);
+    await drawStroke(page, { x: 250, y: 200 }, { x: 150, y: 200 }, 15);
+    await drawStroke(page, { x: 150, y: 200 }, { x: 150, y: 130 }, 15);
+
+    // 2. Move the content to the bottom-right via the move tool
+    await moveLayerContent(page, layerId, 100, 50);
+    await page.waitForTimeout(100);
+
+    const boundsAfterMove = await getLayerBounds(page, layerId);
+    expect(boundsAfterMove.x).toBeGreaterThan(100);
+    expect(boundsAfterMove.y).toBeGreaterThan(50);
+
+    // 3. Switch to brush and click to draw a dot.
+    //    This triggers beginStroke → ensure_layer_full_size on the GPU.
+    //    BUG: ensure_layer_full_size used to discard the cropped texture
+    //    and reset position to (0,0), causing content to jump.
+    await page.keyboard.press('b');
+    await page.waitForTimeout(50);
+
+    const clickPos = await docToScreen(page, 380, 280);
+    await page.mouse.click(clickPos.x, clickPos.y);
+    await page.waitForTimeout(200);
+
+    // After the brush click, expand the layer to get pixel data and check
+    // that the original content is still at its moved position (not at origin).
+    const result = await page.evaluate(
+      ({ lid, movedX, movedY }) => {
+        const store = (window as unknown as Record<string, unknown>).__editorStore as {
+          getState: () => {
+            expandLayerForEditing: (id: string) => ImageData;
+            document: { layers: Array<{ id: string; x: number; y: number }> };
+          };
+        };
+        const st = store.getState();
+        const data = st.expandLayerForEditing(lid);
+        const layer = store.getState().document.layers.find((l) => l.id === lid);
+        const lx = layer?.x ?? 0;
+        const ly = layer?.y ?? 0;
+
+        // Check for opaque pixels near the moved content center
+        const cx = movedX - lx;
+        const cy = movedY - ly;
+        let movedCount = 0;
+        for (let dy = -15; dy <= 15; dy++) {
+          for (let dx = -15; dx <= 15; dx++) {
+            const px = cx + dx;
+            const py = cy + dy;
+            if (px < 0 || px >= data.width || py < 0 || py >= data.height) continue;
+            if ((data.data[(py * data.width + px) * 4 + 3] ?? 0) > 0) movedCount++;
+          }
+        }
+
+        // Check for opaque pixels near the origin (where content should NOT be)
+        const ox = 10 - lx;
+        const oy = 10 - ly;
+        let originCount = 0;
+        for (let dy = -5; dy <= 5; dy++) {
+          for (let dx = -5; dx <= 5; dx++) {
+            const px = ox + dx;
+            const py = oy + dy;
+            if (px < 0 || px >= data.width || py < 0 || py >= data.height) continue;
+            if ((data.data[(py * data.width + px) * 4 + 3] ?? 0) > 0) originCount++;
+          }
+        }
+
+        return { movedCount, originCount, lx, ly, w: data.width, h: data.height };
+      },
+      {
+        lid: layerId,
+        movedX: Math.round(boundsAfterMove.x + boundsAfterMove.width / 2),
+        movedY: Math.round(boundsAfterMove.y + boundsAfterMove.height / 2),
+      },
+    );
+
+    // Content must be at the moved position, NOT at the origin
+    expect(result.movedCount).toBeGreaterThan(0);
+    expect(result.originCount).toBe(0);
+  });
+});

--- a/engine-rs/crates/lopsy-wasm/src/engine.rs
+++ b/engine-rs/crates/lopsy-wasm/src/engine.rs
@@ -231,7 +231,66 @@ impl EngineInner {
         if lw >= self.doc_width && lh >= self.doc_height {
             return Ok(());
         }
+
+        // Get the layer's current position so we can place the old content
+        // correctly in the new full-size texture.
+        let (layer_x, layer_y) = self.layer_stack.iter()
+            .find(|l| l.id == layer_id)
+            .map(|l| (l.x, l.y))
+            .unwrap_or((0, 0));
+
+        // Read old texture pixels via CPU readback (handles float textures).
+        let old_tex_gl = self.texture_pool.get(layer_tex).cloned();
+        let old_pixels = if let Some(ref tex) = old_tex_gl {
+            let fbo = self.gl.create_framebuffer();
+            if let Some(ref fbo) = fbo {
+                self.gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, Some(fbo));
+                self.gl.framebuffer_texture_2d(
+                    WebGl2RenderingContext::FRAMEBUFFER,
+                    WebGl2RenderingContext::COLOR_ATTACHMENT0,
+                    WebGl2RenderingContext::TEXTURE_2D,
+                    Some(tex),
+                    0,
+                );
+                let result = self.texture_pool.read_rgba(&self.gl, 0, 0, lw, lh);
+                self.gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+                self.gl.delete_framebuffer(Some(fbo));
+                result.ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let new_tex = self.texture_pool.acquire(&self.gl, self.doc_width, self.doc_height)?;
+
+        // Re-upload old content at the correct position in the new texture.
+        if let Some(pixels) = old_pixels {
+            let dst_x = layer_x.max(0);
+            let dst_y = layer_y.max(0);
+            let src_skip_x = (-layer_x).max(0) as u32;
+            let src_skip_y = (-layer_y).max(0) as u32;
+            let copy_w = (lw - src_skip_x).min(self.doc_width - dst_x as u32);
+            let copy_h = (lh - src_skip_y).min(self.doc_height - dst_y as u32);
+
+            if copy_w > 0 && copy_h > 0 {
+                let mut sub = vec![0u8; (copy_w * copy_h * 4) as usize];
+                for row in 0..copy_h {
+                    let src_off = ((src_skip_y + row) * lw + src_skip_x) as usize * 4;
+                    let dst_off = (row * copy_w) as usize * 4;
+                    let len = copy_w as usize * 4;
+                    if src_off + len <= pixels.len() && dst_off + len <= sub.len() {
+                        sub[dst_off..dst_off + len].copy_from_slice(&pixels[src_off..src_off + len]);
+                    }
+                }
+                let _ = self.texture_pool.upload_rgba(
+                    &self.gl, new_tex,
+                    dst_x, dst_y, copy_w, copy_h, &sub,
+                );
+            }
+        }
+
         let old = self.layer_textures.insert(layer_id.to_string(), new_tex);
         if let Some(old_tex) = old {
             self.texture_pool.release(old_tex);

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -82,6 +82,14 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
     };
   }
 
+  // Crop the layer to content bounds before moving so that only opaque
+  // pixels are repositioned — transparent areas should stay behind.
+  editorState.expandLayerForEditing(activeLayerId);
+  editorState.cropLayerToContent(activeLayerId);
+  const croppedLayer = useEditorStore.getState().document.layers.find(
+    (l) => l.id === activeLayerId,
+  );
+
   return {
     drawing: true,
     lastPoint: canvasPos,
@@ -90,8 +98,8 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
     layerId: activeLayerId,
     tool: 'move',
     startPoint: canvasPos,
-    layerStartX: activeLayer.x,
-    layerStartY: activeLayer.y,
+    layerStartX: croppedLayer?.x ?? activeLayer.x,
+    layerStartY: croppedLayer?.y ?? activeLayer.y,
     ...DEFAULT_TRANSFORM_FIELDS,
   };
 }

--- a/src/app/store/actions/layer-crop-expand.ts
+++ b/src/app/store/actions/layer-crop-expand.ts
@@ -66,12 +66,21 @@ export function expandLayerToDocument(
     return { layers, pixelData };
   }
 
-  const expanded = expandFromCrop(data, layer.x, layer.y, docWidth, docHeight);
+  // Compute union of canvas area and content area so off-canvas content
+  // is preserved (non-destructive move).
+  const minX = Math.min(0, layer.x);
+  const minY = Math.min(0, layer.y);
+  const maxX = Math.max(docWidth, layer.x + data.width);
+  const maxY = Math.max(docHeight, layer.y + data.height);
+  const bufW = maxX - minX;
+  const bufH = maxY - minY;
+
+  const expanded = expandFromCrop(data, layer.x - minX, layer.y - minY, bufW, bufH);
   const newPixelData = new Map(pixelData);
   newPixelData.set(layerId, expanded);
   const newLayers = layers.map((l) =>
     l.id === layerId
-      ? { ...l, x: 0, y: 0, width: docWidth, height: docHeight } as Layer
+      ? { ...l, x: minX, y: minY, width: bufW, height: bufH } as Layer
       : l,
   );
   return { layers: newLayers, pixelData: newPixelData };

--- a/src/app/store/pixel-data-slice.ts
+++ b/src/app/store/pixel-data-slice.ts
@@ -167,10 +167,29 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
     const docW = state.document.width;
     const docH = state.document.height;
 
+    // Helper: compute the union of the canvas area and the content area so
+    // that off-canvas content is preserved (non-destructive move).
+    const unionBounds = (cx: number, cy: number, cw: number, ch: number) => {
+      const minX = Math.min(0, cx);
+      const minY = Math.min(0, cy);
+      const maxX = Math.max(docW, cx + cw);
+      const maxY = Math.max(docH, cy + ch);
+      return { minX, minY, bufW: maxX - minX, bufH: maxY - minY };
+    };
+
     // Check for sparse data first
     const sparseEntry = state.sparseLayerData.get(layerId);
     if (sparseEntry) {
-      const expanded = fromSparsePixelData(sparseEntry.sparse, docW, docH, sparseEntry.offsetX, sparseEntry.offsetY);
+      // Use layer.x/y as the authoritative position — sparse offsets may
+      // be stale after an updateLayerPosition() call (move tool).
+      const { minX, minY, bufW, bufH } = unionBounds(
+        layer.x, layer.y,
+        sparseEntry.sparse.width, sparseEntry.sparse.height,
+      );
+      const expanded = fromSparsePixelData(
+        sparseEntry.sparse, bufW, bufH,
+        layer.x - minX, layer.y - minY,
+      );
       const pixelData = new Map(state.layerPixelData);
       pixelData.set(layerId, expanded);
       const sparseMap = new Map(state.sparseLayerData);
@@ -179,7 +198,7 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
         document: {
           ...state.document,
           layers: state.document.layers.map((l) =>
-            l.id === layerId ? { ...l, x: 0, y: 0, width: docW, height: docH } as Layer : l,
+            l.id === layerId ? { ...l, x: minX, y: minY, width: bufW, height: bufH } as Layer : l,
           ),
         },
         layerPixelData: pixelData,
@@ -190,8 +209,8 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
 
     const existing = state.layerPixelData.get(layerId);
 
-    // Already full canvas size at origin
-    if (existing && layer.x === 0 && layer.y === 0 && existing.width === docW && existing.height === docH) {
+    // Already covers the full canvas and all content is on-canvas
+    if (existing && layer.x === 0 && layer.y === 0 && existing.width >= docW && existing.height >= docH) {
       return existing;
     }
 
@@ -199,15 +218,15 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
     if (!existing) {
       const gpuData = readLayerAsImageData(layerId);
       if (gpuData) {
-        // GPU data is at layer dimensions — expand to full canvas
-        const expanded = expandFromCrop(gpuData, layer.x, layer.y, docW, docH);
+        const { minX, minY, bufW, bufH } = unionBounds(layer.x, layer.y, gpuData.width, gpuData.height);
+        const expanded = expandFromCrop(gpuData, layer.x - minX, layer.y - minY, bufW, bufH);
         const pixelData = new Map(state.layerPixelData);
         pixelData.set(layerId, expanded);
         set({
           document: {
             ...state.document,
             layers: state.document.layers.map((l) =>
-              l.id === layerId ? { ...l, x: 0, y: 0, width: docW, height: docH } as Layer : l,
+              l.id === layerId ? { ...l, x: minX, y: minY, width: bufW, height: bufH } as Layer : l,
             ),
           },
           layerPixelData: pixelData,
@@ -216,13 +235,27 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
       }
     }
 
-    // Expand cropped data to full canvas size
-    const expanded = existing
-      ? expandFromCrop(existing, layer.x, layer.y, docW, docH)
-      : createImageData(docW, docH);
+    // Expand cropped data, preserving off-canvas content
+    if (existing) {
+      const { minX, minY, bufW, bufH } = unionBounds(layer.x, layer.y, existing.width, existing.height);
+      const expanded = expandFromCrop(existing, layer.x - minX, layer.y - minY, bufW, bufH);
+      const pixelData = new Map(state.layerPixelData);
+      pixelData.set(layerId, expanded);
+      set({
+        document: {
+          ...state.document,
+          layers: state.document.layers.map((l) =>
+            l.id === layerId ? { ...l, x: minX, y: minY, width: bufW, height: bufH } as Layer : l,
+          ),
+        },
+        layerPixelData: pixelData,
+      });
+      return expanded;
+    }
 
+    const empty = createImageData(docW, docH);
     const pixelData = new Map(state.layerPixelData);
-    pixelData.set(layerId, expanded);
+    pixelData.set(layerId, empty);
     set({
       document: {
         ...state.document,
@@ -232,7 +265,7 @@ export const createPixelDataSlice: SliceCreator<PixelDataSlice> = (set, get) => 
       },
       layerPixelData: pixelData,
     });
-    return expanded;
+    return empty;
   },
 
   resolvePixelData: (layerId: string) => {

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -148,6 +148,36 @@ export function useCanvasInteraction(
             // Finalize any pending stroke from a previous mouseup
             finalizePendingStroke(pendingStrokeRef);
             beginStroke(engine, activeLayerId);
+
+            // beginStroke calls ensure_layer_full_size on the WASM side,
+            // which may expand a cropped layer texture to full document
+            // size and reset the layer position to (0,0). Sync the JS
+            // store to match so the two sides don't desync.
+            const docState = useEditorStore.getState().document;
+            const currentLayer = docState.layers.find((l) => l.id === activeLayerId);
+            if (currentLayer && (currentLayer.x !== 0 || currentLayer.y !== 0
+              || (currentLayer.type === 'raster' && (currentLayer.width !== docState.width || currentLayer.height !== docState.height)))) {
+              const updatedLayers = docState.layers.map((l) =>
+                l.id === activeLayerId
+                  ? { ...l, x: 0, y: 0, width: docState.width, height: docState.height } as Layer
+                  : l,
+              );
+              const pixelData = new Map(useEditorStore.getState().layerPixelData);
+              pixelData.delete(activeLayerId);
+              const sparseMap = new Map(useEditorStore.getState().sparseLayerData);
+              sparseMap.delete(activeLayerId);
+              const dirtyIds = new Set(useEditorStore.getState().dirtyLayerIds);
+              dirtyIds.add(activeLayerId);
+              useEditorStore.setState({
+                document: { ...docState, layers: updatedLayers },
+                layerPixelData: pixelData,
+                sparseLayerData: sparseMap,
+                dirtyLayerIds: dirtyIds,
+              });
+              // Re-read activeLayer so layerPos computation below uses updated position
+              expandedLayer = updatedLayers.find((l) => l.id === activeLayerId) ?? activeLayer;
+              layerPos = { x: canvasPos.x - expandedLayer.x, y: canvasPos.y - expandedLayer.y };
+            }
           }
         }
         // Create a minimal dummy buffer for the context (tool handlers
@@ -156,6 +186,10 @@ export function useCanvasInteraction(
         pixelBuffer = PixelBuffer.wrapImageData(dummyData);
         paintSurface = pixelBuffer;
       } else {
+        // Finalize any pending GPU stroke so the layer texture includes it
+        // before we read pixel data back for non-GPU tools (e.g. move).
+        finalizePendingStroke(pendingStrokeRef);
+
         // CPU fallback: expand layer to full canvas for pixel manipulation
         const imageData = editorState.expandLayerForEditing(activeLayerId);
         expandedLayer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId)!;

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -325,6 +325,8 @@ export function syncLayers(
     } else if (!data && sparseEntry && (sparseChanged || isDirty)) {
       const indices = new Uint32Array(sparseEntry.sparse.indices);
       const rgba = new Uint8Array(sparseEntry.sparse.rgba.buffer, sparseEntry.sparse.rgba.byteOffset, sparseEntry.sparse.rgba.byteLength);
+      // Use layer.x/y as authoritative position — sparse offsets may be
+      // stale after updateLayerPosition() (move tool).
       uploadLayerSparsePixels(
         engine,
         layer.id,
@@ -332,8 +334,8 @@ export function syncLayers(
         rgba,
         sparseEntry.sparse.width,
         sparseEntry.sparse.height,
-        sparseEntry.offsetX,
-        sparseEntry.offsetY,
+        layer.x,
+        layer.y,
       );
       tracked.sparseVersions.set(layer.id, sparseEntry);
       tracked.pixelDataVersions.set(layer.id, undefined);


### PR DESCRIPTION
## Summary
- **Content-only move**: Crop layer to content bounds before dragging so transparent pixels stay behind — fixes the bug where moving a layer also moved its empty space.
- **Non-destructive off-canvas**: Expand buffers to union bounds (canvas + content) so content dragged off-canvas is preserved and can be dragged back.
- **GPU/JS desync fix**: Finalize pending GPU strokes before non-GPU tools, sync JS store after `beginStroke`'s `ensure_layer_full_size`, and blit cropped texture content into the new full-size texture (Rust/WASM) so brush clicks after a move don't snap content back to origin.

## Test plan
- [x] 5 new e2e tests in `e2e/move-layer.spec.ts` covering all three fixes
- [x] 197/197 existing e2e tests pass (Chromium), zero regressions
- [x] Manual testing: draw spiral → move → brush click — content stays in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)