### PR TITLE
feat(adjustments): tabbed panel layout with layer ordering fixes

### DIFF
--- a/src/app/store/actions/add-layer.ts
+++ b/src/app/store/actions/add-layer.ts
@@ -18,7 +18,7 @@ export function computeAddLayer(
     layers = addToGroup(layers, newLayer.id, groupId);
   }
 
-  const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId);
+  const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId, doc.rootGroupId);
   const layerOrder = [...doc.layerOrder];
   layerOrder.splice(orderIdx, 0, newLayer.id);
 

--- a/src/app/store/actions/add-text-layer.ts
+++ b/src/app/store/actions/add-text-layer.ts
@@ -11,7 +11,7 @@ export function computeAddTextLayer(
   if (groupId) {
     layers = addToGroup(layers, textLayer.id, groupId);
   }
-  const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId);
+  const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId, doc.rootGroupId);
   const layerOrder = [...doc.layerOrder];
   layerOrder.splice(orderIdx, 0, textLayer.id);
   return {

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -235,7 +235,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     if (targetGroupId) {
       layers = addToGroupUtil(layers, group.id, targetGroupId);
     }
-    const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId);
+    const orderIdx = getInsertionOrderIndex(doc.layerOrder, doc.activeLayerId, doc.rootGroupId);
     const layerOrder = [...doc.layerOrder];
     layerOrder.splice(orderIdx, 0, group.id);
     set({

--- a/src/components/Slider/Slider.module.css
+++ b/src/components/Slider/Slider.module.css
@@ -8,7 +8,7 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   white-space: nowrap;
-  min-width: 40px;
+  min-width: var(--slider-label-width, 40px);
 }
 
 .slider {

--- a/src/layers/group-utils.ts
+++ b/src/layers/group-utils.ts
@@ -132,12 +132,20 @@ export function moveLayerToGroup(
 
   return layers.map((l) => {
     if (isGroupLayer(l)) {
-      // Remove from old parent
-      if (l.children.includes(layerId)) {
+      const isOldParent = l.children.includes(layerId);
+      const isNewParent = l.id === targetGroupId;
+
+      if (isOldParent && isNewParent) {
+        // Reorder within the same group
+        const filtered = l.children.filter((c) => c !== layerId);
+        const idx = insertIndex !== undefined ? insertIndex : filtered.length;
+        filtered.splice(idx, 0, layerId);
+        return { ...l, children: filtered };
+      }
+      if (isOldParent) {
         return { ...l, children: l.children.filter((c) => c !== layerId) };
       }
-      // Add to new parent
-      if (l.id === targetGroupId) {
+      if (isNewParent) {
         const newChildren = [...l.children];
         const idx = insertIndex !== undefined ? insertIndex : newChildren.length;
         newChildren.splice(idx, 0, layerId);
@@ -189,17 +197,25 @@ export function getInsertionGroupId(
 /**
  * Compute the layerOrder insertion index for a new layer.
  * Inserts just above the active layer in layerOrder.
- * If active layer is a group, inserts just before it (so the new layer
- * appears inside the group visually, above the group's existing children).
+ * Never inserts above the root group — the root group must remain the
+ * topmost item in the visual stack (last in layerOrder).
  */
 export function getInsertionOrderIndex(
   layerOrder: readonly string[],
   activeLayerId: string | null,
+  rootGroupId?: string | null,
 ): number {
   if (!activeLayerId) return layerOrder.length;
   const idx = layerOrder.indexOf(activeLayerId);
   if (idx === -1) return layerOrder.length;
-  return idx + 1;
+  let insertIdx = idx + 1;
+  if (rootGroupId) {
+    const rootIdx = layerOrder.indexOf(rootGroupId);
+    if (rootIdx !== -1 && insertIdx > rootIdx) {
+      insertIdx = rootIdx;
+    }
+  }
+  return insertIdx;
 }
 
 /**

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.module.css
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.module.css
@@ -1,17 +1,17 @@
 .panel {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
+  height: 100%;
+  overflow: hidden;
 }
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: var(--space-1);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--space-1);
+  flex-shrink: 0;
 }
 
 .headerTitle {
@@ -20,17 +20,57 @@
   color: var(--color-text-primary);
 }
 
-.groupLabel {
-  font-size: var(--font-size-xs);
+.tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.tab {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
-  padding-bottom: var(--space-1);
-  border-bottom: 1px solid var(--color-border-subtle);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab:hover {
+  color: var(--color-text-primary);
+}
+
+.tabActive {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-accent);
+}
+
+.scrollArea {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+}
+
+.sliders {
+  --slider-label-width: 70px;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
 }
 
 .footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
 }
 
 .textBtn {
@@ -77,9 +117,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding-top: var(--space-2);
-  border-top: 1px solid var(--color-border-subtle);
-  margin-top: var(--space-1);
+  margin-top: var(--space-4);
 }
 
 .curvesHeader {

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -43,7 +43,7 @@ interface AdjustmentSliderDef {
   step: number;
 }
 
-const SLIDERS: AdjustmentSliderDef[] = [
+const VALUE_SLIDERS: AdjustmentSliderDef[] = [
   { key: 'exposure', label: 'Exposure', min: -5, max: 5, step: 0.1 },
   { key: 'contrast', label: 'Contrast', min: -100, max: 100, step: 1 },
   { key: 'highlights', label: 'Highlights', min: -100, max: 100, step: 1 },
@@ -51,9 +51,14 @@ const SLIDERS: AdjustmentSliderDef[] = [
   { key: 'whites', label: 'Whites', min: -100, max: 100, step: 1 },
   { key: 'blacks', label: 'Blacks', min: -100, max: 100, step: 1 },
   { key: 'vignette', label: 'Vignette', min: 0, max: 100, step: 1 },
+];
+
+const COLOR_SLIDERS: AdjustmentSliderDef[] = [
   { key: 'saturation', label: 'Saturation', min: -100, max: 100, step: 1 },
   { key: 'vibrance', label: 'Vibrance', min: -100, max: 100, step: 1 },
 ];
+
+type TabId = 'values' | 'colors';
 
 function useActiveGroup(): GroupLayer | null {
   return useEditorStore((s) => {
@@ -80,6 +85,7 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
   const setGroupAdjustments = useEditorStore((s) => s.setGroupAdjustments);
   const setGroupAdjustmentsEnabled = useEditorStore((s) => s.setGroupAdjustmentsEnabled);
   const setShowEffectsDrawer = useUIStore((s) => s.setShowEffectsDrawer);
+  const [activeTab, setActiveTab] = useState<TabId>('values');
 
   if (!group) return null;
 
@@ -108,11 +114,13 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
     });
   };
 
+  const sliders = activeTab === 'values' ? VALUE_SLIDERS : COLOR_SLIDERS;
+
   return (
     <div className={styles.panel}>
       {showHeader && (
         <div className={styles.header}>
-          <span className={styles.headerTitle}>Group Effects</span>
+          <span className={styles.headerTitle}>{group.name}</span>
           <IconButton
             icon={<X size={14} />}
             label="Close"
@@ -120,25 +128,45 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
           />
         </div>
       )}
-      <div className={styles.groupLabel}>{group.name}</div>
-      {SLIDERS.map((s) => (
-        <Slider
-          key={s.key}
-          label={s.label}
-          value={adjustments[s.key]}
-          min={s.min}
-          max={s.max}
-          step={s.step}
-          defaultValue={0}
-          onChange={(v) => handleChange(s.key, v)}
-          showValue={false}
-        />
-      ))}
-      <CurvesSection
-        curves={curves}
-        onChange={handleCurveChange}
-        onReset={handleResetCurve}
-      />
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={`${styles.tab} ${activeTab === 'values' ? styles.tabActive : ''}`}
+          onClick={() => setActiveTab('values')}
+        >
+          Values
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${activeTab === 'colors' ? styles.tabActive : ''}`}
+          onClick={() => setActiveTab('colors')}
+        >
+          Colors
+        </button>
+      </div>
+      <div className={styles.scrollArea}>
+        <div className={styles.sliders}>
+          {sliders.map((s) => (
+            <Slider
+              key={s.key}
+              label={s.label}
+              value={adjustments[s.key]}
+              min={s.min}
+              max={s.max}
+              step={s.step}
+              defaultValue={0}
+              onChange={(v) => handleChange(s.key, v)}
+            />
+          ))}
+        </div>
+        {activeTab === 'colors' && (
+          <CurvesSection
+            curves={curves}
+            onChange={handleCurveChange}
+            onReset={handleResetCurve}
+          />
+        )}
+      </div>
       <div className={styles.footer}>
         <button type="button" className={styles.textBtn} onClick={handleReset}>
           Reset


### PR DESCRIPTION
## Summary
- Rework AdjustmentsPanel into a tabbed interface with **Values** (exposure, contrast, highlights, shadows, whites, blacks, vignette) and **Colors** (saturation, vibrance, curves) tabs
- Header now shows the group name instead of generic "Group Effects" title
- Sliders are aligned with consistent label width and show text input boxes
- Panel content is scrollable with pinned header/footer
- Fix layer insertion to never place new layers above the root "Project" group
- Fix `moveLayerToGroup` orphaning layers when dragging a layer onto its own parent group (same source/target group caused the layer to be removed from children but never re-added)

## Test plan
- [ ] Open a group's effects panel and verify tabs switch between Values and Colors
- [ ] Verify group name appears in the header
- [ ] Verify all sliders have aligned labels and text input boxes
- [ ] Add layers/groups while the root group is selected — they should appear inside it, not above
- [ ] Drag a layer onto its own parent group — it should stay in the group, not become orphaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)