### PR TITLE
feat(layers): add layer groups with collapsible tree UI

### DIFF
--- a/src/app/store/actions/add-layer.ts
+++ b/src/app/store/actions/add-layer.ts
@@ -1,6 +1,7 @@
 import type { DocumentState } from '../../../types';
 import type { EditorState } from '../types';
 import { createRasterLayer } from '../../../layers/layer-model';
+import { findParentGroup, isGroupLayer } from '../../../layers/group-utils';
 
 export function computeAddLayer(
   doc: DocumentState,
@@ -10,12 +11,37 @@ export function computeAddLayer(
     width: doc.width,
     height: doc.height,
   });
-  // Pixel data is allocated lazily by getOrCreateLayerPixelData when
-  // a tool first writes to the layer — avoids 48MB per empty layer on 4K.
+
+  let layers = [...doc.layers, newLayer];
+
+  // Add the new layer to the active layer's parent group, or the root group
+  const activeId = doc.activeLayerId;
+  let targetGroupId: string | null = null;
+  if (activeId) {
+    const parent = findParentGroup(doc.layers, activeId);
+    if (parent) {
+      targetGroupId = parent.id;
+    } else if (activeId && isGroupLayer(doc.layers.find((l) => l.id === activeId)!)) {
+      targetGroupId = activeId;
+    }
+  }
+  if (!targetGroupId && doc.rootGroupId) {
+    targetGroupId = doc.rootGroupId;
+  }
+
+  if (targetGroupId) {
+    layers = layers.map((l) => {
+      if (l.id === targetGroupId && isGroupLayer(l)) {
+        return { ...l, children: [...l.children, newLayer.id] };
+      }
+      return l;
+    });
+  }
+
   return {
     document: {
       ...doc,
-      layers: [...doc.layers, newLayer],
+      layers,
       layerOrder: [...doc.layerOrder, newLayer.id],
       activeLayerId: newLayer.id,
     },

--- a/src/app/store/actions/create-document.test.ts
+++ b/src/app/store/actions/create-document.test.ts
@@ -8,9 +8,10 @@ describe('computeCreateDocument', () => {
     const result = computeCreateDocument(800, 600, false);
     expect(result.document?.width).toBe(800);
     expect(result.document?.height).toBe(600);
-    expect(result.document?.layers).toHaveLength(2);
-    expect(result.document?.layerOrder).toHaveLength(2);
+    expect(result.document?.layers).toHaveLength(3); // bg + draw layer + root group
+    expect(result.document?.layerOrder).toHaveLength(3);
     expect(result.document?.activeLayerId).toBe(result.document?.layers[1]?.id);
+    expect(result.document?.rootGroupId).toBeTruthy();
   });
 
   it('creates white-filled pixel data for non-transparent background', () => {

--- a/src/app/store/actions/create-document.ts
+++ b/src/app/store/actions/create-document.ts
@@ -1,5 +1,6 @@
+import type { Layer } from '../../../types';
 import type { EditorState, SelectionData } from '../types';
-import { createRasterLayer } from '../../../layers/layer-model';
+import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
 import { createImageData } from '../../../engine/color-space';
 
 export function computeCreateDocument(
@@ -23,7 +24,8 @@ export function computeCreateDocument(
   }
   pixelData.set(bgLayer.id, imgData);
 
-  const layers = [bgLayer];
+  const childIds = [bgLayer.id];
+  const layers: Layer[] = [bgLayer];
   const layerOrder = [bgLayer.id];
   let activeLayerId = bgLayer.id;
 
@@ -31,8 +33,13 @@ export function computeCreateDocument(
     const drawLayer = createRasterLayer({ name: 'Layer 1', width, height });
     layers.push(drawLayer);
     layerOrder.push(drawLayer.id);
+    childIds.push(drawLayer.id);
     activeLayerId = drawLayer.id;
   }
+
+  const rootGroup = createGroupLayer({ name: 'Project', children: childIds });
+  layers.push(rootGroup);
+  layerOrder.push(rootGroup.id);
 
   const selection: SelectionData = { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 };
   return {
@@ -45,6 +52,7 @@ export function computeCreateDocument(
       layerOrder,
       activeLayerId,
       backgroundColor: bgColor,
+      rootGroupId: rootGroup.id,
     },
     layerPixelData: pixelData,
     sparseLayerData: new Map(),

--- a/src/app/store/actions/open-image.ts
+++ b/src/app/store/actions/open-image.ts
@@ -1,11 +1,12 @@
 import type { EditorState, SelectionData } from '../types';
-import { createRasterLayer } from '../../../layers/layer-model';
+import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
 
 export function computeOpenImage(
   imageData: ImageData,
   name: string,
 ): Partial<EditorState> {
   const layer = createRasterLayer({ name: 'Background', width: imageData.width, height: imageData.height });
+  const rootGroup = createGroupLayer({ name: 'Project', children: [layer.id] });
   const pixelData = new Map<string, ImageData>();
   pixelData.set(layer.id, imageData);
   const selection: SelectionData = { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 };
@@ -15,10 +16,11 @@ export function computeOpenImage(
       name,
       width: imageData.width,
       height: imageData.height,
-      layers: [layer],
-      layerOrder: [layer.id],
+      layers: [layer, rootGroup],
+      layerOrder: [layer.id, rootGroup.id],
       activeLayerId: layer.id,
       backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+      rootGroupId: rootGroup.id,
     },
     layerPixelData: pixelData,
     sparseLayerData: new Map(),

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -1,6 +1,7 @@
 import type { BlendMode, LayerEffects, Layer, Rect } from '../../types';
 import type { AlignEdge } from '../../tools/move/move';
-import { createRasterLayer } from '../../layers/layer-model';
+import { createRasterLayer, createGroupLayer } from '../../layers/layer-model';
+import { moveLayerToGroup as moveLayerToGroupUtil } from '../../layers/group-utils';
 import { sparseToImageData } from '../../engine/canvas-ops';
 import { readLayerAsImageData } from '../../engine-wasm/gpu-pixel-access';
 import { getEngine } from '../../engine-wasm/engine-state';
@@ -85,15 +86,17 @@ function syncPixelDataToGpu(
 
 function createInitialDocument() {
   const bg = createRasterLayer({ name: 'Background', width: 800, height: 600 });
+  const rootGroup = createGroupLayer({ name: 'Project', children: [bg.id] });
   return {
     id: crypto.randomUUID(),
     name: 'Untitled' as const,
     width: 800,
     height: 600,
-    layers: [bg],
-    layerOrder: [bg.id],
-    activeLayerId: bg.id,
+    layers: [bg, rootGroup] as readonly Layer[],
+    layerOrder: [bg.id, rootGroup.id] as readonly string[],
+    activeLayerId: bg.id as string | null,
     backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+    rootGroupId: rootGroup.id as string | null,
   };
 }
 
@@ -110,6 +113,9 @@ export interface DocumentSlice {
   toggleLayerVisibility: (id: string) => void;
   toggleLayerLock: (id: string) => void;
   renameLayer: (id: string, name: string) => void;
+  addGroup: (name?: string) => void;
+  toggleGroupCollapsed: (groupId: string) => void;
+  moveLayerToGroup: (layerId: string, targetGroupId: string, insertIndex?: number) => void;
   updateLayerOpacity: (id: string, opacity: number) => void;
   updateLayerBlendMode: (id: string, blendMode: BlendMode) => void;
   moveLayer: (fromIndex: number, toIndex: number) => void;
@@ -203,6 +209,41 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       l.id === id ? { ...l, name } : l,
     );
     set({ document: { ...doc, layers } });
+  },
+
+  addGroup: (name) => {
+    const doc = get().document;
+    const group = createGroupLayer({ name: name ?? 'Group' });
+    const layers = [...doc.layers, group];
+    const layerOrder = [...doc.layerOrder, group.id];
+    // Add to root group if it exists
+    const rootId = doc.rootGroupId;
+    const finalLayers = rootId
+      ? layers.map((l) =>
+          l.id === rootId && l.type === 'group'
+            ? { ...l, children: [...l.children, group.id] }
+            : l,
+        )
+      : layers;
+    set({
+      document: { ...doc, layers: finalLayers, layerOrder, activeLayerId: group.id },
+    });
+  },
+
+  toggleGroupCollapsed: (groupId) => {
+    const doc = get().document;
+    const layers = doc.layers.map((l) =>
+      l.id === groupId && l.type === 'group'
+        ? { ...l, collapsed: !('collapsed' in l && l.collapsed) }
+        : l,
+    );
+    set({ document: { ...doc, layers } });
+  },
+
+  moveLayerToGroup: (layerId, targetGroupId, insertIndex) => {
+    const doc = get().document;
+    const newLayers = moveLayerToGroupUtil(doc.layers, layerId, targetGroupId, insertIndex);
+    set({ document: { ...doc, layers: newLayers } });
   },
 
   updateLayerOpacity: (id, opacity) => {

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -83,6 +83,9 @@ export interface EditorState {
   toggleLayerVisibility: (id: string) => void;
   toggleLayerLock: (id: string) => void;
   renameLayer: (id: string, name: string) => void;
+  addGroup: (name?: string) => void;
+  toggleGroupCollapsed: (groupId: string) => void;
+  moveLayerToGroup: (layerId: string, targetGroupId: string, insertIndex?: number) => void;
   updateLayerOpacity: (id: string, opacity: number) => void;
   updateLayerBlendMode: (id: string, blendMode: BlendMode) => void;
   moveLayer: (fromIndex: number, toIndex: number) => void;

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -173,6 +173,10 @@ function layerToDescJson(layer: Layer): string {
     } : null,
   };
 
+  if (layer.type === 'group' && 'children' in layer) {
+    desc.children = layer.children;
+  }
+
   return JSON.stringify(desc);
 }
 

--- a/src/layers/group-utils.ts
+++ b/src/layers/group-utils.ts
@@ -1,0 +1,164 @@
+import type { Layer, GroupLayer } from '../types';
+
+export interface LayerTreeNode {
+  layer: Layer;
+  depth: number;
+  children: LayerTreeNode[];
+}
+
+export function isGroupLayer(layer: Layer): layer is GroupLayer {
+  return layer.type === 'group';
+}
+
+export function findParentGroup(
+  layers: readonly Layer[],
+  layerId: string,
+): GroupLayer | null {
+  for (const layer of layers) {
+    if (isGroupLayer(layer) && layer.children.includes(layerId)) {
+      return layer;
+    }
+  }
+  return null;
+}
+
+export function getLayerDepth(
+  layers: readonly Layer[],
+  layerId: string,
+): number {
+  let depth = 0;
+  let current = layerId;
+  for (;;) {
+    const parent = findParentGroup(layers, current);
+    if (!parent) break;
+    depth++;
+    current = parent.id;
+  }
+  return depth;
+}
+
+export function getDescendantIds(
+  layers: readonly Layer[],
+  groupId: string,
+): string[] {
+  const group = layers.find((l) => l.id === groupId);
+  if (!group || !isGroupLayer(group)) return [];
+
+  const result: string[] = [];
+  for (const childId of group.children) {
+    result.push(childId);
+    result.push(...getDescendantIds(layers, childId));
+  }
+  return result;
+}
+
+export function isAncestorOf(
+  layers: readonly Layer[],
+  potentialAncestorId: string,
+  layerId: string,
+): boolean {
+  let current = layerId;
+  for (;;) {
+    const parent = findParentGroup(layers, current);
+    if (!parent) return false;
+    if (parent.id === potentialAncestorId) return true;
+    current = parent.id;
+  }
+}
+
+export function canMoveToGroup(
+  layers: readonly Layer[],
+  layerId: string,
+  targetGroupId: string,
+): boolean {
+  if (layerId === targetGroupId) return false;
+  if (isAncestorOf(layers, layerId, targetGroupId)) return false;
+  return true;
+}
+
+/**
+ * Build a flat display list from the layer tree, with depth info.
+ * Respects collapsed groups by skipping their children.
+ * Returns layers in display order (top to bottom = reversed layerOrder).
+ */
+export function buildFlatDisplayList(
+  layers: readonly Layer[],
+  layerOrder: readonly string[],
+): { layer: Layer; depth: number }[] {
+  const layerMap = new Map(layers.map((l) => [l.id, l]));
+
+  const result: { layer: Layer; depth: number }[] = [];
+
+  // Walk layerOrder in reverse (top to bottom display)
+  const reversed = [...layerOrder].reverse();
+  for (const id of reversed) {
+    const layer = layerMap.get(id);
+    if (!layer) continue;
+
+    const depth = getLayerDepth(layers, id);
+
+    // Check if any ancestor is collapsed
+    let hidden = false;
+    let current = id;
+    for (;;) {
+      const parent = findParentGroup(layers, current);
+      if (!parent) break;
+      if (isGroupLayer(parent) && parent.collapsed) {
+        hidden = true;
+        break;
+      }
+      current = parent.id;
+    }
+
+    if (!hidden) {
+      result.push({ layer, depth });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Move a layer into a group, updating all group children arrays.
+ * Returns new layers array.
+ */
+export function moveLayerToGroup(
+  layers: readonly Layer[],
+  layerId: string,
+  targetGroupId: string,
+  insertIndex?: number,
+): Layer[] {
+  if (!canMoveToGroup(layers, layerId, targetGroupId)) return [...layers];
+
+  return layers.map((l) => {
+    if (isGroupLayer(l)) {
+      // Remove from old parent
+      if (l.children.includes(layerId)) {
+        return { ...l, children: l.children.filter((c) => c !== layerId) };
+      }
+      // Add to new parent
+      if (l.id === targetGroupId) {
+        const newChildren = [...l.children];
+        const idx = insertIndex !== undefined ? insertIndex : newChildren.length;
+        newChildren.splice(idx, 0, layerId);
+        return { ...l, children: newChildren };
+      }
+    }
+    return l;
+  });
+}
+
+/**
+ * Remove a layer from its parent group's children.
+ */
+export function removeFromParentGroup(
+  layers: readonly Layer[],
+  layerId: string,
+): Layer[] {
+  return layers.map((l) => {
+    if (isGroupLayer(l) && l.children.includes(layerId)) {
+      return { ...l, children: l.children.filter((c) => c !== layerId) };
+    }
+    return l;
+  });
+}

--- a/src/layers/layer-model.ts
+++ b/src/layers/layer-model.ts
@@ -64,7 +64,7 @@ export function createTextLayer(params: {
   };
 }
 
-export function createGroupLayer(params: { name: string }): GroupLayer {
+export function createGroupLayer(params: { name: string; children?: string[] }): GroupLayer {
   return {
     id: crypto.randomUUID(),
     name: params.name,
@@ -78,7 +78,8 @@ export function createGroupLayer(params: { name: string }): GroupLayer {
     clipToBelow: false,
     effects: DEFAULT_EFFECTS,
     mask: null,
-    children: [],
+    children: params.children ?? [],
+    collapsed: false,
   };
 }
 

--- a/src/panels/LayerPanel/LayerPanel.module.css
+++ b/src/panels/LayerPanel/LayerPanel.module.css
@@ -134,6 +134,39 @@
   color: var(--color-accent);
 }
 
+.groupRow {
+  background: var(--color-bg-secondary);
+}
+
+.rootGroup {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.collapseBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.collapseBtn:hover {
+  background: var(--color-bg-active);
+  color: var(--color-text-primary);
+}
+
+.folderIcon {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
 .effectsBtn {
   display: flex;
   align-items: center;

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef, useState } from 'react';
-import { Eye, EyeOff, GripVertical, Lock, Plus, RectangleCircle, Sparkles, SquareDashed, Trash2, Unlock, X } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ChevronDown, ChevronRight, Eye, EyeOff, Folder, FolderPlus, GripVertical, Lock, Plus, RectangleCircle, Sparkles, SquareDashed, Trash2, Unlock, X } from 'lucide-react';
 import { IconButton } from '../../components/IconButton/IconButton';
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
@@ -7,6 +7,7 @@ import type { Layer } from '../../types';
 import { LayerThumbnail } from './LayerThumbnail';
 import { MaskThumbnail } from './MaskThumbnail';
 import { selectLayerAlpha, convertMaskToMarquee } from './layer-selection';
+import { buildFlatDisplayList, isGroupLayer } from '../../layers/group-utils';
 import styles from './LayerPanel.module.css';
 
 interface LayerPanelProps {
@@ -36,6 +37,10 @@ export function LayerPanel({
   const removeLayerMask = useEditorStore((s) => s.removeLayerMask);
   const toggleLayerLock = useEditorStore((s) => s.toggleLayerLock);
   const renameLayer = useEditorStore((s) => s.renameLayer);
+  const addGroup = useEditorStore((s) => s.addGroup);
+  const toggleGroupCollapsed = useEditorStore((s) => s.toggleGroupCollapsed);
+  const rootGroupId = useEditorStore((s) => s.document.rootGroupId);
+  const layerOrder = useEditorStore((s) => s.document.layerOrder);
   const maskEditMode = useUIStore((s) => s.maskEditMode);
   const setMaskEditMode = useUIStore((s) => s.setMaskEditMode);
   const showEffectsDrawer = useUIStore((s) => s.showEffectsDrawer);
@@ -53,7 +58,11 @@ export function LayerPanel({
     convertMaskToMarquee(layerId);
   }, []);
 
-  const reversedLayers = [...layers].reverse();
+  const displayList = useMemo(
+    () => buildFlatDisplayList(layers, layerOrder),
+    [layers, layerOrder],
+  );
+
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dropGap, setDropGap] = useState<number | null>(null);
   const [editingOpacityId, setEditingOpacityId] = useState<string | null>(null);
@@ -103,41 +112,64 @@ export function LayerPanel({
     document.addEventListener('pointerup', onUp);
   }, [layers.length, onReorderLayer]);
 
+  const isRootGroup = (layerId: string) => layerId === rootGroupId;
+
   return (
     <div className={styles.panel}>
       <div
         ref={listRef}
         className={collapsed ? styles.listCollapsed : styles.list}
       >
-        {reversedLayers.map((layer, ri) => (
+        {displayList.map(({ layer, depth }, ri) => (
           <div key={layer.id} className={styles.itemWrapper}>
             <div
               className={[
                 styles.item,
                 layer.id === activeLayerId ? styles.active : '',
                 layer.locked ? styles.locked : '',
+                isGroupLayer(layer) ? styles.groupRow : '',
+                isRootGroup(layer.id) ? styles.rootGroup : '',
                 dragIndex === ri ? styles.dragging : '',
                 dragIndex !== null && dropGap === ri && dropGap !== dragIndex && dropGap !== dragIndex + 1
                   ? styles.dropTarget : '',
-                dragIndex !== null && dropGap === reversedLayers.length && ri === reversedLayers.length - 1 && dropGap !== dragIndex + 1
+                dragIndex !== null && dropGap === displayList.length && ri === displayList.length - 1 && dropGap !== dragIndex + 1
                   ? styles.dropTargetEnd : '',
               ]
                 .filter(Boolean)
                 .join(' ')}
+              style={{ paddingLeft: `calc(${depth * 16}px + var(--space-2))` }}
               onClick={() => onSelectLayer(layer.id)}
             >
-              <span
-                className={styles.dragHandle}
-                onPointerDown={(e) => handleGripDown(e, ri)}
-              >
-                <GripVertical size={12} />
-              </span>
-              <div
-                className={styles.thumbnail}
-                onClick={(e) => handleThumbnailCmdClick(e, layer.id)}
-              >
-                <LayerThumbnail layer={layer} />
-              </div>
+              {!isRootGroup(layer.id) && (
+                <span
+                  className={styles.dragHandle}
+                  onPointerDown={(e) => handleGripDown(e, ri)}
+                >
+                  <GripVertical size={12} />
+                </span>
+              )}
+              {isGroupLayer(layer) ? (
+                <button
+                  className={styles.collapseBtn}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleGroupCollapsed(layer.id);
+                  }}
+                  type="button"
+                >
+                  {layer.collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                </button>
+              ) : (
+                <div
+                  className={styles.thumbnail}
+                  onClick={(e) => handleThumbnailCmdClick(e, layer.id)}
+                >
+                  <LayerThumbnail layer={layer} />
+                </div>
+              )}
+              {isGroupLayer(layer) && (
+                <Folder size={14} className={styles.folderIcon} />
+              )}
               {renamingLayerId === layer.id ? (
                 <input
                   className={styles.nameInput}
@@ -171,22 +203,24 @@ export function LayerPanel({
                   {layer.name}
                 </span>
               )}
-              <button
-                className={`${styles.effectsBtn} ${showEffectsDrawer && layer.id === activeLayerId ? styles.effectsBtnActive : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (showEffectsDrawer && layer.id === activeLayerId) {
-                    setShowEffectsDrawer(false);
-                  } else {
-                    onSelectLayer(layer.id);
-                    setShowEffectsDrawer(true);
-                  }
-                }}
-                type="button"
-                title="Layer effects"
-              >
-                <Sparkles size={12} />
-              </button>
+              {!isGroupLayer(layer) && (
+                <button
+                  className={`${styles.effectsBtn} ${showEffectsDrawer && layer.id === activeLayerId ? styles.effectsBtnActive : ''}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (showEffectsDrawer && layer.id === activeLayerId) {
+                      setShowEffectsDrawer(false);
+                    } else {
+                      onSelectLayer(layer.id);
+                      setShowEffectsDrawer(true);
+                    }
+                  }}
+                  type="button"
+                  title="Layer effects"
+                >
+                  <Sparkles size={12} />
+                </button>
+              )}
               <span
                 className={styles.opacity}
                 onClick={(e) => {
@@ -285,12 +319,17 @@ export function LayerPanel({
           onClick={onAddLayer}
         />
         <IconButton
+          icon={<FolderPlus size={16} />}
+          label="New Group"
+          onClick={() => addGroup()}
+        />
+        <IconButton
           icon={<Trash2 size={16} />}
           label="Delete Layer"
           onClick={() => {
-            if (activeLayerId) onRemoveLayer(activeLayerId);
+            if (activeLayerId && !isRootGroup(activeLayerId)) onRemoveLayer(activeLayerId);
           }}
-          disabled={layers.length <= 1}
+          disabled={layers.length <= 1 || (activeLayerId !== null && isRootGroup(activeLayerId))}
         />
         {activeLayerId && (() => {
           const activeLayer = layers.find((l) => l.id === activeLayerId);

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -11,6 +11,7 @@ export interface DocumentState {
   readonly layerOrder: readonly string[]; // bottom to top
   readonly activeLayerId: string | null;
   readonly backgroundColor: Color;
+  readonly rootGroupId?: string | null;
 }
 
 export interface ViewportState {

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -54,6 +54,7 @@ export interface ShapeLayer extends LayerBase {
 export interface GroupLayer extends LayerBase {
   readonly type: 'group';
   readonly children: readonly string[]; // layer IDs
+  readonly collapsed: boolean;
 }
 
 export type Layer = RasterLayer | TextLayer | ShapeLayer | GroupLayer;


### PR DESCRIPTION
## Summary
- Root "Project" group created automatically with every new document
- Groups display as collapsible tree in the Layers panel with depth-based indentation
- Folder icon and chevron collapse/expand toggle for group layers
- "New Group" button (FolderPlus) in the toolbar
- Groups can contain layers and other groups (nested)
- New layers automatically added into the parent group of the active layer
- Root group cannot be deleted
- Engine sync passes group children data to the WASM compositor
- `group-utils.ts` with tree traversal utilities

Partial #42

## Test plan
- [ ] Create a new document — verify "Project" root group appears at top of layer list
- [ ] Click the chevron on a group to collapse/expand it
- [ ] Click "New Group" button to create a group
- [ ] Verify new layers are added inside the current group
- [ ] Verify root group cannot be deleted
- [ ] Verify indentation increases for nested layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)