### PR TITLE
refactor: extract clearJsPixelData into shared utility

### DIFF
--- a/src/app/MenuBar/filter-actions.ts
+++ b/src/app/MenuBar/filter-actions.ts
@@ -1,4 +1,5 @@
 import { useEditorStore } from '../editor-store';
+import { clearJsPixelData } from '../store/clear-js-pixel-data';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   filterInvert,
@@ -31,16 +32,6 @@ function getActiveLayerId(): string | null {
   return useEditorStore.getState().document.activeLayerId;
 }
 
-function clearJsPixelData(layerId: string): void {
-  const state = useEditorStore.getState();
-  const pixelDataMap = new Map(state.layerPixelData);
-  pixelDataMap.delete(layerId);
-  const sparseMap = new Map(state.sparseLayerData);
-  sparseMap.delete(layerId);
-  const dirtyIds = new Set(state.dirtyLayerIds);
-  dirtyIds.add(layerId);
-  useEditorStore.setState({ layerPixelData: pixelDataMap, sparseLayerData: sparseMap, dirtyLayerIds: dirtyIds });
-}
 
 export function getFilterDialogConfig(id: FilterDialogId): FilterDefinition | null {
   return filterRegistry[id] ?? null;

--- a/src/app/MenuBar/menus/edit-menu.ts
+++ b/src/app/MenuBar/menus/edit-menu.ts
@@ -1,5 +1,6 @@
 import { useEditorStore } from '../../editor-store';
 import { useUIStore } from '../../ui-store';
+import { clearJsPixelData } from '../../store/clear-js-pixel-data';
 import { getEngine } from '../../../engine-wasm/engine-state';
 import { fillWithColor } from '../../../engine-wasm/wasm-bridge';
 import type { MenuDef } from './types';
@@ -18,18 +19,7 @@ export function fillSelection(): void {
   // GPU fill: uses the engine's selection mask if active
   fillWithColor(engine, activeId, color.r / 255, color.g / 255, color.b / 255, color.a);
 
-  // Clear stale JS pixel data
-  const pixelDataMap = new Map(state.layerPixelData);
-  pixelDataMap.delete(activeId);
-  const sparseMap = new Map(state.sparseLayerData);
-  sparseMap.delete(activeId);
-  const dirtyIds = new Set(state.dirtyLayerIds);
-  dirtyIds.add(activeId);
-  useEditorStore.setState({
-    layerPixelData: pixelDataMap,
-    sparseLayerData: sparseMap,
-    dirtyLayerIds: dirtyIds,
-  });
+  clearJsPixelData(activeId);
   state.notifyRender();
 }
 

--- a/src/app/interactions/misc-handlers.ts
+++ b/src/app/interactions/misc-handlers.ts
@@ -14,6 +14,7 @@ import type { TextStyle } from '../../tools/text/text';
 import { createTextLayer } from '../../layers/layer-model';
 import { hitTestTextLayer } from '../../tools/text/text-hit-test';
 import type { TextEditingState } from '../ui-store';
+import { clearJsPixelData } from '../store/clear-js-pixel-data';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   floodFill as wasmFloodFill,
@@ -28,17 +29,6 @@ import {
   renderRadialGradient as gpuRenderRadialGradient,
   renderShape as gpuRenderShape,
 } from '../../engine-wasm/wasm-bridge';
-
-function clearJsPixelData(layerId: string): void {
-  const state = useEditorStore.getState();
-  const pixelDataMap = new Map(state.layerPixelData);
-  pixelDataMap.delete(layerId);
-  const sparseMap = new Map(state.sparseLayerData);
-  sparseMap.delete(layerId);
-  const dirtyIds = new Set(state.dirtyLayerIds);
-  dirtyIds.add(layerId);
-  useEditorStore.setState({ layerPixelData: pixelDataMap, sparseLayerData: sparseMap, dirtyLayerIds: dirtyIds });
-}
 
 export function handleFillDown(ctx: InteractionContext): void {
   const { layerPos, activeLayerId } = ctx;

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -4,6 +4,7 @@ import { snapPositionToGrid } from '../../tools/move/move';
 import { createTransformState } from '../../tools/transform/transform';
 import { useUIStore } from '../ui-store';
 import { useEditorStore } from '../editor-store';
+import { clearJsPixelData } from '../store/clear-js-pixel-data';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   floatSelection,
@@ -71,19 +72,7 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
       // First move: float the selection on the GPU
       floatSelection(engine, activeLayerId);
 
-      // Clear stale JS pixel data
-      const state = useEditorStore.getState();
-      const pixelDataMap = new Map(state.layerPixelData);
-      pixelDataMap.delete(activeLayerId);
-      const sparseMap = new Map(state.sparseLayerData);
-      sparseMap.delete(activeLayerId);
-      const dirtyIds = new Set(state.dirtyLayerIds);
-      dirtyIds.add(activeLayerId);
-      useEditorStore.setState({
-        layerPixelData: pixelDataMap,
-        sparseLayerData: sparseMap,
-        dirtyLayerIds: dirtyIds,
-      });
+      clearJsPixelData(activeLayerId);
 
       floatingSelectionRef.current = {
         offsetX: 0,
@@ -245,19 +234,7 @@ export function handleNudgeMove(
     if (!floatingSelectionRef.current) {
       floatSelection(engine, activeId);
 
-      // Clear stale JS pixel data
-      const state = useEditorStore.getState();
-      const pixelDataMap = new Map(state.layerPixelData);
-      pixelDataMap.delete(activeId);
-      const sparseMap = new Map(state.sparseLayerData);
-      sparseMap.delete(activeId);
-      const dirtyIds = new Set(state.dirtyLayerIds);
-      dirtyIds.add(activeId);
-      useEditorStore.setState({
-        layerPixelData: pixelDataMap,
-        sparseLayerData: sparseMap,
-        dirtyLayerIds: dirtyIds,
-      });
+      clearJsPixelData(activeId);
 
       floatingSelectionRef.current = {
         offsetX: 0,

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -13,6 +13,7 @@ import {
 import type { TransformState } from '../../tools/transform/transform';
 import { useUIStore } from '../ui-store';
 import { useEditorStore } from '../editor-store';
+import { clearJsPixelData } from '../store/clear-js-pixel-data';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   floatSelection,
@@ -84,19 +85,7 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
     if (engine && !hasFloat(engine)) {
       floatSelection(engine, activeLayerId);
 
-      // Clear stale JS pixel data
-      const state = useEditorStore.getState();
-      const pixelDataMap = new Map(state.layerPixelData);
-      pixelDataMap.delete(activeLayerId);
-      const sparseMap = new Map(state.sparseLayerData);
-      sparseMap.delete(activeLayerId);
-      const dirtyIds = new Set(state.dirtyLayerIds);
-      dirtyIds.add(activeLayerId);
-      useEditorStore.setState({
-        layerPixelData: pixelDataMap,
-        sparseLayerData: sparseMap,
-        dirtyLayerIds: dirtyIds,
-      });
+      clearJsPixelData(activeLayerId);
     }
 
     persistentTransformRef.current = {

--- a/src/app/store/clear-js-pixel-data.ts
+++ b/src/app/store/clear-js-pixel-data.ts
@@ -1,0 +1,17 @@
+import { useEditorStore } from '../editor-store';
+
+/**
+ * Clear JS-side pixel data for a layer, marking it dirty so the GPU texture
+ * becomes the source of truth. Use this after GPU-side operations that modify
+ * layer content (brush strokes, transforms, fills, etc.).
+ */
+export function clearJsPixelData(layerId: string): void {
+  const state = useEditorStore.getState();
+  const pixelDataMap = new Map(state.layerPixelData);
+  pixelDataMap.delete(layerId);
+  const sparseMap = new Map(state.sparseLayerData);
+  sparseMap.delete(layerId);
+  const dirtyIds = new Set(state.dirtyLayerIds);
+  dirtyIds.add(layerId);
+  useEditorStore.setState({ layerPixelData: pixelDataMap, sparseLayerData: sparseMap, dirtyLayerIds: dirtyIds });
+}

--- a/src/app/store/clipboard-slice.ts
+++ b/src/app/store/clipboard-slice.ts
@@ -1,5 +1,6 @@
 import { createRasterLayer } from '../../layers/layer-model';
 import { getInsertionGroupId, addToGroup } from '../../layers/group-utils';
+import { clearJsPixelData } from './clear-js-pixel-data';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   clipboardCopy,
@@ -67,14 +68,7 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
     state.pushHistory('Cut');
     const result = clipboardCut(engine, activeId, hasSelection, bx, by, bw, bh);
     if (result.length >= 4) {
-      // Clear stale JS pixel data for the source layer
-      const pixelDataMap = new Map(state.layerPixelData);
-      pixelDataMap.delete(activeId);
-      const sparseMap = new Map(state.sparseLayerData);
-      sparseMap.delete(activeId);
-      const dirtyIds = new Set(state.dirtyLayerIds);
-      dirtyIds.add(activeId);
-
+      clearJsPixelData(activeId);
       set({
         clipboard: {
           width: result[0]!,
@@ -83,9 +77,6 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
           offsetY: result[3]!,
           gpuResident: true,
         },
-        layerPixelData: pixelDataMap,
-        sparseLayerData: sparseMap,
-        dirtyLayerIds: dirtyIds,
         renderVersion: state.renderVersion + 1,
       });
     }

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -9,6 +9,7 @@ import { beginStroke, endStroke, hasFloat, dropFloat } from '../engine-wasm/wasm
 
 import { clearActiveMaskEditBuffer } from './interactions/mask-buffer';
 import { wrapWithSelectionMask } from './interactions/selection-mask-wrap';
+import { clearJsPixelData } from './store/clear-js-pixel-data';
 import type {
   InteractionState, InteractionContext,
   FloatingSelection, PersistentTransform, LastPaintPoint,
@@ -34,15 +35,8 @@ function finalizePendingStroke(ref: React.MutableRefObject<{ layerId: string } |
 
   endStroke(engine, pending.layerId);
 
-  const editorState = useEditorStore.getState();
-  const pixelData = new Map(editorState.layerPixelData);
-  pixelData.delete(pending.layerId);
-  const sparseMap = new Map(editorState.sparseLayerData);
-  sparseMap.delete(pending.layerId);
-  const dirtyIds = new Set(editorState.dirtyLayerIds);
-  dirtyIds.add(pending.layerId);
-  editorState.notifyRender();
-  useEditorStore.setState({ layerPixelData: pixelData, sparseLayerData: sparseMap, dirtyLayerIds: dirtyIds });
+  clearJsPixelData(pending.layerId);
+  useEditorStore.getState().notifyRender();
 }
 
 const INITIAL_STATE: InteractionState = {
@@ -344,21 +338,10 @@ export function useCanvasInteraction(
       dropFloat(eng);
     }
 
-    // Clear stale JS pixel data so next access reads from the committed GPU texture
     const editorState = useEditorStore.getState();
     const activeId = editorState.document.activeLayerId;
     if (activeId) {
-      const pixelDataMap = new Map(editorState.layerPixelData);
-      pixelDataMap.delete(activeId);
-      const sparseMap = new Map(editorState.sparseLayerData);
-      sparseMap.delete(activeId);
-      const dirtyIds = new Set(editorState.dirtyLayerIds);
-      dirtyIds.add(activeId);
-      useEditorStore.setState({
-        layerPixelData: pixelDataMap,
-        sparseLayerData: sparseMap,
-        dirtyLayerIds: dirtyIds,
-      });
+      clearJsPixelData(activeId);
       editorState.notifyRender();
     }
   }, []);

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, type RefObject } from 'react';
 import { useUIStore } from './ui-store';
 import { useEditorStore } from './editor-store';
+import { clearJsPixelData } from './store/clear-js-pixel-data';
 import { strokeCurrentPath } from './useCanvasInteraction';
 import { getEngine } from '../engine-wasm/engine-state';
 import { clipboardCut, hasFloat, setSelectionMask } from '../engine-wasm/wasm-bridge';
@@ -250,14 +251,7 @@ function handleDeleteKey(): void {
     // GPU-side clear: uses clipboardCut which copies then clears.
     // We discard the clipboard result — we just want the clear.
     clipboardCut(engine, activeId, true, bx, by, bw, bh);
-    // Clear stale JS pixel data
-    const pixelDataMap = new Map(editor.layerPixelData);
-    pixelDataMap.delete(activeId);
-    const sparseMap = new Map(editor.sparseLayerData);
-    sparseMap.delete(activeId);
-    const dirtyIds = new Set(editor.dirtyLayerIds);
-    dirtyIds.add(activeId);
-    useEditorStore.setState({ layerPixelData: pixelDataMap, sparseLayerData: sparseMap, dirtyLayerIds: dirtyIds });
+    clearJsPixelData(activeId);
     editor.notifyRender();
   } else {
     editor.removeLayer(activeId);

--- a/src/panels/LayerPanel/layer-selection.ts
+++ b/src/panels/LayerPanel/layer-selection.ts
@@ -1,5 +1,6 @@
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
+import { clearJsPixelData } from '../../app/store/clear-js-pixel-data';
 import { selectionBounds } from '../../selection/selection';
 import { createTransformState } from '../../tools/transform/transform';
 import { getEngine } from '../../engine-wasm/engine-state';
@@ -12,19 +13,7 @@ export function selectLayerAlpha(layerId: string): void {
     dropFloat(engine);
   }
 
-  // Clear stale JS pixel data so resolvePixelData reads from committed GPU texture
-  const preState = useEditorStore.getState();
-  const pixelDataMap = new Map(preState.layerPixelData);
-  pixelDataMap.delete(layerId);
-  const sparseMap = new Map(preState.sparseLayerData);
-  sparseMap.delete(layerId);
-  const dirtyIds = new Set(preState.dirtyLayerIds);
-  dirtyIds.add(layerId);
-  useEditorStore.setState({
-    layerPixelData: pixelDataMap,
-    sparseLayerData: sparseMap,
-    dirtyLayerIds: dirtyIds,
-  });
+  clearJsPixelData(layerId);
 
   const editorState = useEditorStore.getState();
   const layer = editorState.document.layers.find((l) => l.id === layerId);


### PR DESCRIPTION
## Summary
- Extract the "clear JS pixel data" pattern into `src/app/store/clear-js-pixel-data.ts`
- Replace 10+ inline instances across handlers, menus, keyboard shortcuts, clipboard, layer selection, and canvas interaction
- Net: 36 additions, 125 deletions — 89 lines removed

The pattern (delete from pixelDataMap, sparseMap, add to dirtyIds, setState) was copy-pasted in every file that does GPU-side operations. Now there's one source of truth.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test` — 744 passed, 4 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)