### PR TITLE
fix: Firefox copy/paste and clean up build warnings

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/compositor.rs
+++ b/engine-rs/crates/lopsy-wasm/src/compositor.rs
@@ -388,30 +388,6 @@ fn render_shadow(engine: &mut EngineInner, tex_handle: TextureHandle, tw: u32, t
     }
 }
 
-/// Render color overlay into scratch_b.
-/// Uses scratch_b (not scratch_a) because blend_onto_composite reads the
-/// overlay result as its source while using scratch_a as the intermediate
-/// render target — using scratch_a for both would be a feedback loop.
-fn render_color_overlay(engine: &mut EngineInner, tex_handle: TextureHandle, overlay: &ColorOverlayDesc) {
-    let doc_w = engine.doc_width as i32;
-    let doc_h = engine.doc_height as i32;
-    if let Some(layer_tex) = engine.texture_pool.get(tex_handle).cloned() {
-        engine.gl.use_program(Some(&engine.shaders.color_overlay.program));
-        engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
-        engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&layer_tex));
-        let prog = &engine.shaders.color_overlay.program;
-        if let Some(loc) = engine.gl.get_uniform_location(prog, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
-        if let Some(loc) = engine.gl.get_uniform_location(prog, "u_overlayColor") { engine.gl.uniform4f(Some(&loc), overlay.color[0], overlay.color[1], overlay.color[2], overlay.color[3]); }
-        if let Some(loc) = engine.gl.get_uniform_location(prog, "u_opacity") { engine.gl.uniform1f(Some(&loc), overlay.opacity); }
-
-        engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_b);
-        engine.gl.viewport(0, 0, doc_w, doc_h);
-        engine.gl.clear_color(0.0, 0.0, 0.0, 0.0);
-        engine.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
-        engine.draw_fullscreen_quad();
-    }
-}
-
 /// Render stroke effect using proper hard-edge distance check.
 fn render_stroke(engine: &mut EngineInner, tex_handle: TextureHandle, tw: u32, th: u32, stroke: &StrokeDesc, layer_x: f32, layer_y: f32) {
     let doc_w = engine.doc_width as i32;

--- a/src/app/shortcuts/edit-shortcuts.ts
+++ b/src/app/shortcuts/edit-shortcuts.ts
@@ -1,6 +1,7 @@
 import { useUIStore } from '../ui-store';
 import { useEditorStore } from '../editor-store';
 import { selectAll, invertSelectionAction } from '../MenuBar/menus/select-menu';
+import { scheduleFallbackPaste } from '../useKeyboardShortcuts';
 
 export function handleEditShortcut(
   e: KeyboardEvent,
@@ -20,6 +21,11 @@ export function handleEditShortcut(
     // Don't preventDefault — let the browser fire the 'paste' event so
     // clipboardData.files is populated for file pastes from Finder/Explorer.
     // The paste event handler in useKeyboardShortcuts handles all paste logic.
+    //
+    // Schedule a fallback internal paste in case the paste event doesn't fire
+    // (Firefox may not fire paste on non-editable elements like canvas).
+    // The paste handler cancels this timer if it runs.
+    scheduleFallbackPaste();
     return true;
   }
   if (e.key === 'e') {

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -11,6 +11,26 @@ import { pasteOrOpenBlob } from './paste-or-open';
 import { processTextKey } from '../tools/text/text-input';
 import { commitTextEditing } from './interactions/misc-handlers';
 
+// Fallback timer for browsers where the paste event may not fire on non-editable
+// elements (e.g. Firefox with canvas focus). The keydown handler schedules a
+// deferred internal paste; if the paste event fires, it cancels the timer.
+let fallbackPasteTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function scheduleFallbackPaste(): void {
+  cancelFallbackPaste();
+  fallbackPasteTimer = setTimeout(() => {
+    fallbackPasteTimer = null;
+    useEditorStore.getState().paste();
+  }, 200);
+}
+
+function cancelFallbackPaste(): void {
+  if (fallbackPasteTimer !== null) {
+    clearTimeout(fallbackPasteTimer);
+    fallbackPasteTimer = null;
+  }
+}
+
 interface KeyboardShortcutDeps {
   canvasRef: RefObject<HTMLCanvasElement | null>;
   setIsSpaceDown: (v: boolean) => void;
@@ -129,6 +149,9 @@ export function useKeyboardShortcuts({
     const handlePaste = (e: ClipboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
 
+      // Cancel the fallback timer — the paste event fired as expected.
+      cancelFallbackPaste();
+
       const files = e.clipboardData?.files;
       if (files && files.length > 0) {
         const file = files[0];
@@ -140,22 +163,45 @@ export function useKeyboardShortcuts({
         }
       }
 
-      // Try the async clipboard API for image data (e.g. copied pixels from another app)
-      e.preventDefault();
-      navigator.clipboard.read().then(async (items) => {
-        for (const item of items) {
-          const imageType = item.types.find((t) => t.startsWith('image/'));
-          if (imageType) {
-            const blob = await item.getType(imageType);
-            await pasteOrOpenBlob(blob, 'Copied File');
-            return;
+      // Check clipboardData.items for image data (synchronous, works across browsers
+      // including Firefox which may not support navigator.clipboard.read()).
+      const items = e.clipboardData?.items;
+      if (items) {
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i] as DataTransferItem | undefined;
+          if (item && item.type.startsWith('image/')) {
+            const blob = item.getAsFile();
+            if (blob) {
+              e.preventDefault();
+              pasteOrOpenBlob(blob, 'Copied File');
+              return;
+            }
           }
         }
-        // No external image — fall back to internal clipboard
+      }
+
+      // Try the async clipboard API for image data (e.g. copied pixels from another app).
+      // Not all browsers support this (Firefox added it in v127), so guard the call.
+      e.preventDefault();
+      if (typeof navigator.clipboard?.read === 'function') {
+        navigator.clipboard.read().then(async (clipboardItems) => {
+          for (const clipboardItem of clipboardItems) {
+            const imageType = clipboardItem.types.find((t: string) => t.startsWith('image/'));
+            if (imageType) {
+              const blob = await clipboardItem.getType(imageType);
+              await pasteOrOpenBlob(blob, 'Copied File');
+              return;
+            }
+          }
+          // No external image — fall back to internal clipboard
+          useEditorStore.getState().paste();
+        }).catch(() => {
+          useEditorStore.getState().paste();
+        });
+      } else {
+        // Browser doesn't support clipboard.read() — use internal clipboard
         useEditorStore.getState().paste();
-      }).catch(() => {
-        useEditorStore.getState().paste();
-      });
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown, true);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,4 +79,17 @@ export default defineConfig({
       localsConvention: 'camelCaseOnly',
     },
   },
+  build: {
+    chunkSizeWarningLimit: 750,
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        // Suppress eval warning from wasm-pack generated code
+        if (warning.code === 'EVAL' && warning.id?.includes('lopsy_wasm')) return;
+        // wasm-bridge is dynamically imported by engine-state for lazy init
+        // but statically imported everywhere else — this is intentional
+        if (warning.message?.includes('wasm-bridge.ts is dynamically imported')) return;
+        defaultHandler(warning);
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Fix copy/paste not working in Firefox by checking `clipboardData.items` synchronously, guarding `navigator.clipboard.read()` availability, and adding a 200ms fallback timer for internal paste when the browser doesn't dispatch a paste event on non-editable elements
- Remove dead `render_color_overlay` function (color overlay is now handled inline in the blend shader)
- Suppress expected wasm-pack build warnings (eval in generated code, dynamic/static import mix, chunk size) in vite config

## Test plan
- [ ] Verify internal copy/paste (Cmd+C → Cmd+V of a layer) works in Firefox
- [ ] Verify external image paste (copy image from another app → Cmd+V) works in Firefox
- [ ] Verify file paste from Finder works in Firefox
- [ ] Verify all paste flows still work in Chrome/Safari
- [ ] Verify `npm run build` produces clean output (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)