### PR TITLE
fix(shaders): add triangular dithering to eliminate gradient banding

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/final_blit.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/final_blit.glsl
@@ -46,6 +46,14 @@ void main() {
         color.a = 1.0;
     }
 
+    // Triangular dither to break 8-bit banding on smooth gradients.
+    // Two uniform hashes produce triangular distribution in [-1, 1] / 255.
+    vec2 seed = gl_FragCoord.xy;
+    float n0 = fract(sin(dot(seed, vec2(12.9898, 78.233))) * 43758.5453);
+    float n1 = fract(sin(dot(seed, vec2(63.7264, 10.873))) * 28637.1136);
+    float dither = (n0 + n1 - 1.0) / 255.0;
+    color.rgb += dither;
+
     // Pass through — RGBA16F values > 1.0 are preserved for EDR when the
     // canvas drawingBufferColorSpace is set to 'display-p3'.
     fragColor = color;

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/gradient/gradient_linear.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/gradient/gradient_linear.glsl
@@ -27,6 +27,13 @@ void main() {
         }
     }
 
+    // Triangular dither to reduce banding when stored in RGBA8 textures.
+    vec2 seed = gl_FragCoord.xy;
+    float n0 = fract(sin(dot(seed, vec2(12.9898, 78.233))) * 43758.5453);
+    float n1 = fract(sin(dot(seed, vec2(63.7264, 10.873))) * 28637.1136);
+    float dither = (n0 + n1 - 1.0) / 255.0;
+    gradColor.rgb += dither;
+
     vec4 existing = texture(u_existingTex, v_uv);
 
     if (u_hasMask == 1) {

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/gradient/gradient_radial.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/gradient/gradient_radial.glsl
@@ -25,6 +25,13 @@ void main() {
         }
     }
 
+    // Triangular dither to reduce banding when stored in RGBA8 textures.
+    vec2 seed = gl_FragCoord.xy;
+    float n0 = fract(sin(dot(seed, vec2(12.9898, 78.233))) * 43758.5453);
+    float n1 = fract(sin(dot(seed, vec2(63.7264, 10.873))) * 28637.1136);
+    float dither = (n0 + n1 - 1.0) / 255.0;
+    gradColor.rgb += dither;
+
     vec4 existing = texture(u_existingTex, v_uv);
 
     if (u_hasMask == 1) {


### PR DESCRIPTION
## Summary
- Adds triangular-distributed dither noise (±1/255) to gradient shaders (linear + radial) at render time, eliminating visible banding in narrow-range gradients (e.g. 0,0,0 → 26,22,22)
- Adds the same dithering to `final_blit.glsl` so all composited output is dithered at display time, catching banding from any source
- Gradient shader dithering is baked into layer textures, so it survives export

## Test plan
- [x] Draw a linear gradient from black (0,0,0) to near-black (26,22,22) on a 1080x1080 canvas — no visible banding
- [ ] Verify radial gradients with similar narrow ranges are smooth
- [ ] Export a dithered gradient as PNG and confirm no banding in the exported file
- [ ] Check that bright/wide-range gradients don't show visible noise artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)