### PR TITLE
fix: correct Int32Array type to Uint32Array in gpu-pixel-access

### DIFF
--- a/src/engine-wasm/gpu-pixel-access.ts
+++ b/src/engine-wasm/gpu-pixel-access.ts
@@ -32,7 +32,7 @@ export function readLayerAsImageData(layerId: string): ImageData | null {
   const cached = frameCache.get(layerId);
   if (cached !== undefined) return cached;
 
-  let dims: Int32Array | undefined;
+  let dims: Uint32Array | undefined;
   try {
     dims = getLayerTextureDimensions(currentEngine, layerId);
   } catch {


### PR DESCRIPTION
## Summary
- `getLayerTextureDimensions` returns `Uint32Array` but the local variable in `gpu-pixel-access.ts` was typed as `Int32Array`, causing a TypeScript build error.
- Changed the type annotation to `Uint32Array` to match the actual return type.

## Test plan
- [x] `tsc --noEmit` passes cleanly
- [x] E2E tests (`brush-soft-overlap`, `transform-stray-pixels`) pass on Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)