### PR TITLE
fix(wasm): prevent double-initialization race condition

### DIFF
--- a/src/engine-wasm/engine-state.ts
+++ b/src/engine-wasm/engine-state.ts
@@ -43,7 +43,7 @@ export async function initEngine(canvas: HTMLCanvasElement): Promise<Engine> {
   const w = window as unknown as Record<string, unknown>;
   w.__engineState = { getEngine };
   // Dynamically import wasm-bridge to expose getLayerTextureDimensions
-  import('./wasm-bridge').then((mod) => { w.__wasmBridge = mod; });
+  import('./wasm-bridge').then((mod) => { w.__wasmBridge = mod; }).catch(() => {});
 
   return engine;
 }

--- a/src/engine-wasm/wasm-bridge.ts
+++ b/src/engine-wasm/wasm-bridge.ts
@@ -151,12 +151,13 @@ import init, {
 
 export type { Engine };
 
-let isInitialized = false;
+let initPromise: Promise<void> | null = null;
 
 export async function initWasm(): Promise<void> {
-  if (isInitialized) return;
-  await init();
-  isInitialized = true;
+  if (!initPromise) {
+    initPromise = init().then(() => {});
+  }
+  await initPromise;
 }
 
 // Re-export everything with the same names


### PR DESCRIPTION
## Summary
- Replace boolean flag with cached promise pattern in `initWasm()` — concurrent callers now share the same init promise instead of racing
- Add `.catch()` to unhandled dynamic import in `engine-state.ts`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test` — 738 passed, 4 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)