### PR TITLE
feat: WebGL2 disabled warning with browser-specific instructions

### DIFF
--- a/e2e/webgl2-warning.spec.ts
+++ b/e2e/webgl2-warning.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+// Disable WebGL2 before the page initializes by monkey-patching getContext
+// so that any call for 'webgl2' returns null — identical to what a browser
+// with hardware acceleration turned off would return.
+async function disableWebGL2(page: ReturnType<typeof test['info']> extends never ? never : Parameters<Parameters<typeof test>[1]>[0]['page']) {
+  await page.addInitScript(() => {
+    const original = HTMLCanvasElement.prototype.getContext;
+    // @ts-expect-error overriding overloaded native method
+    HTMLCanvasElement.prototype.getContext = function (
+      type: string,
+      ...args: unknown[]
+    ) {
+      if (type === 'webgl2') return null;
+      // @ts-expect-error forwarding rest args
+      return original.call(this, type, ...args);
+    };
+  });
+}
+
+test.describe('WebGL2 warning', () => {
+  test('shows warning with Chrome instructions when WebGL2 is unavailable', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'Chrome-specific instructions test');
+    await disableWebGL2(page);
+    await page.goto('/');
+
+    await expect(page.getByText('WebGL 2 is not available')).toBeVisible();
+    await expect(page.getByText(/Lopsy requires WebGL 2/)).toBeVisible();
+    await expect(page.getByText(/chrome:\/\/settings\/system/i)).toBeVisible();
+    await expect(page.locator('[data-testid="canvas-container"]')).not.toBeVisible();
+  });
+
+  test('shows warning with Firefox instructions when WebGL2 is unavailable', async ({ page, browserName }) => {
+    test.skip(browserName !== 'firefox', 'Firefox-specific instructions test');
+    await disableWebGL2(page);
+    await page.goto('/');
+
+    await expect(page.getByText('WebGL 2 is not available')).toBeVisible();
+    await expect(page.getByText(/Lopsy requires WebGL 2/)).toBeVisible();
+    await expect(page.getByText(/about:config/i)).toBeVisible();
+    await expect(page.getByText(/webgl\.disabled/i)).toBeVisible();
+    await expect(page.locator('[data-testid="canvas-container"]')).not.toBeVisible();
+  });
+
+  test('shows fallback tip for unsupported browsers', async ({ page }) => {
+    await disableWebGL2(page);
+    // Override user agent to something unrecognised
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        get: () => 'MyUnknownBrowser/1.0',
+        configurable: true,
+      });
+    });
+    await page.goto('/');
+
+    await expect(page.getByText('WebGL 2 is not available')).toBeVisible();
+    // Generic instructions should mention trying Chrome or Firefox
+    await expect(page.getByText(/Chrome, Firefox, or Edge/i)).toBeVisible();
+  });
+
+  test('does not show warning when WebGL2 is available', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('WebGL 2 is not available')).not.toBeVisible();
+    // New Document modal should be shown instead of the warning
+    await expect(page.getByRole('heading', { name: 'New Document' })).toBeVisible();
+  });
+});

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { WebGL2Warning, checkWebGL2Support } from '../components/WebGL2Warning/WebGL2Warning';
 import { Toolbox } from '../toolbox/Toolbox';
 import { LayerPanel } from '../panels/LayerPanel/LayerPanel';
 import { LayerEffectsPanel } from '../panels/LayerEffectsPanel/LayerEffectsPanel';
@@ -46,6 +47,8 @@ function CanvasRenderer({ canvasRef, containerRef, overlayCanvasRef }: {
 }
 
 export function App() {
+  const [hasWebGL2] = useState(() => checkWebGL2Support());
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -415,6 +418,10 @@ export function App() {
   const showBrushModal = useBrushPresetStore((s) => s.showBrushModal);
 
   const showModal = !documentReady || showNewDocumentModal;
+
+  if (!hasWebGL2) {
+    return <WebGL2Warning />;
+  }
 
   if (!documentReady) {
     return (

--- a/src/components/WebGL2Warning/WebGL2Warning.module.css
+++ b/src/components/WebGL2Warning/WebGL2Warning.module.css
@@ -1,0 +1,91 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-primary);
+  z-index: var(--z-modal);
+  padding: var(--space-6);
+}
+
+.card {
+  max-width: 480px;
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-lg);
+}
+
+.heading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.icon {
+  color: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.title {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.description {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-6) 0;
+  line-height: 1.5;
+}
+
+.instructions {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-5);
+}
+
+.instructionsLabel {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-3) 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.steps {
+  margin: 0;
+  padding-left: var(--space-5);
+}
+
+.steps li {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  margin-bottom: var(--space-1);
+}
+
+.steps li:last-child {
+  margin-bottom: 0;
+}
+
+.fallback {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-disabled);
+  margin: 0;
+  line-height: 1.5;
+}

--- a/src/components/WebGL2Warning/WebGL2Warning.tsx
+++ b/src/components/WebGL2Warning/WebGL2Warning.tsx
@@ -1,0 +1,111 @@
+import styles from './WebGL2Warning.module.css';
+
+function detectBrowser(): 'chrome' | 'firefox' | 'safari' | 'edge' | 'other' {
+  const ua = navigator.userAgent;
+  if (ua.includes('Edg/')) return 'edge';
+  if (ua.includes('Chrome/')) return 'chrome';
+  if (ua.includes('Firefox/')) return 'firefox';
+  if (ua.includes('Safari/')) return 'safari';
+  return 'other';
+}
+
+interface BrowserInstructions {
+  name: string;
+  steps: string[];
+}
+
+const INSTRUCTIONS: Record<ReturnType<typeof detectBrowser>, BrowserInstructions> = {
+  chrome: {
+    name: 'Chrome',
+    steps: [
+      'Open a new tab and go to chrome://settings/system',
+      'Enable "Use hardware acceleration when available"',
+      'Click "Relaunch" to restart Chrome',
+      'Return to this page',
+    ],
+  },
+  edge: {
+    name: 'Edge',
+    steps: [
+      'Open a new tab and go to edge://settings/system',
+      'Enable "Use hardware acceleration when available"',
+      'Click "Restart" to relaunch Edge',
+      'Return to this page',
+    ],
+  },
+  firefox: {
+    name: 'Firefox',
+    steps: [
+      'Open a new tab and go to about:config',
+      'Accept the risk warning if prompted',
+      'Search for webgl.disabled',
+      'Double-click the preference to set it to false',
+      'Reload this page',
+    ],
+  },
+  safari: {
+    name: 'Safari',
+    steps: [
+      'Open Safari menu → Settings → Advanced',
+      'Check "Show features for web developers"',
+      'Open the Develop menu → Feature Flags',
+      'Ensure "WebGL 2.0" is enabled',
+      'Reload this page',
+    ],
+  },
+  other: {
+    name: 'your browser',
+    steps: [
+      'Check that hardware acceleration is enabled in your browser settings',
+      'Make sure your graphics drivers are up to date',
+      'Try a different browser such as Chrome or Firefox',
+    ],
+  },
+};
+
+export function checkWebGL2Support(): boolean {
+  try {
+    const canvas = document.createElement('canvas');
+    return canvas.getContext('webgl2') !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function WebGL2Warning() {
+  const browser = detectBrowser();
+  const { name, steps } = INSTRUCTIONS[browser];
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.card}>
+        <div className={styles.heading}>
+          <div className={styles.icon}>
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+          <h1 className={styles.title}>WebGL 2 is not available</h1>
+        </div>
+        <p className={styles.description}>
+          Lopsy requires WebGL 2 for GPU-accelerated rendering. It appears to be
+          disabled or unsupported in {name}.
+        </p>
+        <div className={styles.instructions}>
+          <p className={styles.instructionsLabel}>To enable WebGL 2 in {name}:</p>
+          <ol className={styles.steps}>
+            {steps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        </div>
+        <p className={styles.fallback}>
+          If the issue persists, try updating {name} to the latest version or
+          switch to a recent version of Chrome, Firefox, or Edge.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Detects WebGL2 support synchronously on load via `canvas.getContext('webgl2')`
- If unavailable, renders a full-screen warning card instead of the editor
- Instructions are tailored to the detected browser: Chrome, Edge, Firefox, Safari, or a generic fallback
- Icon and title displayed inline on the same row

## Test plan

- [ ] E2E: `webgl2-warning.spec.ts` — Chrome instructions shown when WebGL2 stubbed out
- [ ] E2E: Firefox instructions (`about:config`, `webgl.disabled`) shown in Firefox
- [ ] E2E: Fallback copy shown for unrecognised user agents
- [ ] E2E: No warning shown when WebGL2 is available (New Document modal loads normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)