### PR TITLE
feat(slider): add inline text input for numeric values

### DIFF
--- a/src/components/Slider/Slider.module.css
+++ b/src/components/Slider/Slider.module.css
@@ -11,7 +11,7 @@
   min-width: 40px;
 }
 
-.input {
+.slider {
   flex: 1;
   -webkit-appearance: none;
   appearance: none;
@@ -22,7 +22,7 @@
   min-width: 60px;
 }
 
-.input::-webkit-slider-thumb {
+.slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 12px;
@@ -33,7 +33,7 @@
   border: none;
 }
 
-.input::-moz-range-thumb {
+.slider::-moz-range-thumb {
   width: 12px;
   height: 12px;
   border-radius: 50%;
@@ -42,10 +42,33 @@
   border: none;
 }
 
-.value {
-  font-size: var(--font-size-sm);
+.valueWrapper {
+  display: flex;
+  align-items: center;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.valueInput {
+  width: 40px;
+  padding: 1px var(--space-1);
+  background: transparent;
+  border: none;
   font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
-  min-width: 28px;
+  outline: none;
   text-align: right;
+}
+
+.valueInput:focus {
+  color: var(--color-text-primary);
+}
+
+.suffix {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  padding-right: var(--space-1);
 }

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import styles from './Slider.module.css';
 
 interface SliderProps {
@@ -9,6 +10,7 @@ interface SliderProps {
   defaultValue?: number;
   onChange: (value: number) => void;
   showValue?: boolean;
+  suffix?: string;
 }
 
 export function Slider({
@@ -20,24 +22,77 @@ export function Slider({
   defaultValue,
   onChange,
   showValue = true,
+  suffix,
 }: SliderProps) {
+  const [localValue, setLocalValue] = useState(String(value));
+  const [isFocused, setIsFocused] = useState(false);
+
   const handleDoubleClick = () => {
     onChange(defaultValue ?? min);
   };
+
+  const handleBlur = useCallback(() => {
+    setIsFocused(false);
+    const parsed = parseFloat(localValue);
+    if (isNaN(parsed)) {
+      setLocalValue(String(value));
+    } else {
+      setLocalValue(String(parsed));
+      onChange(parsed);
+    }
+  }, [localValue, value, onChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        (e.target as HTMLInputElement).blur();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const next = value + step;
+        onChange(next);
+        setLocalValue(String(next));
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = value - step;
+        onChange(next);
+        setLocalValue(String(next));
+      }
+    },
+    [value, step, onChange],
+  );
 
   return (
     <div className={styles.container} onDoubleClick={handleDoubleClick}>
       {label && <span className={styles.label}>{label}</span>}
       <input
         type="range"
-        className={styles.input}
-        value={value}
+        className={styles.slider}
+        value={Math.max(min, Math.min(max, value))}
         min={min}
         max={max}
         step={step}
         onChange={(e) => onChange(Number(e.target.value))}
       />
-      {showValue && <span className={styles.value}>{value}</span>}
+      {showValue && (
+        <div className={styles.valueWrapper}>
+          <input
+            type="text"
+            className={styles.valueInput}
+            value={isFocused ? localValue : String(value)}
+            onChange={(e) => setLocalValue(e.target.value)}
+            onFocus={(e) => {
+              setIsFocused(true);
+              setLocalValue(String(value));
+              e.target.select();
+            }}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+          />
+          {suffix && <span className={styles.suffix}>{suffix}</span>}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the static value display on Slider components with an editable text input
- Users can type any numeric value, including values outside the slider's min/max range
- Text input and slider stay in sync; supports arrow keys for increment/decrement
- Added `suffix` prop support for unit labels (e.g., "px", "%")

Closes #45

## Test plan
- [ ] Verify sliders still work with drag interaction
- [ ] Click the value text to focus and type a custom number
- [ ] Press Enter or click away to commit the value
- [ ] Arrow up/down to increment/decrement
- [ ] Double-click slider to reset to default value
- [ ] Verify values outside slider range are accepted via text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)