### PR TITLE
fix: detect image transparency when opening PNGs

### DIFF
--- a/src/app/store/actions/open-image.test.ts
+++ b/src/app/store/actions/open-image.test.ts
@@ -26,4 +26,20 @@ describe('computeOpenImage', () => {
     const result = computeOpenImage(imgData, 'my-image.jpg');
     expect(result.document!.name).toBe('my-image.jpg');
   });
+
+  it('sets transparent background when image has alpha < 255', () => {
+    const imgData = new ImageData(2, 2);
+    imgData.data[3] = 0; // first pixel fully transparent
+    const result = computeOpenImage(imgData, 'transparent.png');
+    expect(result.document!.backgroundColor).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+  });
+
+  it('sets white background when image is fully opaque', () => {
+    const imgData = new ImageData(2, 2);
+    for (let i = 3; i < imgData.data.length; i += 4) {
+      imgData.data[i] = 255;
+    }
+    const result = computeOpenImage(imgData, 'opaque.png');
+    expect(result.document!.backgroundColor).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+  });
 });

--- a/src/app/store/actions/open-image.ts
+++ b/src/app/store/actions/open-image.ts
@@ -1,10 +1,18 @@
 import type { EditorState, SelectionData } from '../types';
 import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
 
+function imageHasTransparency(data: Uint8ClampedArray): boolean {
+  for (let i = 3; i < data.length; i += 4) {
+    if ((data[i] as number) < 255) return true;
+  }
+  return false;
+}
+
 export function computeOpenImage(
   imageData: ImageData,
   name: string,
 ): Partial<EditorState> {
+  const hasAlpha = imageHasTransparency(imageData.data);
   const layer = createRasterLayer({ name: 'Background', width: imageData.width, height: imageData.height });
   const rootGroup = createGroupLayer({ name: 'Project', children: [layer.id] });
   const pixelData = new Map<string, ImageData>();
@@ -19,7 +27,9 @@ export function computeOpenImage(
       layers: [layer, rootGroup],
       layerOrder: [layer.id, rootGroup.id],
       activeLayerId: layer.id,
-      backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+      backgroundColor: hasAlpha
+        ? { r: 0, g: 0, b: 0, a: 0 }
+        : { r: 255, g: 255, b: 255, a: 1 },
       rootGroupId: rootGroup.id,
     },
     layerPixelData: pixelData,


### PR DESCRIPTION
## Summary
- When opening a PNG with transparent pixels, the document background is now set to transparent (alpha=0) instead of always defaulting to opaque white
- Scans pixel data for any alpha < 255 to detect transparency
- Fixes both the transparent PNG rendering issue and the "hiding all layers shows white" issue for transparent images

Closes #86
Closes #89

## Test plan
- [ ] Open a PNG with transparent background — should show checkerboard pattern through transparent areas
- [ ] Open a fully opaque PNG/JPG — should show white background as before
- [ ] Hide all layers on a transparent-bg document — should show checkerboard, not white
- [ ] Unit tests pass for both transparent and opaque image detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)