### PR TITLE
fix(compositor): disable GL blend state before export to preserve alpha

### DIFF
--- a/e2e/export-transparency.spec.ts
+++ b/e2e/export-transparency.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test';
+import { waitForStore, createDocument, paintRect, getPixelAt } from './helpers';
+import * as path from 'path';
+import * as fs from 'fs';
+
+test.describe('Transparency export roundtrip', () => {
+  test('exported PNG preserves transparency when re-opened', async ({ page }) => {
+    // Auto-accept any "unsaved changes" dialogs
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.goto('/');
+    await waitForStore(page);
+
+    // Create a transparent 100x100 document
+    await createDocument(page, 100, 100, true);
+    await page.waitForTimeout(300);
+
+    // Paint a fully opaque red rectangle, leaving the rest transparent
+    await paintRect(page, 10, 10, 30, 30, { r: 255, g: 0, b: 0, a: 255 });
+    await page.waitForTimeout(200);
+
+    // Sanity-check before export: transparent area vs painted area
+    const prePainted = await getPixelAt(page, 20, 20);
+    expect(prePainted.r).toBe(255);
+    expect(prePainted.a).toBe(255);
+
+    const preTransparent = await getPixelAt(page, 50, 50);
+    expect(preTransparent.a).toBe(0);
+
+    // Export as PNG
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'File' }).click();
+    await page.waitForTimeout(200);
+    await page.getByRole('button', { name: 'Export PNG' }).click();
+
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe('lopsy.png');
+
+    // Save the downloaded PNG to a temp location
+    const tmpDir = path.join(process.cwd(), 'test-results', 'tmp');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, 'transparency-roundtrip.png');
+    await download.saveAs(tmpFile);
+
+    // Verify the exported PNG has transparency by decoding it in-browser
+    const pngBase64 = fs.readFileSync(tmpFile).toString('base64');
+    const exportedPixels = await page.evaluate(async (b64: string) => {
+      const response = await fetch(`data:image/png;base64,${b64}`);
+      const blob = await response.blob();
+      const bitmap = await createImageBitmap(blob);
+      const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(bitmap, 0, 0);
+      const data = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+      // Sample a transparent pixel (50,50) and a painted pixel (20,20)
+      const tIdx = (50 * data.width + 50) * 4;
+      const pIdx = (20 * data.width + 20) * 4;
+      return {
+        transparent: {
+          r: data.data[tIdx]!, g: data.data[tIdx + 1]!,
+          b: data.data[tIdx + 2]!, a: data.data[tIdx + 3]!,
+        },
+        painted: {
+          r: data.data[pIdx]!, g: data.data[pIdx + 1]!,
+          b: data.data[pIdx + 2]!, a: data.data[pIdx + 3]!,
+        },
+      };
+    }, pngBase64);
+
+    // The exported PNG must preserve transparency
+    expect(exportedPixels.transparent.a).toBe(0);
+    expect(exportedPixels.painted.r).toBe(255);
+    expect(exportedPixels.painted.a).toBe(255);
+
+    // Refresh the UI completely
+    await page.goto('/');
+    await waitForStore(page);
+
+    // Load the exported PNG back into the app programmatically
+    // (same code path as File > Open, avoids file chooser UI timing issues)
+    await page.evaluate(async (b64: string) => {
+      return new Promise<void>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.createElement('canvas');
+          canvas.width = img.width;
+          canvas.height = img.height;
+          const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
+          if (!ctx) { reject(new Error('no 2d context')); return; }
+          ctx.drawImage(img, 0, 0);
+          const imageData = ctx.getImageData(0, 0, img.width, img.height);
+          const store = (window as unknown as Record<string, unknown>).__editorStore as {
+            getState: () => { openImageAsDocument: (data: ImageData, name: string) => void };
+          };
+          store.getState().openImageAsDocument(imageData, 'transparency-test');
+          resolve();
+        };
+        img.onerror = () => reject(new Error('failed to load image'));
+        img.src = `data:image/png;base64,${b64}`;
+      });
+    }, pngBase64);
+
+    await page.waitForTimeout(500);
+
+    // The app should detect transparency and set a transparent background
+    const bgColor = await page.evaluate(() => {
+      const store = (window as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { backgroundColor: { r: number; g: number; b: number; a: number } };
+        };
+      };
+      return store.getState().document.backgroundColor;
+    });
+    expect(bgColor.a).toBe(0);
+
+    // Transparent regions must still have alpha = 0
+    const postTransparent = await getPixelAt(page, 50, 50);
+    expect(postTransparent.a).toBe(0);
+
+    // Painted region must retain full red at full opacity
+    const postPainted = await getPixelAt(page, 20, 20);
+    expect(postPainted.r).toBe(255);
+    expect(postPainted.a).toBe(255);
+
+    await page.screenshot({
+      path: 'test-results/screenshots/export-transparency-roundtrip.png',
+    });
+
+    // Clean up temp file
+    fs.unlinkSync(tmpFile);
+  });
+});

--- a/engine-rs/crates/lopsy-wasm/src/compositor.rs
+++ b/engine-rs/crates/lopsy-wasm/src/compositor.rs
@@ -428,6 +428,11 @@ pub fn composite_for_export(engine: &mut EngineInner) -> Result<Vec<u8>, String>
     let doc_h = engine.doc_height;
     let bg = engine.bg_color;
 
+    // Reset GL state — brush/shape/selection tools may have left blending enabled.
+    // If BLEND is on, the blit passes in blend_onto_composite would blend
+    // instead of overwrite, corrupting alpha.
+    engine.gl.disable(WebGl2RenderingContext::BLEND);
+
     // Render composite (same as display but without viewport transform)
     engine.fbo_pool.bind(&engine.gl, engine.composite_fbo);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,24 @@
       "name": "lopsy",
       "version": "0.1.0",
       "dependencies": {
-        "lucide-react": "^0.577.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "zustand": "^5.0.11"
+        "lucide-react": "0.577.0",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "zustand": "5.0.11"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "@storybook/react-vite": "^10.2.17",
-        "@types/react": "^19.2.14",
-        "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^5.1.4",
-        "jsdom": "^28.1.0",
-        "playwright": "^1.58.2",
-        "typescript": "^5.9.3",
-        "vite": "^7.3.1",
-        "vite-plugin-top-level-await": "^1.6.0",
-        "vite-plugin-wasm": "^3.6.0",
-        "vitest": "^4.0.18"
+        "@playwright/test": "1.58.2",
+        "@storybook/react-vite": "10.2.17",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "5.1.4",
+        "jsdom": "28.1.0",
+        "playwright": "1.58.2",
+        "typescript": "5.9.3",
+        "vite": "7.3.1",
+        "vite-plugin-top-level-await": "1.6.0",
+        "vite-plugin-wasm": "3.6.0",
+        "vitest": "4.0.18"
       }
     },
     "node_modules/@acemir/cssom": {


### PR DESCRIPTION
composite_for_export() was missing the gl.disable(BLEND) call that both
composite() and composite_single_layer() already had. When brush/shape
tools left blending enabled, the blit passes in blend_onto_composite
would blend instead of overwrite, corrupting the alpha channel and
destroying transparency in exported PNGs.

Add an e2e test that exports a transparent document as PNG, reloads it,
and verifies that transparent regions still have alpha=0.

https://claude.ai/code/session_01CgGdySddXRrQ1y6hHTFLvA