### PR TITLE
fix(selection): always show marching ants

### DIFF
--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -180,12 +180,7 @@ function renderFrameGpu(
       renderGrid(overlayCtx, doc.width, doc.height, gridSize, viewport.zoom);
     }
 
-    // Hide marching ants during active transform — the transform handles
-    // show the bounding box, and the selection mask may not match the
-    // GPU-rendered content during drag. Ants reappear on commit.
-    if (!transform) {
-      renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhaseRef.current);
-    }
+    renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhaseRef.current);
     renderTransformHandles(overlayCtx, selection, transform, viewport.zoom);
     const selectedPath = editorState.selectedPathId
       ? editorState.paths.find((p) => p.id === editorState.selectedPathId)


### PR DESCRIPTION
## Summary

- `renderSelectionAnts` was wrapped in `if (!transform)`, but a transform state is always set alongside every selection creation
- This meant marching ants were never rendered for any selection type (rectangle, ellipse, lasso)
- Removed the `!transform` guard so ants render whenever `selection.active` is true

Fixes #71

## Test plan
- [ ] Draw a rectangle selection — marching ants appear around it
- [ ] Draw an ellipse selection — marching ants appear around it
- [ ] Draw a freeform lasso selection — marching ants appear around it
- [ ] Transform handles still render correctly alongside the ants

🤖 Generated with [Claude Code](https://claude.com/claude-code)