### PR TITLE
fix: add buffer bounds check, deduplicate color utils

### DIFF
--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -4,6 +4,7 @@ import type { TransformHandle, TransformState } from '../tools/transform/transfo
 import { useToolSettingsStore } from './tool-settings-store';
 import { DEFAULT_ADJUSTMENTS } from '../filters/image-adjustments';
 import type { ImageAdjustments } from '../filters/image-adjustments';
+import { colorEquals } from '../utils/color';
 
 export interface TextEditingState {
   layerId: string;
@@ -41,10 +42,6 @@ export interface RulerHover {
 }
 
 const MAX_RECENT_COLORS = 20;
-
-function colorsEqual(a: Color, b: Color): boolean {
-  return a.r === b.r && a.g === b.g && a.b === b.b && a.a === b.a;
-}
 
 interface UIState {
   activeTool: ToolId;
@@ -178,7 +175,7 @@ export const useUIStore = create<UIState>((set) => ({
 
   addRecentColor: (color) =>
     set((state) => {
-      const filtered = state.recentColors.filter((c) => !colorsEqual(c, color));
+      const filtered = state.recentColors.filter((c) => !colorEquals(c, color));
       return { recentColors: [color, ...filtered].slice(0, MAX_RECENT_COLORS) };
     }),
 

--- a/src/engine-wasm/gpu-pixel-access.ts
+++ b/src/engine-wasm/gpu-pixel-access.ts
@@ -96,6 +96,9 @@ export function readLayerThumbnail(layerId: string, maxSize: number): ImageData 
 
   if (tw === 0 || th === 0) return null;
 
+  const expectedSize = tw * th * 4 + 8;
+  if (result.byteLength < expectedSize) return null;
+
   const pixelData = new Uint8ClampedArray(tw * th * 4);
   pixelData.set(new Uint8Array(result.buffer, result.byteOffset + 8, tw * th * 4));
 

--- a/src/panels/ColorPanel/ColorPanel.tsx
+++ b/src/panels/ColorPanel/ColorPanel.tsx
@@ -4,6 +4,7 @@ import { ColorSwatch } from '../../components/ColorSwatch/ColorSwatch';
 import { ColorPicker } from '../../components/ColorPicker/ColorPicker';
 import { Slider } from '../../components/Slider/Slider';
 import { IconButton } from '../../components/IconButton/IconButton';
+import { rgbToHex6, hexToRgb } from '../../utils/color';
 import type { Color } from '../../types';
 import styles from './ColorPanel.module.css';
 
@@ -17,21 +18,13 @@ interface ColorPanelProps {
   collapsed?: boolean;
 }
 
+/** Hex string without # prefix for the text input field. */
 function colorToHex(c: Color): string {
-  const r = c.r.toString(16).padStart(2, '0');
-  const g = c.g.toString(16).padStart(2, '0');
-  const b = c.b.toString(16).padStart(2, '0');
-  return `${r}${g}${b}`;
+  return rgbToHex6(c).slice(1);
 }
 
 function hexToColor(hex: string): Color | null {
-  const clean = hex.replace('#', '');
-  if (clean.length !== 6) return null;
-  const r = parseInt(clean.slice(0, 2), 16);
-  const g = parseInt(clean.slice(2, 4), 16);
-  const b = parseInt(clean.slice(4, 6), 16);
-  if (isNaN(r) || isNaN(g) || isNaN(b)) return null;
-  return { r, g, b, a: 1 };
+  return hexToRgb(hex);
 }
 
 export function ColorPanel({

--- a/src/panels/LayerEffectsPanel/color-convert.ts
+++ b/src/panels/LayerEffectsPanel/color-convert.ts
@@ -1,18 +1,12 @@
 import type { Color } from '../../types';
+import { rgbToHex6, hexToRgb } from '../../utils/color';
 
 export function colorToHex(c: Color): string {
-  const r = c.r.toString(16).padStart(2, '0');
-  const g = c.g.toString(16).padStart(2, '0');
-  const b = c.b.toString(16).padStart(2, '0');
-  return `#${r}${g}${b}`;
+  return rgbToHex6(c);
 }
 
 export function hexToColor(hex: string, alpha: number): Color {
-  const val = hex.replace('#', '');
-  return {
-    r: parseInt(val.slice(0, 2), 16),
-    g: parseInt(val.slice(2, 4), 16),
-    b: parseInt(val.slice(4, 6), 16),
-    a: alpha,
-  };
+  const parsed = hexToRgb(hex);
+  if (!parsed) return { r: 0, g: 0, b: 0, a: alpha };
+  return { ...parsed, a: alpha };
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -91,6 +91,14 @@ export function rgbToHex(color: Color): string {
   return `#${r}${g}${b}`;
 }
 
+/** Always returns #RRGGBB (no alpha), suitable for <input type="color">. */
+export function rgbToHex6(color: Color): string {
+  const r = color.r.toString(16).padStart(2, '0');
+  const g = color.g.toString(16).padStart(2, '0');
+  const b = color.b.toString(16).padStart(2, '0');
+  return `#${r}${g}${b}`;
+}
+
 export function hexToRgb(hex: string): Color | null {
   const cleaned = hex.startsWith('#') ? hex.slice(1) : hex;
 


### PR DESCRIPTION
## Summary
- Add bounds validation in `readLayerThumbnail` before creating ArrayBuffer view — prevents `RangeError` on truncated WASM results
- Remove duplicate `colorsEqual` from `ui-store.ts`, use canonical `colorEquals` from `utils/color.ts`
- Add `rgbToHex6` to `utils/color.ts` (always `#RRGGBB`, no alpha suffix) for `<input type="color">` compatibility
- Consolidate ColorPanel and LayerEffectsPanel color conversions to delegate to `utils/color.ts`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test` — 732 passed, 4 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)