### PR TITLE
fix(wasm): prevent StrictMode engine destruction race

### DIFF
--- a/e2e/canvas-visible.spec.ts
+++ b/e2e/canvas-visible.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { waitForStore, createDocument, paintRect, getPixelAt } from './helpers';
+
+test.describe('Canvas renders visibly', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+  });
+
+  test('white document produces non-zero composited pixels', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await createDocument(page, 400, 300, false);
+    await page.waitForTimeout(1000);
+
+    // Use the composited pixels helper which does sync+render+readPixels
+    // in a single rAF (avoids preserveDrawingBuffer timing issues)
+    const result = await page.evaluate(() => {
+      const readFn = (window as unknown as Record<string, unknown>).__readCompositedPixels as
+        () => Promise<{ width: number; height: number; pixels: number[] } | null>;
+      return readFn();
+    });
+
+    expect(errors.filter((e) => e.includes('null pointer'))).toHaveLength(0);
+    expect(result).not.toBeNull();
+    expect(result!.width).toBeGreaterThan(0);
+    expect(result!.height).toBeGreaterThan(0);
+
+    // Count non-zero pixels — a white document should fill the canvas area
+    let nonZero = 0;
+    for (const v of result!.pixels) {
+      if (v !== 0) nonZero++;
+    }
+    expect(nonZero).toBeGreaterThan(1000);
+  });
+
+  test('painted red rectangle is readable from GPU', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await createDocument(page, 400, 300, true);
+    await paintRect(page, 100, 100, 50, 50, { r: 255, g: 0, b: 0, a: 255 });
+    await page.waitForTimeout(500);
+
+    const pixel = await getPixelAt(page, 125, 125);
+
+    expect(errors.filter((e) => e.includes('null pointer'))).toHaveLength(0);
+    expect(pixel.r).toBeGreaterThan(200);
+    expect(pixel.a).toBeGreaterThan(200);
+  });
+});

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -283,7 +283,11 @@ export function useCanvasRendering(
 
     initEngine(canvas).then((engine) => {
       if (cancelled) {
-        destroyEngine();
+        // Only destroy if this engine is still the current global engine.
+        // In StrictMode, a second mount may have already replaced it.
+        if (getEngine() === engine) {
+          destroyEngine();
+        }
         return;
       }
       engineReadyRef.current = true;

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -333,6 +333,10 @@ export function syncLayers(
     }
   }
 
+  // Track which layers were successfully added so we don't mark failed
+  // adds as tracked (which would prevent retry on the next frame).
+  const failedAdds = new Set<string>();
+
   // Add or update layers
   for (const layer of layers) {
     const descJson = layerToDescJson(layer, layers);
@@ -343,6 +347,7 @@ export function syncLayers(
         tracked.layerVersions.set(layer.id, descJson);
       } catch (e) {
         console.error('[syncLayers] addLayer failed:', layer.id, e);
+        failedAdds.add(layer.id);
       }
     } else if (tracked.layerVersions.get(layer.id) !== descJson) {
       try {
@@ -409,6 +414,11 @@ export function syncLayers(
     }
   }
 
+  // Exclude layers that failed to add — they stay out of tracking so
+  // syncLayers retries addLayer on the next frame.
+  for (const id of failedAdds) {
+    currentIds.delete(id);
+  }
   tracked.layerIds = currentIds;
 
   // Sync layer order


### PR DESCRIPTION
## Summary
- React StrictMode double-mount race caused `destroyEngine()` from the first mount's cleanup to free the second mount's engine, producing `null pointer passed to rust` on every WASM call and leaving the canvas completely blank.
- Guard the cancelled-path `destroyEngine()` with `getEngine() === engine` so it only frees the engine if it's still the current global instance.
- Fix `syncLayers` to exclude failed `addLayer` calls from `tracked.layerIds` so they retry next frame instead of being permanently skipped.

## Test plan
- [x] New `e2e/canvas-visible.spec.ts` asserts composited pixels are non-zero and painted rectangles are readable from GPU
- [x] All 69 existing rendering e2e tests pass
- [x] TypeScript typecheck passes
- [x] Verified visually in headed Playwright — canvas renders again

🤖 Generated with [Claude Code](https://claude.com/claude-code)