### PR TITLE
feat(guides): add guide color picker in ruler corner

### DIFF
--- a/src/app/App.module.css
+++ b/src/app/App.module.css
@@ -82,6 +82,18 @@
   z-index: 1;
 }
 
+.guideColorPicker {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  z-index: var(--z-popover, 100);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2);
+  box-shadow: var(--shadow-lg);
+}
+
 .sidebarArea {
   position: relative;
   flex-shrink: 0;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,6 +30,7 @@ import { useCanvasRendering } from './useCanvasRendering';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { useCanvasCursor } from './useCanvasCursor';
 import { useContextMenu } from './useContextMenu';
+import { ColorPicker } from '../components/ColorPicker/ColorPicker';
 import { ContextMenu } from '../components/ContextMenu/ContextMenu';
 import { TextActionButtons } from '../components/TextActionButtons/TextActionButtons';
 import { commitTextEditing } from './interactions/misc-handlers';
@@ -89,7 +90,10 @@ export function App() {
   const addGuide = useUIStore((s) => s.addGuide);
   const setHoveredGuide = useUIStore((s) => s.setHoveredGuide);
   const setRulerHover = useUIStore((s) => s.setRulerHover);
+  const guideColor = useUIStore((s) => s.guideColor);
+  const setGuideColor = useUIStore((s) => s.setGuideColor);
 
+  const [showGuideColorPicker, setShowGuideColorPicker] = useState(false);
   const [isPanning, setIsPanning] = useState(false);
   const [isSpaceDown, setIsSpaceDown] = useState(false);
   const panStartRef = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
@@ -340,6 +344,22 @@ export function App() {
       }
 
       const rect = containerRef.current?.getBoundingClientRect();
+      if (rect && showRulers && e.button === 0) {
+        const screenX = e.clientX - rect.left;
+        const screenY = e.clientY - rect.top;
+
+        // Click on the ruler corner swatch to toggle guide color picker
+        if (showGuides && screenX < RULER_SIZE && screenY < RULER_SIZE) {
+          setShowGuideColorPicker((prev) => !prev);
+          return;
+        }
+      }
+
+      // Close guide color picker on any click outside the corner
+      if (showGuideColorPicker) {
+        setShowGuideColorPicker(false);
+      }
+
       if (rect && showRulers && showGuides && e.button === 0) {
         const screenX = e.clientX - rect.left;
         const screenY = e.clientY - rect.top;
@@ -365,7 +385,7 @@ export function App() {
 
       handleToolDown(e);
     },
-    [isSpaceDown, viewport.panX, viewport.panY, handleToolDown, showRulers, showGuides, screenToCanvas, addGuide, setRulerHover, findGuideAtCursor],
+    [isSpaceDown, viewport.panX, viewport.panY, handleToolDown, showRulers, showGuides, screenToCanvas, addGuide, setRulerHover, findGuideAtCursor, showGuideColorPicker],
   );
 
   const handleMouseUp = useCallback((e: React.MouseEvent) => {
@@ -474,6 +494,18 @@ export function App() {
         >
           <canvas ref={canvasRef} />
           <canvas ref={overlayCanvasRef} className={styles.overlayCanvas} />
+          {showGuideColorPicker && showRulers && showGuides && (
+            <div
+              className={styles.guideColorPicker}
+              onMouseDown={(e) => e.stopPropagation()}
+              onMouseUp={(e) => e.stopPropagation()}
+            >
+              <ColorPicker
+                color={guideColor}
+                onChange={setGuideColor}
+              />
+            </div>
+          )}
           <TextActionButtons containerRef={containerRef} />
           <CanvasRenderer canvasRef={canvasRef} containerRef={containerRef} overlayCanvasRef={overlayCanvasRef} />
         </div>

--- a/src/app/rendering/render-grid.ts
+++ b/src/app/rendering/render-grid.ts
@@ -1,10 +1,9 @@
-import type { Point } from '../../types';
+import type { Color, Point } from '../../types';
 
 const RULER_SIZE = 20;
 const RULER_BG = '#2a2a2a';
 const RULER_TEXT = '#888888';
 const RULER_TICK = '#555555';
-const RULER_INDICATOR = '#4a9eff';
 
 export function renderRulers(
   ctx: CanvasRenderingContext2D,
@@ -14,7 +13,11 @@ export function renderRulers(
   docWidth: number,
   docHeight: number,
   cursorPosition: Point,
+  guideColor?: Color,
 ): void {
+  const indicatorColor = guideColor
+    ? `rgb(${guideColor.r}, ${guideColor.g}, ${guideColor.b})`
+    : '#4a9eff';
   const { panX, panY, zoom } = viewport;
   const originX = panX + canvasWidth / 2 - (docWidth / 2) * zoom;
   const originY = panY + canvasHeight / 2 - (docHeight / 2) * zoom;
@@ -101,7 +104,7 @@ export function renderRulers(
   const cursorScreenX = originX + cursorPosition.x * zoom;
   const cursorScreenY = originY + cursorPosition.y * zoom;
 
-  ctx.strokeStyle = RULER_INDICATOR;
+  ctx.strokeStyle = indicatorColor;
   ctx.lineWidth = 1;
 
   // Horizontal indicator

--- a/src/app/rendering/render-guides.ts
+++ b/src/app/rendering/render-guides.ts
@@ -1,14 +1,16 @@
 import type { Guide, RulerHover } from '../ui-store';
+import type { Color } from '../../types';
 
 const RULER_SIZE = 20;
-const GUIDE_COLOR = 'rgba(0, 180, 255, 0.7)';
-const GUIDE_ACTIVE_COLOR = 'rgba(0, 220, 255, 1)';
 const PLAYHEAD_HOVER_COLOR = 'rgba(255, 255, 255, 0.9)';
 const PLAYHEAD_SELECTED_COLOR = 'rgba(255, 255, 255, 1)';
-const PLAYHEAD_COLOR = 'rgba(0, 180, 255, 0.9)';
 const TOOLTIP_BG = 'rgba(0, 0, 0, 0.8)';
 const TOOLTIP_TEXT = '#ffffff';
 const PLAYHEAD_SIZE = 6;
+
+function colorToRgba(c: Color, alpha: number): string {
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${alpha})`;
+}
 
 /**
  * Render guide lines on the canvas in document-space.
@@ -21,10 +23,14 @@ export function renderGuides(
   docWidth: number,
   docHeight: number,
   zoom: number,
+  guideColor: Color,
 ): void {
+  const baseColor = colorToRgba(guideColor, 0.7);
+  const activeColor = colorToRgba(guideColor, 1);
+
   for (const guide of guides) {
     const isSelected = guide.id === selectedGuideId;
-    ctx.strokeStyle = isSelected ? GUIDE_ACTIVE_COLOR : GUIDE_COLOR;
+    ctx.strokeStyle = isSelected ? activeColor : baseColor;
     ctx.lineWidth = 1 / zoom;
     ctx.setLineDash([]);
     ctx.beginPath();
@@ -49,8 +55,9 @@ export function renderGuidePreview(
   docWidth: number,
   docHeight: number,
   zoom: number,
+  guideColor: Color,
 ): void {
-  ctx.strokeStyle = PLAYHEAD_COLOR;
+  ctx.strokeStyle = colorToRgba(guideColor, 0.9);
   ctx.lineWidth = 1 / zoom;
   ctx.setLineDash([4 / zoom, 4 / zoom]);
   ctx.beginPath();
@@ -80,16 +87,18 @@ export function renderGuideRulerOverlays(
   viewport: { panX: number; panY: number; zoom: number },
   docWidth: number,
   docHeight: number,
+  guideColor: Color,
 ): void {
   const { panX, panY, zoom } = viewport;
   const originX = panX + canvasWidth / 2 - (docWidth / 2) * zoom;
   const originY = panY + canvasHeight / 2 - (docHeight / 2) * zoom;
+  const baseColor = colorToRgba(guideColor, 0.7);
 
   // Draw playhead triangles on rulers for placed guides
   for (const guide of guides) {
     const isSelected = guide.id === selectedGuideId;
     const isHovered = guide.id === hoveredGuideId;
-    ctx.fillStyle = isSelected ? PLAYHEAD_SELECTED_COLOR : isHovered ? PLAYHEAD_HOVER_COLOR : GUIDE_COLOR;
+    ctx.fillStyle = isSelected ? PLAYHEAD_SELECTED_COLOR : isHovered ? PLAYHEAD_HOVER_COLOR : baseColor;
 
     if (guide.orientation === 'vertical') {
       const screenX = originX + guide.position * zoom;
@@ -116,7 +125,7 @@ export function renderGuideRulerOverlays(
 
   // Draw hover playhead + tooltip (skip if hovering an existing guide)
   if (rulerHover && !hoveredGuideId) {
-    ctx.fillStyle = PLAYHEAD_COLOR;
+    ctx.fillStyle = colorToRgba(guideColor, 0.9);
 
     if (rulerHover.orientation === 'vertical') {
       const screenX = originX + rulerHover.position * zoom;
@@ -148,6 +157,28 @@ export function renderGuideRulerOverlays(
       }
     }
   }
+}
+
+/**
+ * Render a color swatch in the ruler corner (where horizontal and vertical rulers meet).
+ */
+export function renderGuideColorSwatch(
+  ctx: CanvasRenderingContext2D,
+  guideColor: Color,
+): void {
+  const padding = 3;
+  const size = RULER_SIZE - padding * 2;
+
+  ctx.fillStyle = colorToRgba(guideColor, 1);
+  ctx.beginPath();
+  ctx.roundRect(padding, padding, size, size, 2);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.roundRect(padding, padding, size, size, 2);
+  ctx.stroke();
 }
 
 function drawTooltip(

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -56,6 +56,7 @@ interface UIState {
   showGuides: boolean;
   snapToGrid: boolean;
   gridSize: number;
+  guideColor: Color;
   sidebarCollapsed: boolean;
   pathAnchors: PathAnchor[];
   pathClosed: boolean;
@@ -86,6 +87,7 @@ interface UIState {
   toggleGuides: () => void;
   toggleSnapToGrid: () => void;
   setGridSize: (size: number) => void;
+  setGuideColor: (color: Color) => void;
   toggleSidebar: () => void;
   addPathAnchor: (anchor: PathAnchor) => void;
   updateLastPathAnchor: (anchor: PathAnchor) => void;
@@ -138,6 +140,7 @@ export const useUIStore = create<UIState>((set) => ({
   showGuides: true,
   snapToGrid: false,
   gridSize: 16,
+  guideColor: { r: 0, g: 180, b: 255, a: 1 },
   sidebarCollapsed: false,
   pathAnchors: [],
   pathClosed: false,
@@ -217,6 +220,7 @@ export const useUIStore = create<UIState>((set) => ({
   toggleGuides: () => set((state) => ({ showGuides: !state.showGuides })),
   toggleSnapToGrid: () => set((state) => ({ snapToGrid: !state.snapToGrid })),
   setGridSize: (size) => set({ gridSize: size }),
+  setGuideColor: (color) => set({ guideColor: color }),
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
   addPathAnchor: (anchor) => set((state) => ({ pathAnchors: [...state.pathAnchors, anchor] })),
   updateLastPathAnchor: (anchor) =>

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -26,7 +26,7 @@ import { renderTextDragOverlay, renderTextEditOverlay } from './rendering/render
 import { renderTextToCanvas } from '../tools/text/text';
 import type { TextStyle } from '../tools/text/text';
 import { uploadLayerPixels } from '../engine-wasm/wasm-bridge';
-import { renderGuides, renderGuidePreview, renderGuideRulerOverlays } from './rendering/render-guides';
+import { renderGuides, renderGuidePreview, renderGuideRulerOverlays, renderGuideColorSwatch } from './rendering/render-guides';
 import { contextOptions } from '../engine/color-space';
 import { clearFrameCache } from '../engine-wasm/gpu-pixel-access';
 import { getActiveMaskEditBuffer } from './interactions/mask-buffer';
@@ -85,6 +85,7 @@ function renderFrameGpu(
   const selectedGuideId = uiState.selectedGuideId;
   const hoveredGuideId = uiState.hoveredGuideId;
   const rulerHover = uiState.rulerHover;
+  const guideColor = uiState.guideColor;
 
   // Live-update text layer pixels during editing so the GPU preview
   // matches the committed result exactly (same pipeline).
@@ -197,18 +198,19 @@ function renderFrameGpu(
     }
 
     if (showGuides) {
-      renderGuides(overlayCtx, guides, selectedGuideId, doc.width, doc.height, viewport.zoom);
+      renderGuides(overlayCtx, guides, selectedGuideId, doc.width, doc.height, viewport.zoom, guideColor);
       if (rulerHover && !hoveredGuideId) {
-        renderGuidePreview(overlayCtx, rulerHover, doc.width, doc.height, viewport.zoom);
+        renderGuidePreview(overlayCtx, rulerHover, doc.width, doc.height, viewport.zoom, guideColor);
       }
     }
 
     overlayCtx.restore();
 
     if (showRulers) {
-      renderRulers(overlayCtx, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height, cursorPosition);
+      renderRulers(overlayCtx, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height, cursorPosition, guideColor);
       if (showGuides) {
-        renderGuideRulerOverlays(overlayCtx, guides, selectedGuideId, hoveredGuideId, rulerHover, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height);
+        renderGuideRulerOverlays(overlayCtx, guides, selectedGuideId, hoveredGuideId, rulerHover, overlayCanvas.width, overlayCanvas.height, viewport, doc.width, doc.height, guideColor);
+        renderGuideColorSwatch(overlayCtx, guideColor);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds a color swatch in the corner where horizontal and vertical rulers meet
- Clicking the swatch opens a color picker to change the guide color
- Guide color applies to: guide lines, playhead indicators, ruler cursor indicators, and guide previews
- Guide color state is stored in the UI store and defaults to the existing blue (#00b4ff)

Closes #43

## Test plan
- [ ] Verify color swatch appears in the ruler corner when rulers and guides are visible
- [ ] Click the swatch to open color picker
- [ ] Change the color and verify all guide UI elements update
- [ ] Verify clicking outside the picker closes it
- [ ] Verify rulers still function normally (guide placement, hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)