### PR TITLE
feat(psd): add homerolled PSD reader/writer with 16-bit support

### DIFF
--- a/engine-rs/Cargo.lock
+++ b/engine-rs/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
 name = "lopsy-core"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "png",
  "serde",
  "serde_json",

--- a/engine-rs/crates/lopsy-core/Cargo.toml
+++ b/engine-rs/crates/lopsy-core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 png = "0.17"
+flate2 = "1"

--- a/engine-rs/crates/lopsy-core/src/lib.rs
+++ b/engine-rs/crates/lopsy-core/src/lib.rs
@@ -12,3 +12,4 @@ pub mod flood_fill;
 pub mod magnetic_lasso;
 pub mod compress;
 pub mod decode;
+pub mod psd;

--- a/engine-rs/crates/lopsy-core/src/psd/blend_keys.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/blend_keys.rs
@@ -1,0 +1,85 @@
+use crate::color::BlendMode;
+
+/// Convert a Lopsy BlendMode to the PSD 4-byte blend mode key.
+pub fn blend_mode_to_psd_key(mode: BlendMode) -> [u8; 4] {
+    match mode {
+        BlendMode::Normal => *b"norm",
+        BlendMode::Multiply => *b"mul ",
+        BlendMode::Screen => *b"scrn",
+        BlendMode::Overlay => *b"over",
+        BlendMode::Darken => *b"dark",
+        BlendMode::Lighten => *b"lite",
+        BlendMode::ColorDodge => *b"div ",
+        BlendMode::ColorBurn => *b"idiv",
+        BlendMode::HardLight => *b"hLit",
+        BlendMode::SoftLight => *b"sLit",
+        BlendMode::Difference => *b"diff",
+        BlendMode::Exclusion => *b"smud",
+        BlendMode::Hue => *b"hue ",
+        BlendMode::Saturation => *b"sat ",
+        BlendMode::Color => *b"colr",
+        BlendMode::Luminosity => *b"lum ",
+    }
+}
+
+/// Convert a PSD 4-byte blend mode key to a Lopsy BlendMode.
+/// Returns Normal for unrecognized keys.
+pub fn psd_key_to_blend_mode(key: &[u8; 4]) -> BlendMode {
+    match key {
+        b"norm" => BlendMode::Normal,
+        b"mul " => BlendMode::Multiply,
+        b"scrn" => BlendMode::Screen,
+        b"over" => BlendMode::Overlay,
+        b"dark" => BlendMode::Darken,
+        b"lite" => BlendMode::Lighten,
+        b"div " => BlendMode::ColorDodge,
+        b"idiv" => BlendMode::ColorBurn,
+        b"hLit" => BlendMode::HardLight,
+        b"sLit" => BlendMode::SoftLight,
+        b"diff" => BlendMode::Difference,
+        b"smud" => BlendMode::Exclusion,
+        b"hue " => BlendMode::Hue,
+        b"sat " => BlendMode::Saturation,
+        b"colr" => BlendMode::Color,
+        b"lum " => BlendMode::Luminosity,
+        // PSD has additional modes Lopsy doesn't support — fall back to Normal
+        _ => BlendMode::Normal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_all_modes() {
+        let modes = [
+            BlendMode::Normal,
+            BlendMode::Multiply,
+            BlendMode::Screen,
+            BlendMode::Overlay,
+            BlendMode::Darken,
+            BlendMode::Lighten,
+            BlendMode::ColorDodge,
+            BlendMode::ColorBurn,
+            BlendMode::HardLight,
+            BlendMode::SoftLight,
+            BlendMode::Difference,
+            BlendMode::Exclusion,
+            BlendMode::Hue,
+            BlendMode::Saturation,
+            BlendMode::Color,
+            BlendMode::Luminosity,
+        ];
+        for mode in modes {
+            let key = blend_mode_to_psd_key(mode);
+            let back = psd_key_to_blend_mode(&key);
+            assert_eq!(back, mode, "roundtrip failed for {mode:?}");
+        }
+    }
+
+    #[test]
+    fn unknown_key_returns_normal() {
+        assert_eq!(psd_key_to_blend_mode(b"xxxx"), BlendMode::Normal);
+    }
+}

--- a/engine-rs/crates/lopsy-core/src/psd/flatten.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/flatten.rs
@@ -1,0 +1,288 @@
+use crate::blend::blend_colors;
+use crate::color::{srgb_to_linear, linear_to_srgb, Color};
+use super::types::{PsdDocument, PsdDepth, GroupKind};
+
+/// Deinterleaved channel planes for the PSD merged composite.
+pub struct ChannelPlanes {
+    pub r: Vec<u8>,
+    pub g: Vec<u8>,
+    pub b: Vec<u8>,
+    pub a: Vec<u8>,
+    pub depth: PsdDepth,
+}
+
+/// Flatten all visible layers into deinterleaved channel planes for the merged composite.
+///
+/// Layers are in bottom-to-top order. Groups are treated as pass-through.
+/// Blending is done in linear light; the output is in sRGB.
+pub fn flatten_layers(doc: &PsdDocument) -> ChannelPlanes {
+    let w = doc.width as usize;
+    let h = doc.height as usize;
+    let pixel_count = w * h;
+
+    // Composite buffer in linear float
+    let mut comp = vec![Color::transparent(); pixel_count];
+
+    for layer in &doc.layers {
+        if !layer.visible || layer.group_kind != GroupKind::Normal {
+            continue;
+        }
+
+        let lw = layer.rect.width() as usize;
+        let lh = layer.rect.height() as usize;
+        if lw == 0 || lh == 0 {
+            continue;
+        }
+
+        let layer_opacity = layer.opacity as f32 / 255.0;
+
+        for ly in 0..lh {
+            let doc_y = layer.rect.top as isize + ly as isize;
+            if doc_y < 0 || doc_y >= h as isize {
+                continue;
+            }
+            let doc_y = doc_y as usize;
+
+            for lx in 0..lw {
+                let doc_x = layer.rect.left as isize + lx as isize;
+                if doc_x < 0 || doc_x >= w as isize {
+                    continue;
+                }
+                let doc_x = doc_x as usize;
+
+                let src_color = read_pixel(&layer.pixel_data, lx, ly, lw, doc.depth);
+                if src_color.a < 1e-7 {
+                    continue;
+                }
+
+                // Apply layer mask
+                let mask_factor = if let Some(ref mask) = layer.mask {
+                    let mask_x = doc_x as i32 - mask.rect.left;
+                    let mask_y = doc_y as i32 - mask.rect.top;
+                    let mw = mask.rect.width() as i32;
+                    let mh = mask.rect.height() as i32;
+                    if mask_x >= 0 && mask_x < mw && mask_y >= 0 && mask_y < mh {
+                        mask.data[(mask_y as usize) * (mw as usize) + mask_x as usize] as f32 / 255.0
+                    } else {
+                        mask.default_color as f32 / 255.0
+                    }
+                } else {
+                    1.0
+                };
+
+                let effective_alpha = src_color.a * layer_opacity * mask_factor;
+                if effective_alpha < 1e-7 {
+                    continue;
+                }
+
+                let src = Color::new(src_color.r, src_color.g, src_color.b, effective_alpha);
+                let idx = doc_y * w + doc_x;
+                comp[idx] = blend_colors(src, comp[idx], layer.blend_mode);
+            }
+        }
+    }
+
+    // Convert from linear to sRGB and deinterleave into channel planes
+    match doc.depth {
+        PsdDepth::Eight => {
+            let mut r = Vec::with_capacity(pixel_count);
+            let mut g = Vec::with_capacity(pixel_count);
+            let mut b = Vec::with_capacity(pixel_count);
+            let mut a = Vec::with_capacity(pixel_count);
+
+            for c in &comp {
+                r.push(linear_to_srgb(c.r));
+                g.push(linear_to_srgb(c.g));
+                b.push(linear_to_srgb(c.b));
+                a.push((c.a.clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+            }
+
+            ChannelPlanes { r, g, b, a, depth: PsdDepth::Eight }
+        }
+        PsdDepth::Sixteen => {
+            // For 16-bit, each channel plane stores big-endian u16 bytes
+            let mut r = Vec::with_capacity(pixel_count * 2);
+            let mut g = Vec::with_capacity(pixel_count * 2);
+            let mut b = Vec::with_capacity(pixel_count * 2);
+            let mut a = Vec::with_capacity(pixel_count * 2);
+
+            for c in &comp {
+                let rv = (linear_to_srgb_f32(c.r) * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+                let gv = (linear_to_srgb_f32(c.g) * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+                let bv = (linear_to_srgb_f32(c.b) * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+                let av = (c.a.clamp(0.0, 1.0) * 65535.0 + 0.5) as u16;
+                r.extend_from_slice(&rv.to_be_bytes());
+                g.extend_from_slice(&gv.to_be_bytes());
+                b.extend_from_slice(&bv.to_be_bytes());
+                a.extend_from_slice(&av.to_be_bytes());
+            }
+
+            ChannelPlanes { r, g, b, a, depth: PsdDepth::Sixteen }
+        }
+    }
+}
+
+/// Read one pixel from interleaved RGBA layer data, converting to linear Color.
+fn read_pixel(data: &[u8], x: usize, y: usize, width: usize, depth: PsdDepth) -> Color {
+    match depth {
+        PsdDepth::Eight => {
+            let idx = (y * width + x) * 4;
+            if idx + 3 >= data.len() {
+                return Color::transparent();
+            }
+            Color {
+                r: srgb_to_linear(data[idx]),
+                g: srgb_to_linear(data[idx + 1]),
+                b: srgb_to_linear(data[idx + 2]),
+                a: data[idx + 3] as f32 / 255.0,
+            }
+        }
+        PsdDepth::Sixteen => {
+            let idx = (y * width + x) * 8;
+            if idx + 7 >= data.len() {
+                return Color::transparent();
+            }
+            let r = u16::from_be_bytes([data[idx], data[idx + 1]]) as f32 / 65535.0;
+            let g = u16::from_be_bytes([data[idx + 2], data[idx + 3]]) as f32 / 65535.0;
+            let b = u16::from_be_bytes([data[idx + 4], data[idx + 5]]) as f32 / 65535.0;
+            let a = u16::from_be_bytes([data[idx + 6], data[idx + 7]]) as f32 / 65535.0;
+            // sRGB to linear for the color channels
+            Color {
+                r: srgb_to_linear_f32(r),
+                g: srgb_to_linear_f32(g),
+                b: srgb_to_linear_f32(b),
+                a,
+            }
+        }
+    }
+}
+
+/// sRGB EOTF for f32 input (0.0-1.0 range)
+fn srgb_to_linear_f32(s: f32) -> f32 {
+    if s <= 0.04045 {
+        s / 12.92
+    } else {
+        ((s + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// sRGB OETF returning f32 (0.0-1.0 range), for 16-bit output
+fn linear_to_srgb_f32(c: f32) -> f32 {
+    let v = c.clamp(0.0, 1.0);
+    if v <= 0.0031308 {
+        v * 12.92
+    } else {
+        1.055 * v.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::BlendMode;
+    use super::super::types::{PsdDocument, PsdLayer, PsdRect, PsdDepth, GroupKind};
+
+    fn solid_layer_8bit(x: i32, y: i32, w: u32, h: u32, r: u8, g: u8, b: u8, a: u8, mode: BlendMode) -> PsdLayer {
+        let pixel_count = (w * h) as usize;
+        let mut data = Vec::with_capacity(pixel_count * 4);
+        for _ in 0..pixel_count {
+            data.extend_from_slice(&[r, g, b, a]);
+        }
+        PsdLayer {
+            name: "test".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: mode,
+            clip_to_below: false,
+            rect: PsdRect::from_xywh(x, y, w, h),
+            pixel_data: data,
+            mask: None,
+            group_kind: GroupKind::Normal,
+        }
+    }
+
+    #[test]
+    fn flatten_single_opaque_layer() {
+        let doc = PsdDocument {
+            width: 2,
+            height: 2,
+            depth: PsdDepth::Eight,
+            layers: vec![solid_layer_8bit(0, 0, 2, 2, 255, 0, 0, 255, BlendMode::Normal)],
+            icc_profile: None,
+        };
+        let planes = flatten_layers(&doc);
+        assert_eq!(planes.r, vec![255, 255, 255, 255]);
+        assert_eq!(planes.g, vec![0, 0, 0, 0]);
+        assert_eq!(planes.b, vec![0, 0, 0, 0]);
+        assert_eq!(planes.a, vec![255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn flatten_transparent_over_opaque() {
+        let doc = PsdDocument {
+            width: 1,
+            height: 1,
+            depth: PsdDepth::Eight,
+            layers: vec![
+                solid_layer_8bit(0, 0, 1, 1, 0, 0, 255, 255, BlendMode::Normal), // blue bg
+                solid_layer_8bit(0, 0, 1, 1, 255, 0, 0, 128, BlendMode::Normal), // red 50%
+            ],
+            icc_profile: None,
+        };
+        let planes = flatten_layers(&doc);
+        // Should be a blend of red over blue at ~50% opacity
+        assert!(planes.r[0] > 100); // has red
+        assert!(planes.b[0] > 50);  // has some blue
+        assert_eq!(planes.a[0], 255);
+    }
+
+    #[test]
+    fn flatten_invisible_layer_ignored() {
+        let mut layer = solid_layer_8bit(0, 0, 1, 1, 255, 0, 0, 255, BlendMode::Normal);
+        layer.visible = false;
+        let doc = PsdDocument {
+            width: 1,
+            height: 1,
+            depth: PsdDepth::Eight,
+            layers: vec![layer],
+            icc_profile: None,
+        };
+        let planes = flatten_layers(&doc);
+        assert_eq!(planes.a[0], 0);
+    }
+
+    #[test]
+    fn flatten_layer_with_offset() {
+        // 2x2 doc, 1x1 layer at position (1, 1)
+        let doc = PsdDocument {
+            width: 2,
+            height: 2,
+            depth: PsdDepth::Eight,
+            layers: vec![solid_layer_8bit(1, 1, 1, 1, 0, 255, 0, 255, BlendMode::Normal)],
+            icc_profile: None,
+        };
+        let planes = flatten_layers(&doc);
+        // Only bottom-right pixel should be opaque
+        assert_eq!(planes.a[0], 0); // (0,0)
+        assert_eq!(planes.a[1], 0); // (1,0)
+        assert_eq!(planes.a[2], 0); // (0,1)
+        assert_eq!(planes.a[3], 255); // (1,1)
+    }
+
+    #[test]
+    fn flatten_multiply_blend() {
+        let doc = PsdDocument {
+            width: 1,
+            height: 1,
+            depth: PsdDepth::Eight,
+            layers: vec![
+                solid_layer_8bit(0, 0, 1, 1, 255, 255, 255, 255, BlendMode::Normal),
+                solid_layer_8bit(0, 0, 1, 1, 128, 128, 128, 255, BlendMode::Multiply),
+            ],
+            icc_profile: None,
+        };
+        let planes = flatten_layers(&doc);
+        // Multiply: white * mid-gray (in linear) should produce mid-gray
+        assert!(planes.r[0] < 200 && planes.r[0] > 50);
+    }
+}

--- a/engine-rs/crates/lopsy-core/src/psd/mod.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/mod.rs
@@ -1,0 +1,7 @@
+pub mod types;
+pub mod blend_keys;
+pub mod packbits;
+pub mod zip_predict;
+pub mod flatten;
+pub mod writer;
+pub mod reader;

--- a/engine-rs/crates/lopsy-core/src/psd/packbits.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/packbits.rs
@@ -1,0 +1,184 @@
+/// Encode a single scanline using Apple PackBits compression.
+///
+/// PackBits rules:
+/// - Flag byte n as i8:
+///   - 0..=127: copy next (n+1) literal bytes
+///   - -1..=-127 (129..=255 as u8): repeat next byte (1-n) times
+///   - -128 (128 as u8): no-op
+pub fn packbits_encode(data: &[u8]) -> Vec<u8> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(data.len() + data.len() / 128 + 1);
+    let len = data.len();
+    let mut i = 0;
+
+    while i < len {
+        // Count run length
+        let mut run = 1;
+        while i + run < len && run < 128 && data[i + run] == data[i] {
+            run += 1;
+        }
+
+        if run >= 3 || (run == 2 && (i + run >= len || data[i + run] != data[i])) {
+            // Emit a run: flag = 1-run as i8 (e.g. run=128 -> flag=-127 -> 0x81)
+            out.push((1i16 - run as i16) as u8);
+            out.push(data[i]);
+            i += run;
+        } else {
+            // Collect literals
+            let start = i;
+            let mut lit_len = 0;
+
+            while i + lit_len < len && lit_len < 128 {
+                // Check if a run of 3+ starts here
+                let remaining = len - (i + lit_len);
+                if remaining >= 3
+                    && data[i + lit_len] == data[i + lit_len + 1]
+                    && data[i + lit_len] == data[i + lit_len + 2]
+                {
+                    break;
+                }
+                lit_len += 1;
+            }
+
+            if lit_len == 0 {
+                lit_len = 1;
+            }
+
+            out.push((lit_len - 1) as u8);
+            out.extend_from_slice(&data[start..start + lit_len]);
+            i += lit_len;
+        }
+    }
+
+    out
+}
+
+/// Decode PackBits-compressed data into the original bytes.
+pub fn packbits_decode(data: &[u8], expected_len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(expected_len);
+    let mut pos = 0;
+
+    while pos < data.len() && out.len() < expected_len {
+        let flag = data[pos] as i8;
+        pos += 1;
+
+        if flag >= 0 {
+            // Literal run: copy (flag+1) bytes
+            let count = flag as usize + 1;
+            let end = (pos + count).min(data.len());
+            out.extend_from_slice(&data[pos..end]);
+            pos = end;
+        } else if flag == -128 {
+            // No-op
+        } else {
+            // Repeated byte: repeat (1-flag) times
+            let count = (1 - flag as i16) as usize;
+            if pos < data.len() {
+                let byte = data[pos];
+                pos += 1;
+                for _ in 0..count {
+                    out.push(byte);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        let encoded = packbits_encode(&[]);
+        assert!(encoded.is_empty());
+        let decoded = packbits_decode(&encoded, 0);
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_single_byte() {
+        let data = vec![42];
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_constant_run() {
+        let data = vec![0xAA; 200];
+        let encoded = packbits_encode(&data);
+        // Should compress well: 200 identical bytes
+        assert!(encoded.len() < data.len() / 10);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_alternating() {
+        let data: Vec<u8> = (0..200).map(|i| if i % 2 == 0 { 0xAA } else { 0x55 }).collect();
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_mixed() {
+        let mut data = Vec::new();
+        // Run of 50 identical
+        data.extend_from_slice(&vec![0xFF; 50]);
+        // 20 unique bytes
+        for i in 0..20u8 {
+            data.push(i * 10);
+        }
+        // Run of 80 identical
+        data.extend_from_slice(&vec![0x42; 80]);
+        // 5 unique
+        data.extend_from_slice(&[1, 2, 3, 4, 5]);
+
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_max_run() {
+        let data = vec![0xBB; 128];
+        let encoded = packbits_encode(&data);
+        // Single run: flag + byte = 2 bytes
+        assert_eq!(encoded.len(), 2);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_over_max_run() {
+        let data = vec![0xCC; 300];
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn roundtrip_gradient() {
+        // Simulates a gradient scanline — each byte is unique
+        let data: Vec<u8> = (0..=255).collect();
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn run_of_two_at_end() {
+        // Edge case: run of 2 identical bytes at the very end
+        let data = vec![1, 2, 3, 0xAA, 0xAA];
+        let encoded = packbits_encode(&data);
+        let decoded = packbits_decode(&encoded, data.len());
+        assert_eq!(decoded, data);
+    }
+}

--- a/engine-rs/crates/lopsy-core/src/psd/reader.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/reader.rs
@@ -1,0 +1,979 @@
+use std::io::Read as IoRead;
+use super::blend_keys::psd_key_to_blend_mode;
+use super::packbits::packbits_decode;
+use super::zip_predict::zip_predict_decode_16;
+use super::types::*;
+
+/// Parse a PSD file and return a document descriptor with all layer data.
+pub fn read_psd(data: &[u8]) -> Result<PsdDocument, PsdError> {
+    let mut cursor = PsdCursor::new(data);
+
+    let header = read_header(&mut cursor)?;
+    skip_color_mode_data(&mut cursor)?;
+    let icc_profile = read_image_resources(&mut cursor)?;
+    let layers = read_layer_and_mask_info(&mut cursor, &header)?;
+
+    // If no layers were found, try to read the merged composite as a single layer
+    let layers = if layers.is_empty() {
+        let composite = read_merged_composite(&mut cursor, &header)?;
+        vec![PsdLayer {
+            name: "Background".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: crate::color::BlendMode::Normal,
+            clip_to_below: false,
+            rect: PsdRect::from_xywh(0, 0, header.width, header.height),
+            pixel_data: composite,
+            mask: None,
+            group_kind: GroupKind::Normal,
+        }]
+    } else {
+        layers
+    };
+
+    Ok(PsdDocument {
+        width: header.width,
+        height: header.height,
+        depth: header.depth,
+        layers,
+        icc_profile,
+    })
+}
+
+// ─── Internal types ────────────────────────────────────────────────────
+
+struct PsdHeader {
+    width: u32,
+    height: u32,
+    depth: PsdDepth,
+    channels: u16,
+}
+
+struct PsdCursor<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> PsdCursor<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.pos)
+    }
+
+    fn read_bytes(&mut self, n: usize) -> Result<&'a [u8], PsdError> {
+        if self.pos + n > self.data.len() {
+            return Err(PsdError::TruncatedData);
+        }
+        let slice = &self.data[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, PsdError> {
+        let b = self.read_bytes(1)?;
+        Ok(b[0])
+    }
+
+    fn read_u16(&mut self) -> Result<u16, PsdError> {
+        let b = self.read_bytes(2)?;
+        Ok(u16::from_be_bytes([b[0], b[1]]))
+    }
+
+    fn read_i16(&mut self) -> Result<i16, PsdError> {
+        let b = self.read_bytes(2)?;
+        Ok(i16::from_be_bytes([b[0], b[1]]))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, PsdError> {
+        let b = self.read_bytes(4)?;
+        Ok(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn read_i32(&mut self) -> Result<i32, PsdError> {
+        let b = self.read_bytes(4)?;
+        Ok(i32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn skip(&mut self, n: usize) -> Result<(), PsdError> {
+        if self.pos + n > self.data.len() {
+            return Err(PsdError::TruncatedData);
+        }
+        self.pos += n;
+        Ok(())
+    }
+
+    fn position(&self) -> usize {
+        self.pos
+    }
+}
+
+// ─── Section 1: Header ────────────────────────────────────────────────
+
+fn read_header(c: &mut PsdCursor) -> Result<PsdHeader, PsdError> {
+    let sig = c.read_bytes(4)?;
+    if sig != b"8BPS" {
+        return Err(PsdError::InvalidSignature);
+    }
+
+    let version = c.read_u16()?;
+    if version != 1 {
+        return Err(PsdError::UnsupportedVersion(version));
+    }
+
+    c.skip(6)?; // reserved
+
+    let channels = c.read_u16()?;
+    let height = c.read_u32()?;
+    let width = c.read_u32()?;
+    let depth_bits = c.read_u16()?;
+    let color_mode = c.read_u16()?;
+
+    if color_mode != 3 {
+        return Err(PsdError::UnsupportedColorMode(color_mode));
+    }
+
+    let depth = match depth_bits {
+        8 => PsdDepth::Eight,
+        16 => PsdDepth::Sixteen,
+        _ => return Err(PsdError::UnsupportedDepth(depth_bits)),
+    };
+
+    Ok(PsdHeader { width, height, depth, channels })
+}
+
+// ─── Section 2: Color Mode Data ────────────────────────────────────────
+
+fn skip_color_mode_data(c: &mut PsdCursor) -> Result<(), PsdError> {
+    let len = c.read_u32()? as usize;
+    c.skip(len)
+}
+
+// ─── Section 3: Image Resources ────────────────────────────────────────
+
+fn read_image_resources(c: &mut PsdCursor) -> Result<Option<Vec<u8>>, PsdError> {
+    let section_len = c.read_u32()? as usize;
+    let section_end = c.position() + section_len;
+    let mut icc_profile = None;
+
+    while c.position() + 12 <= section_end {
+        let sig = c.read_bytes(4)?;
+        if sig != b"8BIM" {
+            break;
+        }
+
+        let id = c.read_u16()?;
+
+        // Pascal string name (padded to even)
+        let name_len = c.read_u8()? as usize;
+        let padded_name_len = if (name_len + 1) % 2 != 0 { name_len + 1 } else { name_len };
+        c.skip(padded_name_len)?;
+
+        let data_len = c.read_u32()? as usize;
+        let data_start = c.position();
+
+        if id == 1039 && data_len > 0 {
+            // ICC profile
+            icc_profile = Some(c.read_bytes(data_len)?.to_vec());
+        } else {
+            c.skip(data_len)?;
+        }
+
+        // Pad to even
+        let consumed = c.position() - data_start;
+        if consumed < data_len {
+            c.skip(data_len - consumed)?;
+        }
+        if data_len % 2 != 0 {
+            c.skip(1)?;
+        }
+    }
+
+    // Ensure we're at section end
+    if c.position() < section_end {
+        c.skip(section_end - c.position())?;
+    }
+
+    Ok(icc_profile)
+}
+
+// ─── Section 4: Layer and Mask Information ─────────────────────────────
+
+struct LayerRecord {
+    rect: PsdRect,
+    channel_info: Vec<ChannelInfo>,
+    blend_mode: crate::color::BlendMode,
+    opacity: u8,
+    visible: bool,
+    clip_to_below: bool,
+    name: String,
+    group_kind: GroupKind,
+    mask: Option<MaskRecord>,
+}
+
+struct ChannelInfo {
+    id: i16,
+    data_length: u32,
+}
+
+struct MaskRecord {
+    rect: PsdRect,
+    default_color: u8,
+}
+
+fn read_layer_and_mask_info(c: &mut PsdCursor, header: &PsdHeader) -> Result<Vec<PsdLayer>, PsdError> {
+    let section_len = c.read_u32()? as usize;
+    if section_len == 0 {
+        return Ok(Vec::new());
+    }
+    let section_end = c.position() + section_len;
+
+    // First, try the main layer info section
+    let mut layers = read_layer_info(c, header)?;
+
+    // For 16-bit/32-bit docs, layers may be in an Lr16/Lr32 block at document level.
+    // Scan the remaining section for these blocks.
+    if layers.is_empty() && c.position() < section_end {
+        // Skip global layer mask info
+        let global_mask_len = c.read_u32()? as usize;
+        c.skip(global_mask_len)?;
+
+        // Scan additional layer info blocks
+        while c.position() + 12 <= section_end {
+            let sig = c.read_bytes(4)?;
+            if sig != b"8BIM" && sig != b"8B64" {
+                break;
+            }
+            let key = c.read_bytes(4)?;
+            let block_len = c.read_u32()? as usize;
+            let block_start = c.position();
+
+            if key == b"Lr16" || key == b"Lr32" {
+                // Block body is layer count + records + channel data (no length prefix)
+                let inner_layers = read_layer_info_body(c, header, block_start + block_len)?;
+                if !inner_layers.is_empty() {
+                    layers = inner_layers;
+                }
+            }
+
+            // Skip to end of this block
+            let consumed = c.position() - block_start;
+            if consumed < block_len {
+                c.skip(block_len - consumed)?;
+            }
+            // Pad to even
+            if block_len % 2 != 0 && c.position() < section_end {
+                c.skip(1)?;
+            }
+        }
+    }
+
+    // Skip to end of section
+    if c.position() < section_end {
+        c.skip(section_end - c.position())?;
+    }
+
+    Ok(layers)
+}
+
+fn read_layer_info(c: &mut PsdCursor, header: &PsdHeader) -> Result<Vec<PsdLayer>, PsdError> {
+    let layer_info_len = c.read_u32()? as usize;
+    if layer_info_len == 0 {
+        return Ok(Vec::new());
+    }
+    let layer_info_end = c.position() + layer_info_len;
+    let layers = read_layer_info_body(c, header, layer_info_end)?;
+
+    // Align to layer_info_end
+    if c.position() < layer_info_end {
+        c.skip(layer_info_end - c.position())?;
+    }
+
+    Ok(layers)
+}
+
+/// Read the layer info body (layer count + records + channel data)
+/// from a bounded region.
+fn read_layer_info_body(c: &mut PsdCursor, header: &PsdHeader, end: usize) -> Result<Vec<PsdLayer>, PsdError> {
+    if c.position() >= end {
+        return Ok(Vec::new());
+    }
+
+    let layer_count_raw = c.read_i16()?;
+    let layer_count = layer_count_raw.unsigned_abs() as usize;
+
+    let mut records = Vec::with_capacity(layer_count);
+    for _ in 0..layer_count {
+        records.push(read_layer_record(c)?);
+    }
+
+    let mut layers = Vec::with_capacity(layer_count);
+    for record in records {
+        let (pixel_data, mask) = read_all_layer_channels(c, &record, header)?;
+
+        layers.push(PsdLayer {
+            name: record.name,
+            visible: record.visible,
+            opacity: record.opacity,
+            blend_mode: record.blend_mode,
+            clip_to_below: record.clip_to_below,
+            rect: record.rect,
+            pixel_data,
+            mask,
+            group_kind: record.group_kind,
+        });
+    }
+
+    Ok(layers)
+}
+
+fn read_layer_record(c: &mut PsdCursor) -> Result<LayerRecord, PsdError> {
+    let top = c.read_i32()?;
+    let left = c.read_i32()?;
+    let bottom = c.read_i32()?;
+    let right = c.read_i32()?;
+    let rect = PsdRect::new(top, left, bottom, right);
+
+    let channel_count = c.read_u16()? as usize;
+    let mut channel_info = Vec::with_capacity(channel_count);
+    for _ in 0..channel_count {
+        let id = c.read_i16()?;
+        let data_length = c.read_u32()?;
+        channel_info.push(ChannelInfo { id, data_length });
+    }
+
+    // Blend mode signature + key
+    let sig = c.read_bytes(4)?;
+    if sig != b"8BIM" {
+        return Err(PsdError::InvalidLayerData("bad blend mode signature".into()));
+    }
+    let key = c.read_bytes(4)?;
+    let blend_mode = psd_key_to_blend_mode(key.try_into().unwrap());
+
+    let opacity = c.read_u8()?;
+    let clipping = c.read_u8()?;
+    let flags = c.read_u8()?;
+    c.skip(1)?; // filler
+
+    let visible = (flags & 0x02) == 0;
+    let clip_to_below = clipping == 1;
+
+    // Extra data
+    let extra_len = c.read_u32()? as usize;
+    let extra_end = c.position() + extra_len;
+
+    // Layer mask data
+    let mask_data_len = c.read_u32()? as usize;
+    let mask = if mask_data_len >= 20 {
+        let mask_top = c.read_i32()?;
+        let mask_left = c.read_i32()?;
+        let mask_bottom = c.read_i32()?;
+        let mask_right = c.read_i32()?;
+        let default_color = c.read_u8()?;
+        let _flags = c.read_u8()?;
+        // Skip remaining mask data
+        let consumed = 18;
+        if mask_data_len > consumed {
+            c.skip(mask_data_len - consumed)?;
+        }
+        Some(MaskRecord {
+            rect: PsdRect::new(mask_top, mask_left, mask_bottom, mask_right),
+            default_color,
+        })
+    } else {
+        if mask_data_len > 0 {
+            c.skip(mask_data_len)?;
+        }
+        None
+    };
+
+    // Layer blending ranges
+    let blend_ranges_len = c.read_u32()? as usize;
+    c.skip(blend_ranges_len)?;
+
+    // Layer name (Pascal string padded to 4 bytes)
+    let name_len = c.read_u8()? as usize;
+    let name_bytes = c.read_bytes(name_len)?;
+    let name = String::from_utf8_lossy(name_bytes).to_string();
+    let total = 1 + name_len;
+    let padding = (4 - (total % 4)) % 4;
+    c.skip(padding)?;
+
+    // Scan additional layer info for luni and lsct
+    let mut unicode_name: Option<String> = None;
+    let mut group_kind = GroupKind::Normal;
+
+    while c.position() + 12 <= extra_end {
+        let ali_sig = c.read_bytes(4)?;
+        if ali_sig != b"8BIM" && ali_sig != b"8B64" {
+            // Not a valid additional layer info block, rewind and stop
+            break;
+        }
+        let ali_key = c.read_bytes(4)?;
+        let ali_len = c.read_u32()? as usize;
+        let ali_data_start = c.position();
+
+        match ali_key {
+            b"luni" => {
+                let char_count = c.read_u32()? as usize;
+                let utf16_bytes = c.read_bytes(char_count * 2)?;
+                let utf16: Vec<u16> = utf16_bytes
+                    .chunks_exact(2)
+                    .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+                    .collect();
+                unicode_name = Some(String::from_utf16_lossy(&utf16));
+            }
+            b"lsct" | b"lsdk" => {
+                let divider_type = c.read_u32()?;
+                group_kind = match divider_type {
+                    1 => GroupKind::GroupOpen,
+                    2 => GroupKind::GroupClosed,
+                    3 => GroupKind::GroupEnd,
+                    _ => GroupKind::Normal,
+                };
+            }
+            _ => {}
+        }
+
+        // Skip to end of this additional layer info block
+        let consumed = c.position() - ali_data_start;
+        if consumed < ali_len {
+            c.skip(ali_len - consumed)?;
+        }
+        // Pad to even
+        if ali_len % 2 != 0 {
+            if c.position() < extra_end {
+                c.skip(1)?;
+            }
+        }
+    }
+
+    // Skip to extra_end
+    if c.position() < extra_end {
+        c.skip(extra_end - c.position())?;
+    }
+
+    // Group-end sentinels in real PSD files use "</Layer group>" as their name
+    // — normalize back to empty for clean semantics.
+    let raw_name = unicode_name.unwrap_or(name);
+    let final_name = if group_kind == GroupKind::GroupEnd && raw_name == "</Layer group>" {
+        String::new()
+    } else {
+        raw_name
+    };
+
+    Ok(LayerRecord {
+        rect,
+        channel_info,
+        blend_mode,
+        opacity,
+        visible,
+        clip_to_below,
+        name: final_name,
+        group_kind,
+        mask,
+    })
+}
+
+/// Read and interleave all channel pixel data for a single layer,
+/// including the mask channel if present.
+fn read_all_layer_channels(
+    c: &mut PsdCursor,
+    record: &LayerRecord,
+    header: &PsdHeader,
+) -> Result<(Vec<u8>, Option<PsdMask>), PsdError> {
+    let w = record.rect.width() as usize;
+    let h = record.rect.height() as usize;
+
+    if w == 0 || h == 0 {
+        // Group markers / empty layers — skip channel data
+        for ch in &record.channel_info {
+            c.skip(ch.data_length as usize)?;
+        }
+        return Ok((Vec::new(), None));
+    }
+
+    let bpc = header.depth.bytes_per_channel();
+    let pixel_count = w * h;
+
+    // Read each channel
+    let mut r_plane: Option<Vec<u8>> = None;
+    let mut g_plane: Option<Vec<u8>> = None;
+    let mut b_plane: Option<Vec<u8>> = None;
+    let mut a_plane: Option<Vec<u8>> = None;
+    let mut mask_plane: Option<Vec<u8>> = None;
+
+    for ch in &record.channel_info {
+        if ch.id == -2 {
+            // Mask channel — decode using mask rect dimensions
+            if let Some(ref mr) = record.mask {
+                let mw = mr.rect.width() as usize;
+                let mh = mr.rect.height() as usize;
+                if mw > 0 && mh > 0 {
+                    // Masks are always 8-bit grayscale
+                    let mask_header = PsdHeader {
+                        width: mw as u32,
+                        height: mh as u32,
+                        depth: PsdDepth::Eight,
+                        channels: 1,
+                    };
+                    let plane = decode_channel(c, ch.data_length as usize, mw, mh, &mask_header)?;
+                    mask_plane = Some(plane);
+                } else {
+                    c.skip(ch.data_length as usize)?;
+                }
+            } else {
+                c.skip(ch.data_length as usize)?;
+            }
+            continue;
+        }
+
+        let plane = decode_channel(c, ch.data_length as usize, w, h, header)?;
+
+        match ch.id {
+            -1 => a_plane = Some(plane),
+            0 => r_plane = Some(plane),
+            1 => g_plane = Some(plane),
+            2 => b_plane = Some(plane),
+            _ => {} // skip unknown channels
+        }
+    }
+
+    // Interleave into RGBA
+    let default_color = vec![0u8; pixel_count * bpc];
+    let default_alpha = match header.depth {
+        PsdDepth::Eight => vec![255u8; pixel_count],
+        PsdDepth::Sixteen => {
+            let mut v = Vec::with_capacity(pixel_count * 2);
+            for _ in 0..pixel_count {
+                v.extend_from_slice(&[0xFF, 0xFF]);
+            }
+            v
+        }
+    };
+
+    let r = r_plane.as_ref().unwrap_or(&default_color);
+    let g = g_plane.as_ref().unwrap_or(&default_color);
+    let b = b_plane.as_ref().unwrap_or(&default_color);
+    let a = a_plane.as_ref().unwrap_or(&default_alpha);
+
+    let mut interleaved = Vec::with_capacity(pixel_count * 4 * bpc);
+    match header.depth {
+        PsdDepth::Eight => {
+            for i in 0..pixel_count {
+                interleaved.push(r[i]);
+                interleaved.push(g[i]);
+                interleaved.push(b[i]);
+                interleaved.push(a[i]);
+            }
+        }
+        PsdDepth::Sixteen => {
+            for i in 0..pixel_count {
+                interleaved.extend_from_slice(&r[i * 2..i * 2 + 2]);
+                interleaved.extend_from_slice(&g[i * 2..i * 2 + 2]);
+                interleaved.extend_from_slice(&b[i * 2..i * 2 + 2]);
+                interleaved.extend_from_slice(&a[i * 2..i * 2 + 2]);
+            }
+        }
+    }
+
+    // Build mask
+    let mask = match (&record.mask, mask_plane) {
+        (Some(mr), Some(data)) if !mr.rect.is_empty() => {
+            Some(PsdMask {
+                rect: mr.rect,
+                data,
+                default_color: mr.default_color,
+            })
+        }
+        (Some(mr), None) if !mr.rect.is_empty() => {
+            let mw = mr.rect.width() as usize;
+            let mh = mr.rect.height() as usize;
+            Some(PsdMask {
+                rect: mr.rect,
+                data: vec![mr.default_color; mw * mh],
+                default_color: mr.default_color,
+            })
+        }
+        _ => None,
+    };
+
+    Ok((interleaved, mask))
+}
+
+/// Decode a single channel from the stream.
+fn decode_channel(
+    c: &mut PsdCursor,
+    total_len: usize,
+    w: usize,
+    h: usize,
+    header: &PsdHeader,
+) -> Result<Vec<u8>, PsdError> {
+    if total_len < 2 {
+        return Err(PsdError::InvalidLayerData("channel data too short".into()));
+    }
+
+    let compression = c.read_u16()?;
+    let data_len = total_len - 2;
+
+    match compression {
+        0 => {
+            // Raw
+            let data = c.read_bytes(data_len)?;
+            Ok(data.to_vec())
+        }
+        1 => {
+            // PackBits RLE
+            // Byte count table: h entries of u16
+            let mut total_compressed = 0usize;
+            for _ in 0..h {
+                total_compressed += c.read_u16()? as usize;
+            }
+
+            let compressed = c.read_bytes(total_compressed)?;
+            let bpc = header.depth.bytes_per_channel();
+            let expected_total = w * bpc * h;
+            let decoded = packbits_decode(compressed, expected_total);
+            Ok(decoded)
+        }
+        2 => {
+            // ZIP without prediction
+            let compressed = c.read_bytes(data_len)?;
+            super::zip_predict::zip_decode(compressed, w * h * header.depth.bytes_per_channel())
+                .map_err(|e| PsdError::DecompressionFailed(e))
+        }
+        3 => {
+            // ZIP with prediction
+            let compressed = c.read_bytes(data_len)?;
+            match header.depth {
+                PsdDepth::Sixteen => {
+                    let u16_data = zip_predict_decode_16(compressed, w as u32, h as u32)
+                        .map_err(|e| PsdError::DecompressionFailed(e))?;
+                    let mut bytes = Vec::with_capacity(u16_data.len() * 2);
+                    for val in &u16_data {
+                        bytes.extend_from_slice(&val.to_be_bytes());
+                    }
+                    Ok(bytes)
+                }
+                PsdDepth::Eight => {
+                    // 8-bit ZIP with prediction: byte-level delta
+                    let mut decoder = flate2::read::ZlibDecoder::new(compressed);
+                    let mut delta_buf = Vec::new();
+                    decoder.read_to_end(&mut delta_buf)
+                        .map_err(|e| PsdError::DecompressionFailed(e.to_string()))?;
+
+                    // Undo delta per row
+                    let row_size = w;
+                    for y in 0..h {
+                        let start = y * row_size;
+                        for x in 1..row_size {
+                            delta_buf[start + x] = delta_buf[start + x].wrapping_add(delta_buf[start + x - 1]);
+                        }
+                    }
+                    Ok(delta_buf)
+                }
+            }
+        }
+        _ => {
+            // Unknown compression — skip
+            c.skip(data_len)?;
+            let bpc = header.depth.bytes_per_channel();
+            Ok(vec![0; w * h * bpc])
+        }
+    }
+}
+
+// ─── Section 5: Merged Composite ───────────────────────────────────────
+
+fn read_merged_composite(c: &mut PsdCursor, header: &PsdHeader) -> Result<Vec<u8>, PsdError> {
+    if c.remaining() < 2 {
+        return Err(PsdError::TruncatedData);
+    }
+
+    let compression = c.read_u16()?;
+    let w = header.width as usize;
+    let h = header.height as usize;
+    let bpc = header.depth.bytes_per_channel();
+    let channels = header.channels as usize;
+    let plane_size = w * h * bpc;
+
+    let all_planes = match compression {
+        0 => {
+            // Raw
+            let data = c.read_bytes(plane_size * channels)?;
+            data.to_vec()
+        }
+        1 => {
+            // RLE: byte counts for all channels, then data
+            let total_rows = h * channels;
+            let mut total_compressed = 0usize;
+            for _ in 0..total_rows {
+                total_compressed += c.read_u16()? as usize;
+            }
+            let compressed = c.read_bytes(total_compressed)?;
+            packbits_decode(compressed, plane_size * channels)
+        }
+        3 => {
+            // ZIP with prediction — single stream, all channels stacked
+            let remaining = c.remaining();
+            let compressed = c.read_bytes(remaining)?;
+            match header.depth {
+                PsdDepth::Sixteen => {
+                    let total_pixels = w * h * channels;
+                    let u16_data = zip_predict_decode_16(compressed, w as u32, (h * channels) as u32)
+                        .map_err(|e| PsdError::DecompressionFailed(e))?;
+                    let mut bytes = Vec::with_capacity(total_pixels * 2);
+                    for val in &u16_data {
+                        bytes.extend_from_slice(&val.to_be_bytes());
+                    }
+                    bytes
+                }
+                PsdDepth::Eight => {
+                    let mut decoder = flate2::read::ZlibDecoder::new(compressed);
+                    let mut delta_buf = Vec::new();
+                    decoder.read_to_end(&mut delta_buf)
+                        .map_err(|e| PsdError::DecompressionFailed(e.to_string()))?;
+                    let row_size = w * bpc;
+                    let total_rows = h * channels;
+                    for y in 0..total_rows {
+                        let start = y * row_size;
+                        for x in 1..row_size {
+                            delta_buf[start + x] = delta_buf[start + x].wrapping_add(delta_buf[start + x - 1]);
+                        }
+                    }
+                    delta_buf
+                }
+            }
+        }
+        _ => {
+            return Err(PsdError::DecompressionFailed(format!("unsupported compression type {compression}")));
+        }
+    };
+
+    // Deinterleave from planar (R plane, G plane, B plane, [A plane]) to interleaved RGBA
+    let pixel_count = w * h;
+    let has_alpha = channels >= 4;
+
+    let mut rgba = Vec::with_capacity(pixel_count * 4 * bpc);
+    match header.depth {
+        PsdDepth::Eight => {
+            let r_plane = &all_planes[0..plane_size];
+            let g_plane = &all_planes[plane_size..plane_size * 2];
+            let b_plane = &all_planes[plane_size * 2..plane_size * 3];
+            let a_plane = if has_alpha {
+                &all_planes[plane_size * 3..plane_size * 4]
+            } else {
+                &[]
+            };
+
+            for i in 0..pixel_count {
+                rgba.push(r_plane[i]);
+                rgba.push(g_plane[i]);
+                rgba.push(b_plane[i]);
+                rgba.push(if has_alpha { a_plane[i] } else { 255 });
+            }
+        }
+        PsdDepth::Sixteen => {
+            let r_plane = &all_planes[0..plane_size];
+            let g_plane = &all_planes[plane_size..plane_size * 2];
+            let b_plane = &all_planes[plane_size * 2..plane_size * 3];
+            let a_plane = if has_alpha {
+                &all_planes[plane_size * 3..plane_size * 4]
+            } else {
+                &[]
+            };
+
+            for i in 0..pixel_count {
+                rgba.extend_from_slice(&r_plane[i * 2..i * 2 + 2]);
+                rgba.extend_from_slice(&g_plane[i * 2..i * 2 + 2]);
+                rgba.extend_from_slice(&b_plane[i * 2..i * 2 + 2]);
+                if has_alpha {
+                    rgba.extend_from_slice(&a_plane[i * 2..i * 2 + 2]);
+                } else {
+                    rgba.extend_from_slice(&[0xFF, 0xFF]);
+                }
+            }
+        }
+    }
+
+    Ok(rgba)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::BlendMode;
+    use super::super::writer::write_psd;
+
+    fn make_doc_8bit() -> PsdDocument {
+        let w = 4u32;
+        let h = 4u32;
+        let mut data = Vec::with_capacity(64);
+        for _ in 0..16 {
+            data.extend_from_slice(&[255, 0, 0, 255]);
+        }
+        PsdDocument {
+            width: w,
+            height: h,
+            depth: PsdDepth::Eight,
+            layers: vec![PsdLayer {
+                name: "Red".to_string(),
+                visible: true,
+                opacity: 200,
+                blend_mode: BlendMode::Multiply,
+                clip_to_below: false,
+                rect: PsdRect::from_xywh(1, 2, 4, 4),
+                pixel_data: data,
+                mask: None,
+                group_kind: GroupKind::Normal,
+            }],
+            icc_profile: None,
+        }
+    }
+
+    fn make_doc_16bit() -> PsdDocument {
+        let w = 4u32;
+        let h = 4u32;
+        let mut data = Vec::with_capacity(128);
+        for _ in 0..16 {
+            data.extend_from_slice(&[0x80, 0x00]); // R = 32768
+            data.extend_from_slice(&[0x40, 0x00]); // G = 16384
+            data.extend_from_slice(&[0xC0, 0x00]); // B = 49152
+            data.extend_from_slice(&[0xFF, 0xFF]); // A = 65535
+        }
+        PsdDocument {
+            width: w,
+            height: h,
+            depth: PsdDepth::Sixteen,
+            layers: vec![PsdLayer {
+                name: "16bit layer".to_string(),
+                visible: true,
+                opacity: 255,
+                blend_mode: BlendMode::Screen,
+                clip_to_below: false,
+                rect: PsdRect::from_xywh(0, 0, w, h),
+                pixel_data: data,
+                mask: None,
+                group_kind: GroupKind::Normal,
+            }],
+            icc_profile: None,
+        }
+    }
+
+    #[test]
+    fn roundtrip_8bit_single_layer() {
+        let original = make_doc_8bit();
+        let psd_bytes = write_psd(&original);
+        let parsed = read_psd(&psd_bytes).unwrap();
+
+        assert_eq!(parsed.width, original.width);
+        assert_eq!(parsed.height, original.height);
+        assert_eq!(parsed.depth, original.depth);
+        assert_eq!(parsed.layers.len(), 1);
+
+        let orig_layer = &original.layers[0];
+        let parsed_layer = &parsed.layers[0];
+        assert_eq!(parsed_layer.name, orig_layer.name);
+        assert_eq!(parsed_layer.opacity, orig_layer.opacity);
+        assert_eq!(parsed_layer.blend_mode, orig_layer.blend_mode);
+        assert_eq!(parsed_layer.visible, orig_layer.visible);
+        assert_eq!(parsed_layer.rect, orig_layer.rect);
+        assert_eq!(parsed_layer.pixel_data, orig_layer.pixel_data);
+    }
+
+    #[test]
+    fn roundtrip_16bit_single_layer() {
+        let original = make_doc_16bit();
+        let psd_bytes = write_psd(&original);
+        let parsed = read_psd(&psd_bytes).unwrap();
+
+        assert_eq!(parsed.width, original.width);
+        assert_eq!(parsed.height, original.height);
+        assert_eq!(parsed.depth, original.depth);
+        assert_eq!(parsed.layers.len(), 1);
+
+        let orig_layer = &original.layers[0];
+        let parsed_layer = &parsed.layers[0];
+        assert_eq!(parsed_layer.name, orig_layer.name);
+        assert_eq!(parsed_layer.opacity, orig_layer.opacity);
+        assert_eq!(parsed_layer.blend_mode, orig_layer.blend_mode);
+        assert_eq!(parsed_layer.pixel_data, orig_layer.pixel_data, "16-bit pixel data mismatch");
+    }
+
+    #[test]
+    fn roundtrip_with_groups() {
+        let doc = PsdDocument {
+            width: 2,
+            height: 2,
+            depth: PsdDepth::Eight,
+            layers: vec![
+                PsdLayer {
+                    name: "BG".to_string(),
+                    visible: true,
+                    opacity: 255,
+                    blend_mode: BlendMode::Normal,
+                    clip_to_below: false,
+                    rect: PsdRect::from_xywh(0, 0, 2, 2),
+                    pixel_data: vec![0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255],
+                    mask: None,
+                    group_kind: GroupKind::Normal,
+                },
+                PsdLayer {
+                    name: "".to_string(),
+                    visible: true,
+                    opacity: 255,
+                    blend_mode: BlendMode::Normal,
+                    clip_to_below: false,
+                    rect: PsdRect::new(0, 0, 0, 0),
+                    pixel_data: Vec::new(),
+                    mask: None,
+                    group_kind: GroupKind::GroupEnd,
+                },
+                PsdLayer {
+                    name: "Child".to_string(),
+                    visible: true,
+                    opacity: 128,
+                    blend_mode: BlendMode::Overlay,
+                    clip_to_below: false,
+                    rect: PsdRect::from_xywh(0, 0, 2, 2),
+                    pixel_data: vec![255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255],
+                    mask: None,
+                    group_kind: GroupKind::Normal,
+                },
+                PsdLayer {
+                    name: "My Group".to_string(),
+                    visible: true,
+                    opacity: 255,
+                    blend_mode: BlendMode::Normal,
+                    clip_to_below: false,
+                    rect: PsdRect::new(0, 0, 0, 0),
+                    pixel_data: Vec::new(),
+                    mask: None,
+                    group_kind: GroupKind::GroupOpen,
+                },
+            ],
+            icc_profile: None,
+        };
+
+        let psd_bytes = write_psd(&doc);
+        let parsed = read_psd(&psd_bytes).unwrap();
+
+        assert_eq!(parsed.layers.len(), 4);
+        assert_eq!(parsed.layers[0].name, "BG");
+        assert_eq!(parsed.layers[0].group_kind, GroupKind::Normal);
+        assert_eq!(parsed.layers[1].group_kind, GroupKind::GroupEnd);
+        assert_eq!(parsed.layers[2].name, "Child");
+        assert_eq!(parsed.layers[2].opacity, 128);
+        assert_eq!(parsed.layers[2].blend_mode, BlendMode::Overlay);
+        assert_eq!(parsed.layers[3].name, "My Group");
+        assert_eq!(parsed.layers[3].group_kind, GroupKind::GroupOpen);
+    }
+
+    #[test]
+    fn reject_invalid_signature() {
+        let result = read_psd(b"NOT_PSD_DATA_HERE");
+        assert!(matches!(result, Err(PsdError::InvalidSignature)));
+    }
+}

--- a/engine-rs/crates/lopsy-core/src/psd/types.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/types.rs
@@ -1,0 +1,139 @@
+use crate::color::BlendMode;
+
+/// Bit depth of a PSD document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsdDepth {
+    Eight,
+    Sixteen,
+}
+
+impl PsdDepth {
+    pub fn bits_per_channel(self) -> u16 {
+        match self {
+            PsdDepth::Eight => 8,
+            PsdDepth::Sixteen => 16,
+        }
+    }
+
+    pub fn bytes_per_channel(self) -> usize {
+        match self {
+            PsdDepth::Eight => 1,
+            PsdDepth::Sixteen => 2,
+        }
+    }
+}
+
+/// Role of a layer in the PSD group hierarchy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupKind {
+    /// Normal raster/content layer.
+    Normal,
+    /// Group start marker (open folder in Photoshop).
+    GroupOpen,
+    /// Group start marker (closed folder).
+    GroupClosed,
+    /// Group end / bounding section divider.
+    GroupEnd,
+}
+
+/// Axis-aligned rectangle in document coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PsdRect {
+    pub top: i32,
+    pub left: i32,
+    pub bottom: i32,
+    pub right: i32,
+}
+
+impl PsdRect {
+    pub fn new(top: i32, left: i32, bottom: i32, right: i32) -> Self {
+        Self { top, left, bottom, right }
+    }
+
+    pub fn from_xywh(x: i32, y: i32, w: u32, h: u32) -> Self {
+        Self {
+            top: y,
+            left: x,
+            bottom: y + h as i32,
+            right: x + w as i32,
+        }
+    }
+
+    pub fn width(self) -> u32 {
+        (self.right - self.left).max(0) as u32
+    }
+
+    pub fn height(self) -> u32 {
+        (self.bottom - self.top).max(0) as u32
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.width() == 0 || self.height() == 0
+    }
+}
+
+/// Layer mask data.
+#[derive(Debug, Clone)]
+pub struct PsdMask {
+    pub rect: PsdRect,
+    /// Grayscale mask data, one byte per pixel, row-major.
+    pub data: Vec<u8>,
+    /// Default color for pixels outside the mask rect (0 or 255).
+    pub default_color: u8,
+}
+
+/// A single layer in a PSD document.
+#[derive(Debug, Clone)]
+pub struct PsdLayer {
+    pub name: String,
+    pub visible: bool,
+    /// 0–255
+    pub opacity: u8,
+    pub blend_mode: BlendMode,
+    pub clip_to_below: bool,
+    pub rect: PsdRect,
+    /// Interleaved RGBA pixel data covering `rect`.
+    /// For 8-bit: one byte per component (len = w * h * 4).
+    /// For 16-bit: big-endian u16 pairs, two bytes per component (len = w * h * 8).
+    pub pixel_data: Vec<u8>,
+    pub mask: Option<PsdMask>,
+    pub group_kind: GroupKind,
+}
+
+/// A PSD document ready to be written or just read.
+#[derive(Debug, Clone)]
+pub struct PsdDocument {
+    pub width: u32,
+    pub height: u32,
+    pub depth: PsdDepth,
+    pub layers: Vec<PsdLayer>,
+    pub icc_profile: Option<Vec<u8>>,
+}
+
+/// Errors that can occur when reading a PSD file.
+#[derive(Debug)]
+pub enum PsdError {
+    InvalidSignature,
+    UnsupportedVersion(u16),
+    UnsupportedColorMode(u16),
+    UnsupportedDepth(u16),
+    TruncatedData,
+    InvalidLayerData(String),
+    DecompressionFailed(String),
+}
+
+impl std::fmt::Display for PsdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PsdError::InvalidSignature => write!(f, "not a PSD file (invalid signature)"),
+            PsdError::UnsupportedVersion(v) => write!(f, "unsupported PSD version {v}"),
+            PsdError::UnsupportedColorMode(m) => write!(f, "unsupported color mode {m} (only RGB is supported)"),
+            PsdError::UnsupportedDepth(d) => write!(f, "unsupported bit depth {d} (only 8 and 16 are supported)"),
+            PsdError::TruncatedData => write!(f, "unexpected end of file"),
+            PsdError::InvalidLayerData(msg) => write!(f, "invalid layer data: {msg}"),
+            PsdError::DecompressionFailed(msg) => write!(f, "decompression failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PsdError {}

--- a/engine-rs/crates/lopsy-core/src/psd/writer.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/writer.rs
@@ -1,0 +1,713 @@
+use std::io::{Cursor, Seek, SeekFrom, Write};
+use crate::color::ColorSpace;
+use crate::export::build_icc_profile;
+use super::blend_keys::blend_mode_to_psd_key;
+use super::flatten::flatten_layers;
+use super::packbits::packbits_encode;
+use super::zip_predict::zip_predict_encode_16;
+use super::types::{PsdDocument, PsdDepth, PsdLayer, GroupKind};
+
+/// Write a PSD file from a document descriptor.
+pub fn write_psd(doc: &PsdDocument) -> Vec<u8> {
+    let mut out = Cursor::new(Vec::with_capacity(1024 * 1024));
+
+    write_header(&mut out, doc);
+    write_color_mode_data(&mut out);
+    write_image_resources(&mut out, doc);
+    write_layer_and_mask_info(&mut out, doc);
+    write_merged_composite(&mut out, doc);
+
+    out.into_inner()
+}
+
+// ─── Section 1: File Header ────────────────────────────────────────────
+
+fn write_header(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    out.write_all(b"8BPS").unwrap();          // signature
+    write_u16(out, 1);                         // version
+    out.write_all(&[0u8; 6]).unwrap();         // reserved
+    // Photoshop expects the header channel count to match the color mode
+    // (RGB = 3). The merged image section writes 3 planes. Layer transparency
+    // is handled per-layer via channel id -1, not via this header count.
+    write_u16(out, 3);                         // channels (RGB)
+    write_u32(out, doc.height);                // rows
+    write_u32(out, doc.width);                 // columns
+    write_u16(out, doc.depth.bits_per_channel()); // depth
+    write_u16(out, 3);                         // color mode: RGB
+}
+
+// ─── Section 2: Color Mode Data ────────────────────────────────────────
+
+fn write_color_mode_data(out: &mut Cursor<Vec<u8>>) {
+    write_u32(out, 0); // length = 0 for RGB
+}
+
+// ─── Section 3: Image Resources ────────────────────────────────────────
+
+fn write_image_resources(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    let section_start = out.position();
+    write_u32(out, 0); // placeholder for length
+
+    // Resolution info (ID 1005): 72 DPI
+    write_image_resource(out, 1005, &build_resolution_info(72, 72));
+
+    // ICC profile (ID 1039)
+    let icc = doc.icc_profile.clone().unwrap_or_else(|| build_icc_profile(ColorSpace::Srgb));
+    write_image_resource(out, 1039, &icc);
+
+    // Backpatch section length
+    backpatch_u32(out, section_start);
+}
+
+fn write_image_resource(out: &mut Cursor<Vec<u8>>, id: u16, data: &[u8]) {
+    out.write_all(b"8BIM").unwrap();
+    write_u16(out, id);
+    out.write_all(&[0, 0]).unwrap(); // pascal string name (empty, padded to even)
+    write_u32(out, data.len() as u32);
+    out.write_all(data).unwrap();
+    // Pad to even
+    if data.len() % 2 != 0 {
+        out.write_all(&[0]).unwrap();
+    }
+}
+
+fn build_resolution_info(h_dpi: u16, v_dpi: u16) -> Vec<u8> {
+    let mut data = Vec::with_capacity(16);
+    // Horizontal resolution: fixed 16.16
+    write_u32_to_vec(&mut data, (h_dpi as u32) << 16);
+    write_u16_to_vec(&mut data, 1); // display unit: pixels per inch
+    write_u16_to_vec(&mut data, 1); // width unit: inches
+    // Vertical resolution: fixed 16.16
+    write_u32_to_vec(&mut data, (v_dpi as u32) << 16);
+    write_u16_to_vec(&mut data, 1); // display unit
+    write_u16_to_vec(&mut data, 1); // height unit
+    data
+}
+
+// ─── Section 4: Layer and Mask Information ─────────────────────────────
+
+fn write_layer_and_mask_info(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    let section_start = out.position();
+    write_u32(out, 0); // placeholder for total section length
+
+    match doc.depth {
+        PsdDepth::Eight => {
+            // 8-bit: layer info goes in the main layer info section.
+            write_layer_info_section(out, doc);
+            write_global_mask_info(out);
+        }
+        PsdDepth::Sixteen => {
+            // 16-bit: Photoshop requires layer info to be wrapped in an
+            // 'Lr16' additional layer info block at the document level.
+            // The main layer info section must be empty.
+            write_u32(out, 0); // empty main layer info
+            write_global_mask_info(out);
+            write_lr16_block(out, doc);
+        }
+    }
+
+    // Backpatch section length
+    backpatch_u32(out, section_start);
+}
+
+/// Write the layer info section (for 8-bit: directly in Section 4;
+/// for 16-bit: inside an Lr16 additional info block).
+fn write_layer_info_body(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    // Layer count: negative means first alpha channel contains transparency for merged result
+    let layer_count = doc.layers.len() as i16;
+    write_i16(out, -layer_count);
+
+    // Pre-compute channel data for each layer
+    let channel_data: Vec<LayerChannelData> = doc.layers.iter()
+        .map(|layer| encode_layer_channels(layer, doc.depth))
+        .collect();
+
+    // Write layer records
+    for (layer, ch_data) in doc.layers.iter().zip(channel_data.iter()) {
+        write_layer_record(out, layer, ch_data, doc.depth);
+    }
+
+    // Write channel image data for each layer
+    for ch_data in &channel_data {
+        for channel in &ch_data.channels {
+            write_u16(out, channel.compression);
+            out.write_all(&channel.data).unwrap();
+        }
+    }
+}
+
+fn write_layer_info_section(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    if doc.layers.is_empty() {
+        write_u32(out, 0);
+        return;
+    }
+
+    let layer_info_start = out.position();
+    write_u32(out, 0); // placeholder for layer info length
+
+    write_layer_info_body(out, doc);
+
+    // Backpatch layer info length (must be even)
+    backpatch_u32_even(out, layer_info_start);
+}
+
+/// Write an 'Lr16' additional layer info block containing the layer info body
+/// (layer count + records + channel data, NO inner length prefix).
+/// The body is padded to a 4-byte boundary — Photoshop requires this alignment.
+fn write_lr16_block(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    if doc.layers.is_empty() {
+        return;
+    }
+
+    out.write_all(b"8BIM").unwrap();
+    out.write_all(b"Lr16").unwrap();
+
+    let block_len_pos = out.position();
+    write_u32(out, 0); // placeholder for block length
+
+    write_layer_info_body(out, doc);
+
+    // Pad the block body to a 4-byte boundary
+    let end = out.position();
+    let data_len = (end - block_len_pos - 4) as usize;
+    let padding = (4 - (data_len % 4)) % 4;
+    for _ in 0..padding {
+        out.write_all(&[0]).unwrap();
+    }
+
+    let final_end = out.position();
+    let final_len = (final_end - block_len_pos - 4) as u32;
+    out.seek(SeekFrom::Start(block_len_pos)).unwrap();
+    out.write_all(&final_len.to_be_bytes()).unwrap();
+    out.seek(SeekFrom::Start(final_end)).unwrap();
+}
+
+fn write_layer_record(
+    out: &mut Cursor<Vec<u8>>,
+    layer: &PsdLayer,
+    ch_data: &LayerChannelData,
+    _depth: PsdDepth,
+) {
+    // Bounding rect: top, left, bottom, right
+    write_i32(out, layer.rect.top);
+    write_i32(out, layer.rect.left);
+    write_i32(out, layer.rect.bottom);
+    write_i32(out, layer.rect.right);
+
+    // Channel count
+    let channel_count = ch_data.channels.len() as u16;
+    write_u16(out, channel_count);
+
+    // Per-channel info: channel ID (i16) + data length (u32)
+    // Data length includes the 2-byte compression type
+    for channel in &ch_data.channels {
+        write_i16(out, channel.id);
+        write_u32(out, channel.data.len() as u32 + 2); // +2 for compression type
+    }
+
+    // Blend mode signature + key
+    out.write_all(b"8BIM").unwrap();
+    out.write_all(&blend_mode_to_psd_key(layer.blend_mode)).unwrap();
+
+    // Opacity
+    out.write_all(&[layer.opacity]).unwrap();
+
+    // Clipping: 0 = base, 1 = non-base (clipped)
+    out.write_all(&[if layer.clip_to_below { 1 } else { 0 }]).unwrap();
+
+    // Flags: bit 1 = visible (inverted: 0 = visible), bit 3 = Photoshop 5+ marker (always set)
+    let mut flags: u8 = 0x08;
+    if !layer.visible {
+        flags |= 0x02;
+    }
+    out.write_all(&[flags]).unwrap();
+
+    // Filler
+    out.write_all(&[0]).unwrap();
+
+    // Extra data
+    let extra_start = out.position();
+    write_u32(out, 0); // placeholder for extra data length
+
+    // Layer mask data
+    write_layer_mask_data(out, layer);
+
+    // Layer blending ranges (empty)
+    write_u32(out, 0);
+
+    // Layer name (Pascal string, padded to 4 bytes)
+    // Group-end markers conventionally use "</Layer group>"
+    let effective_name = if layer.group_kind == GroupKind::GroupEnd {
+        "</Layer group>"
+    } else {
+        &layer.name
+    };
+    write_pascal_string_padded4(out, effective_name);
+
+    // Additional layer info: Unicode name
+    write_unicode_name(out, effective_name);
+
+    // Additional layer info: Section divider (for groups)
+    if layer.group_kind != GroupKind::Normal {
+        write_section_divider(out, layer);
+    }
+
+    // Backpatch extra data length
+    backpatch_u32(out, extra_start);
+}
+
+fn write_layer_mask_data(out: &mut Cursor<Vec<u8>>, layer: &PsdLayer) {
+    match &layer.mask {
+        None => {
+            write_u32(out, 0);
+        }
+        Some(mask) => {
+            // Size of mask data: rect(16) + default_color(1) + flags(1) + padding(2) = 20
+            write_u32(out, 20);
+            write_i32(out, mask.rect.top);
+            write_i32(out, mask.rect.left);
+            write_i32(out, mask.rect.bottom);
+            write_i32(out, mask.rect.right);
+            out.write_all(&[mask.default_color]).unwrap();
+            out.write_all(&[0]).unwrap(); // flags
+            out.write_all(&[0, 0]).unwrap(); // padding
+        }
+    }
+}
+
+fn write_pascal_string_padded4(out: &mut Cursor<Vec<u8>>, s: &str) {
+    let bytes = s.as_bytes();
+    let len = bytes.len().min(255) as u8;
+    out.write_all(&[len]).unwrap();
+    out.write_all(&bytes[..len as usize]).unwrap();
+    // Pad to 4-byte boundary (1 byte length + N bytes name, total padded to multiple of 4)
+    let total = 1 + len as usize;
+    let padding = (4 - (total % 4)) % 4;
+    for _ in 0..padding {
+        out.write_all(&[0]).unwrap();
+    }
+}
+
+fn write_unicode_name(out: &mut Cursor<Vec<u8>>, name: &str) {
+    // 8BIM + 'luni' + length + data
+    out.write_all(b"8BIM").unwrap();
+    out.write_all(b"luni").unwrap();
+
+    let utf16: Vec<u16> = name.encode_utf16().collect();
+    // Data: u32 char count + u16[] chars
+    let data_len = 4 + utf16.len() * 2;
+    write_u32(out, data_len as u32);
+
+    write_u32(out, utf16.len() as u32);
+    for ch in &utf16 {
+        write_u16(out, *ch);
+    }
+
+    // Pad to even
+    if data_len % 2 != 0 {
+        out.write_all(&[0]).unwrap();
+    }
+}
+
+fn write_section_divider(out: &mut Cursor<Vec<u8>>, layer: &PsdLayer) {
+    out.write_all(b"8BIM").unwrap();
+    out.write_all(b"lsct").unwrap();
+
+    let divider_type: u32 = match layer.group_kind {
+        GroupKind::GroupEnd => 3,
+        GroupKind::GroupOpen => 1,
+        GroupKind::GroupClosed => 2,
+        GroupKind::Normal => 0,
+    };
+
+    // Data: type (4) + optional signature+key (8)
+    if layer.group_kind == GroupKind::GroupOpen || layer.group_kind == GroupKind::GroupClosed {
+        write_u32(out, 12); // length: type + sig + key
+        write_u32(out, divider_type);
+        out.write_all(b"8BIM").unwrap();
+        out.write_all(&blend_mode_to_psd_key(layer.blend_mode)).unwrap();
+    } else {
+        write_u32(out, 4); // length: just the type
+        write_u32(out, divider_type);
+    }
+}
+
+// ─── Channel Encoding ──────────────────────────────────────────────────
+
+struct ChannelEncoded {
+    id: i16,
+    compression: u16,
+    data: Vec<u8>,
+}
+
+struct LayerChannelData {
+    channels: Vec<ChannelEncoded>,
+}
+
+fn encode_layer_channels(layer: &PsdLayer, depth: PsdDepth) -> LayerChannelData {
+    let w = layer.rect.width() as usize;
+    let h = layer.rect.height() as usize;
+
+    // Group markers and empty layers have no pixel data
+    if w == 0 || h == 0 || layer.group_kind == GroupKind::GroupEnd {
+        return LayerChannelData {
+            channels: vec![
+                ChannelEncoded { id: -1, compression: 0, data: Vec::new() },
+                ChannelEncoded { id: 0, compression: 0, data: Vec::new() },
+                ChannelEncoded { id: 1, compression: 0, data: Vec::new() },
+                ChannelEncoded { id: 2, compression: 0, data: Vec::new() },
+            ],
+        };
+    }
+
+    // Deinterleave RGBA into separate channel planes
+    let (r_plane, g_plane, b_plane, a_plane) = deinterleave_rgba(&layer.pixel_data, w, h, depth);
+
+    let mut channels = Vec::with_capacity(5);
+
+    // Photoshop expects R, G, B, then transparency
+    channels.push(encode_channel_plane(0, &r_plane, w, h, depth));
+    channels.push(encode_channel_plane(1, &g_plane, w, h, depth));
+    channels.push(encode_channel_plane(2, &b_plane, w, h, depth));
+    channels.push(encode_channel_plane(-1, &a_plane, w, h, depth));
+
+    // Layer mask channel (id = -2) if present
+    if let Some(ref mask) = layer.mask {
+        channels.push(encode_channel_plane(-2, &mask.data, mask.rect.width() as usize, mask.rect.height() as usize, PsdDepth::Eight));
+    }
+
+    LayerChannelData { channels }
+}
+
+fn deinterleave_rgba(data: &[u8], w: usize, h: usize, depth: PsdDepth) -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
+    let pixel_count = w * h;
+    let bpc = depth.bytes_per_channel();
+
+    let mut r = Vec::with_capacity(pixel_count * bpc);
+    let mut g = Vec::with_capacity(pixel_count * bpc);
+    let mut b = Vec::with_capacity(pixel_count * bpc);
+    let mut a = Vec::with_capacity(pixel_count * bpc);
+
+    match depth {
+        PsdDepth::Eight => {
+            for i in 0..pixel_count {
+                let base = i * 4;
+                r.push(data[base]);
+                g.push(data[base + 1]);
+                b.push(data[base + 2]);
+                a.push(data[base + 3]);
+            }
+        }
+        PsdDepth::Sixteen => {
+            for i in 0..pixel_count {
+                let base = i * 8;
+                r.extend_from_slice(&data[base..base + 2]);
+                g.extend_from_slice(&data[base + 2..base + 4]);
+                b.extend_from_slice(&data[base + 4..base + 6]);
+                a.extend_from_slice(&data[base + 6..base + 8]);
+            }
+        }
+    }
+
+    (r, g, b, a)
+}
+
+fn encode_channel_plane(id: i16, plane: &[u8], w: usize, h: usize, depth: PsdDepth) -> ChannelEncoded {
+    if w == 0 || h == 0 {
+        return ChannelEncoded { id, compression: 0, data: Vec::new() };
+    }
+
+    match depth {
+        PsdDepth::Eight => {
+            // PackBits (compression type 1)
+            let row_size = w;
+            let mut byte_counts: Vec<u16> = Vec::with_capacity(h);
+            let mut compressed_rows: Vec<Vec<u8>> = Vec::with_capacity(h);
+
+            for y in 0..h {
+                let row = &plane[y * row_size..(y + 1) * row_size];
+                let encoded = packbits_encode(row);
+                byte_counts.push(encoded.len() as u16);
+                compressed_rows.push(encoded);
+            }
+
+            // Build data: byte count table + compressed rows
+            let mut data = Vec::with_capacity(h * 2 + plane.len());
+            for &count in &byte_counts {
+                data.extend_from_slice(&count.to_be_bytes());
+            }
+            for row in &compressed_rows {
+                data.extend_from_slice(row);
+            }
+
+            ChannelEncoded { id, compression: 1, data }
+        }
+        PsdDepth::Sixteen => {
+            // ZIP with prediction (compression type 3)
+            // Convert the big-endian byte plane to u16 values
+            let pixel_count = w * h;
+            let mut channel_u16 = Vec::with_capacity(pixel_count);
+            for i in 0..pixel_count {
+                let hi = plane[i * 2] as u16;
+                let lo = plane[i * 2 + 1] as u16;
+                channel_u16.push((hi << 8) | lo);
+            }
+
+            let data = zip_predict_encode_16(&channel_u16, w as u32, h as u32);
+            ChannelEncoded { id, compression: 3, data }
+        }
+    }
+}
+
+// ─── Global Mask Info ──────────────────────────────────────────────────
+
+fn write_global_mask_info(out: &mut Cursor<Vec<u8>>) {
+    write_u32(out, 0); // length = 0
+}
+
+// ─── Section 5: Merged Composite ───────────────────────────────────────
+
+fn write_merged_composite(out: &mut Cursor<Vec<u8>>, doc: &PsdDocument) {
+    let planes = flatten_layers(doc);
+    let w = doc.width as usize;
+    let h = doc.height as usize;
+
+    match doc.depth {
+        PsdDepth::Eight => {
+            // PackBits compression (type 1)
+            write_u16(out, 1);
+
+            // Merged composite has 3 planes (R, G, B) for RGB mode.
+            // Alpha is not stored in the merged image.
+            let channel_planes = [&planes.r, &planes.g, &planes.b];
+            let mut all_byte_counts: Vec<Vec<u16>> = Vec::new();
+            let mut all_compressed: Vec<Vec<Vec<u8>>> = Vec::new();
+
+            for plane in &channel_planes {
+                let mut byte_counts = Vec::with_capacity(h);
+                let mut compressed_rows = Vec::with_capacity(h);
+                for y in 0..h {
+                    let row = &plane[y * w..(y + 1) * w];
+                    let encoded = packbits_encode(row);
+                    byte_counts.push(encoded.len() as u16);
+                    compressed_rows.push(encoded);
+                }
+                all_byte_counts.push(byte_counts);
+                all_compressed.push(compressed_rows);
+            }
+
+            for counts in &all_byte_counts {
+                for &count in counts {
+                    write_u16(out, count);
+                }
+            }
+
+            for rows in &all_compressed {
+                for row in rows {
+                    out.write_all(row).unwrap();
+                }
+            }
+        }
+        PsdDepth::Sixteen => {
+            // Raw (type 0) for maximum compatibility.
+            // The merged image is 3 planes (R, G, B) of big-endian u16 bytes,
+            // written one plane after another.
+            write_u16(out, 0);
+
+            out.write_all(&planes.r).unwrap();
+            out.write_all(&planes.g).unwrap();
+            out.write_all(&planes.b).unwrap();
+        }
+    }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+fn write_u16(out: &mut Cursor<Vec<u8>>, v: u16) {
+    out.write_all(&v.to_be_bytes()).unwrap();
+}
+
+fn write_u32(out: &mut Cursor<Vec<u8>>, v: u32) {
+    out.write_all(&v.to_be_bytes()).unwrap();
+}
+
+fn write_i16(out: &mut Cursor<Vec<u8>>, v: i16) {
+    out.write_all(&v.to_be_bytes()).unwrap();
+}
+
+fn write_i32(out: &mut Cursor<Vec<u8>>, v: i32) {
+    out.write_all(&v.to_be_bytes()).unwrap();
+}
+
+fn write_u16_to_vec(v: &mut Vec<u8>, val: u16) {
+    v.extend_from_slice(&val.to_be_bytes());
+}
+
+fn write_u32_to_vec(v: &mut Vec<u8>, val: u32) {
+    v.extend_from_slice(&val.to_be_bytes());
+}
+
+/// Write a u32 placeholder at `start`, then backpatch it with the actual length
+/// of data written after the placeholder.
+fn backpatch_u32(out: &mut Cursor<Vec<u8>>, start: u64) {
+    let end = out.position();
+    let length = (end - start - 4) as u32; // subtract 4 for the placeholder itself
+    out.seek(SeekFrom::Start(start)).unwrap();
+    out.write_all(&length.to_be_bytes()).unwrap();
+    out.seek(SeekFrom::Start(end)).unwrap();
+}
+
+/// Like backpatch_u32 but ensures the data is padded to an even boundary.
+fn backpatch_u32_even(out: &mut Cursor<Vec<u8>>, start: u64) {
+    let end = out.position();
+    let length = end - start - 4;
+    if length % 2 != 0 {
+        out.write_all(&[0]).unwrap();
+    }
+    let final_end = out.position();
+    let final_length = (final_end - start - 4) as u32;
+    out.seek(SeekFrom::Start(start)).unwrap();
+    out.write_all(&final_length.to_be_bytes()).unwrap();
+    out.seek(SeekFrom::Start(final_end)).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::BlendMode;
+    use super::super::types::{PsdDocument, PsdLayer, PsdRect, PsdDepth, PsdMask, GroupKind};
+
+    fn make_red_layer(w: u32, h: u32) -> PsdLayer {
+        let pixel_count = (w * h) as usize;
+        let mut data = Vec::with_capacity(pixel_count * 4);
+        for _ in 0..pixel_count {
+            data.extend_from_slice(&[255, 0, 0, 255]);
+        }
+        PsdLayer {
+            name: "Red".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: BlendMode::Normal,
+            clip_to_below: false,
+            rect: PsdRect::from_xywh(0, 0, w, h),
+            pixel_data: data,
+            mask: None,
+            group_kind: GroupKind::Normal,
+        }
+    }
+
+    #[test]
+    fn write_minimal_psd_has_correct_header() {
+        let doc = PsdDocument {
+            width: 4,
+            height: 4,
+            depth: PsdDepth::Eight,
+            layers: vec![make_red_layer(4, 4)],
+            icc_profile: None,
+        };
+        let psd = write_psd(&doc);
+
+        assert_eq!(&psd[0..4], b"8BPS");
+        assert_eq!(u16::from_be_bytes([psd[4], psd[5]]), 1); // version
+        assert_eq!(u16::from_be_bytes([psd[12], psd[13]]), 3); // channels (RGB)
+        assert_eq!(u32::from_be_bytes([psd[14], psd[15], psd[16], psd[17]]), 4); // height
+        assert_eq!(u32::from_be_bytes([psd[18], psd[19], psd[20], psd[21]]), 4); // width
+        assert_eq!(u16::from_be_bytes([psd[22], psd[23]]), 8); // depth
+        assert_eq!(u16::from_be_bytes([psd[24], psd[25]]), 3); // color mode RGB
+    }
+
+    #[test]
+    fn write_psd_nonzero_size() {
+        let doc = PsdDocument {
+            width: 10,
+            height: 10,
+            depth: PsdDepth::Eight,
+            layers: vec![make_red_layer(10, 10)],
+            icc_profile: None,
+        };
+        let psd = write_psd(&doc);
+        assert!(psd.len() > 26, "PSD file too small: {} bytes", psd.len());
+    }
+
+    #[test]
+    fn write_16bit_psd_has_correct_depth() {
+        let mut layer = make_red_layer(2, 2);
+        // Convert to 16-bit: each pixel is 8 bytes (4 * u16 big-endian)
+        let mut data16 = Vec::new();
+        for _ in 0..4 {
+            data16.extend_from_slice(&[0xFF, 0xFF]); // R = 65535
+            data16.extend_from_slice(&[0x00, 0x00]); // G = 0
+            data16.extend_from_slice(&[0x00, 0x00]); // B = 0
+            data16.extend_from_slice(&[0xFF, 0xFF]); // A = 65535
+        }
+        layer.pixel_data = data16;
+
+        let doc = PsdDocument {
+            width: 2,
+            height: 2,
+            depth: PsdDepth::Sixteen,
+            layers: vec![layer],
+            icc_profile: None,
+        };
+        let psd = write_psd(&doc);
+        assert_eq!(u16::from_be_bytes([psd[22], psd[23]]), 16);
+    }
+
+    #[test]
+    fn write_psd_with_group() {
+        let group_end = PsdLayer {
+            name: "".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: BlendMode::Normal,
+            clip_to_below: false,
+            rect: PsdRect::new(0, 0, 0, 0),
+            pixel_data: Vec::new(),
+            mask: None,
+            group_kind: GroupKind::GroupEnd,
+        };
+        let child = make_red_layer(4, 4);
+        let group_open = PsdLayer {
+            name: "My Group".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: BlendMode::Normal,
+            clip_to_below: false,
+            rect: PsdRect::new(0, 0, 0, 0),
+            pixel_data: Vec::new(),
+            mask: None,
+            group_kind: GroupKind::GroupOpen,
+        };
+
+        let doc = PsdDocument {
+            width: 4,
+            height: 4,
+            depth: PsdDepth::Eight,
+            layers: vec![group_end, child, group_open],
+            icc_profile: None,
+        };
+        let psd = write_psd(&doc);
+        // Should not panic and should produce valid data
+        assert!(psd.len() > 100);
+    }
+
+    #[test]
+    fn write_psd_with_mask() {
+        let mut layer = make_red_layer(4, 4);
+        layer.mask = Some(PsdMask {
+            rect: PsdRect::from_xywh(0, 0, 4, 4),
+            data: vec![128; 16], // 50% mask
+            default_color: 0,
+        });
+
+        let doc = PsdDocument {
+            width: 4,
+            height: 4,
+            depth: PsdDepth::Eight,
+            layers: vec![layer],
+            icc_profile: None,
+        };
+        let psd = write_psd(&doc);
+        assert!(psd.len() > 100);
+    }
+}

--- a/engine-rs/crates/lopsy-core/src/psd/zip_predict.rs
+++ b/engine-rs/crates/lopsy-core/src/psd/zip_predict.rs
@@ -1,0 +1,159 @@
+use flate2::read::ZlibDecoder;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use std::io::{Read, Write};
+
+/// Encode a 16-bit channel plane using ZIP with prediction (PSD compression type 3).
+///
+/// Process per scanline:
+/// 1. Convert each u16 to two big-endian bytes.
+/// 2. Apply byte-level horizontal differencing (delta): first byte unchanged,
+///    subsequent bytes = current - previous (wrapping).
+/// 3. Deflate the entire delta buffer.
+pub fn zip_predict_encode_16(channel: &[u16], width: u32, height: u32) -> Vec<u8> {
+    let w = width as usize;
+    let h = height as usize;
+    assert_eq!(channel.len(), w * h, "channel size mismatch");
+
+    // Each row: w pixels * 2 bytes per pixel
+    let row_bytes = w * 2;
+    let mut delta_buf = Vec::with_capacity(row_bytes * h);
+
+    for y in 0..h {
+        let row = &channel[y * w..(y + 1) * w];
+
+        // Convert to big-endian bytes
+        let mut be_bytes = Vec::with_capacity(row_bytes);
+        for &val in row {
+            be_bytes.extend_from_slice(&val.to_be_bytes());
+        }
+
+        // Apply delta encoding
+        delta_buf.push(be_bytes[0]);
+        for i in 1..be_bytes.len() {
+            delta_buf.push(be_bytes[i].wrapping_sub(be_bytes[i - 1]));
+        }
+    }
+
+    // Deflate
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&delta_buf).expect("zlib encode failed");
+    encoder.finish().expect("zlib finish failed")
+}
+
+/// Decode a 16-bit channel plane from ZIP with prediction data.
+pub fn zip_predict_decode_16(data: &[u8], width: u32, height: u32) -> Result<Vec<u16>, String> {
+    let w = width as usize;
+    let h = height as usize;
+    let row_bytes = w * 2;
+    let expected = row_bytes * h;
+
+    // Inflate
+    let mut decoder = ZlibDecoder::new(data);
+    let mut delta_buf = Vec::with_capacity(expected);
+    decoder.read_to_end(&mut delta_buf).map_err(|e| format!("zlib decode: {e}"))?;
+
+    if delta_buf.len() != expected {
+        return Err(format!(
+            "decompressed size mismatch: got {} expected {expected}",
+            delta_buf.len()
+        ));
+    }
+
+    // Undo delta and reconstruct u16 values
+    let mut result = Vec::with_capacity(w * h);
+
+    for y in 0..h {
+        let row_start = y * row_bytes;
+        let row = &mut delta_buf[row_start..row_start + row_bytes];
+
+        // Undo delta: accumulate
+        for i in 1..row.len() {
+            row[i] = row[i].wrapping_add(row[i - 1]);
+        }
+
+        // Reconstruct u16 from big-endian pairs
+        for x in 0..w {
+            let hi = row[x * 2] as u16;
+            let lo = row[x * 2 + 1] as u16;
+            result.push((hi << 8) | lo);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Plain ZIP encode (compression type 2) for 8-bit mask data or other buffers.
+pub fn zip_encode(data: &[u8]) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).expect("zlib encode failed");
+    encoder.finish().expect("zlib finish failed")
+}
+
+/// Plain ZIP decode.
+pub fn zip_decode(data: &[u8], expected_len: usize) -> Result<Vec<u8>, String> {
+    let mut decoder = ZlibDecoder::new(data);
+    let mut out = Vec::with_capacity(expected_len);
+    decoder.read_to_end(&mut out).map_err(|e| format!("zlib decode: {e}"))?;
+    if out.len() != expected_len {
+        return Err(format!("decompressed size mismatch: got {} expected {expected_len}", out.len()));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_constant() {
+        let width = 10;
+        let height = 5;
+        let channel = vec![32768u16; (width * height) as usize];
+        let encoded = zip_predict_encode_16(&channel, width, height);
+        let decoded = zip_predict_decode_16(&encoded, width, height).unwrap();
+        assert_eq!(decoded, channel);
+    }
+
+    #[test]
+    fn roundtrip_gradient() {
+        let width = 100;
+        let height = 50;
+        let channel: Vec<u16> = (0..(width * height) as u16).collect();
+        let encoded = zip_predict_encode_16(&channel, width, height);
+        let decoded = zip_predict_decode_16(&encoded, width, height).unwrap();
+        assert_eq!(decoded, channel);
+    }
+
+    #[test]
+    fn roundtrip_full_range() {
+        let width = 256;
+        let height = 1;
+        let channel: Vec<u16> = (0..256).map(|i| (i * 257) as u16).collect();
+        let encoded = zip_predict_encode_16(&channel, width, height);
+        let decoded = zip_predict_decode_16(&encoded, width, height).unwrap();
+        assert_eq!(decoded, channel);
+    }
+
+    #[test]
+    fn roundtrip_multi_row() {
+        let width = 4;
+        let height = 3;
+        let channel = vec![
+            0, 100, 200, 65535,
+            1000, 2000, 3000, 4000,
+            65535, 0, 32768, 16384,
+        ];
+        let encoded = zip_predict_encode_16(&channel, width, height);
+        let decoded = zip_predict_decode_16(&encoded, width, height).unwrap();
+        assert_eq!(decoded, channel);
+    }
+
+    #[test]
+    fn plain_zip_roundtrip() {
+        let data: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
+        let encoded = zip_encode(&data);
+        let decoded = zip_decode(&encoded, data.len()).unwrap();
+        assert_eq!(decoded, data);
+    }
+}

--- a/engine-rs/crates/lopsy-core/tests/psd_write_gimp.rs
+++ b/engine-rs/crates/lopsy-core/tests/psd_write_gimp.rs
@@ -1,0 +1,326 @@
+use lopsy_core::color::BlendMode;
+use lopsy_core::psd::types::*;
+use lopsy_core::psd::writer::write_psd;
+use lopsy_core::psd::reader::read_psd;
+use std::fs;
+
+/// Generate multi-layer PSDs and write to /tmp for external validation.
+#[test]
+fn generate_test_psd_8bit() {
+    let doc = build_test_doc_8bit();
+    let psd = write_psd(&doc);
+    fs::write("/tmp/lopsy_test_8bit.psd", &psd).unwrap();
+    eprintln!("Wrote /tmp/lopsy_test_8bit.psd ({} bytes)", psd.len());
+}
+
+#[test]
+fn generate_test_psd_16bit() {
+    let doc = build_test_doc_16bit();
+    let psd = write_psd(&doc);
+    fs::write("/tmp/lopsy_test_16bit.psd", &psd).unwrap();
+    eprintln!("Wrote /tmp/lopsy_test_16bit.psd ({} bytes)", psd.len());
+}
+
+/// Full roundtrip: write → read → compare for 8-bit multi-layer document with all features.
+#[test]
+fn roundtrip_8bit_full() {
+    let original = build_test_doc_8bit();
+    let psd_bytes = write_psd(&original);
+    let parsed = read_psd(&psd_bytes).unwrap();
+
+    assert_eq!(parsed.width, original.width);
+    assert_eq!(parsed.height, original.height);
+    assert_eq!(parsed.depth, PsdDepth::Eight);
+    assert_eq!(parsed.layers.len(), original.layers.len());
+
+    for (orig, parsed) in original.layers.iter().zip(parsed.layers.iter()) {
+        assert_eq!(parsed.name, orig.name, "name mismatch for layer '{}'", orig.name);
+        assert_eq!(parsed.opacity, orig.opacity, "opacity mismatch for '{}'", orig.name);
+        assert_eq!(parsed.blend_mode, orig.blend_mode, "blend mode mismatch for '{}'", orig.name);
+        assert_eq!(parsed.visible, orig.visible, "visibility mismatch for '{}'", orig.name);
+        assert_eq!(parsed.group_kind, orig.group_kind, "group_kind mismatch for '{}'", orig.name);
+        assert_eq!(parsed.rect, orig.rect, "rect mismatch for '{}'", orig.name);
+        assert_eq!(parsed.pixel_data, orig.pixel_data, "pixel data mismatch for '{}'", orig.name);
+    }
+}
+
+/// Full roundtrip: write → read → compare for 16-bit document.
+#[test]
+fn roundtrip_16bit_full() {
+    let original = build_test_doc_16bit();
+    let psd_bytes = write_psd(&original);
+    let parsed = read_psd(&psd_bytes).unwrap();
+
+    assert_eq!(parsed.width, original.width);
+    assert_eq!(parsed.height, original.height);
+    assert_eq!(parsed.depth, PsdDepth::Sixteen);
+    assert_eq!(parsed.layers.len(), original.layers.len());
+
+    for (orig, parsed) in original.layers.iter().zip(parsed.layers.iter()) {
+        assert_eq!(parsed.name, orig.name);
+        assert_eq!(parsed.opacity, orig.opacity);
+        assert_eq!(parsed.blend_mode, orig.blend_mode);
+        assert_eq!(parsed.pixel_data, orig.pixel_data, "16-bit pixel data mismatch for '{}'", orig.name);
+    }
+}
+
+/// Roundtrip with layer masks.
+#[test]
+fn roundtrip_with_mask() {
+    let w = 8u32;
+    let h = 8u32;
+
+    // Build a checkerboard mask
+    let mut mask_data = Vec::with_capacity(64);
+    for y in 0..8u32 {
+        for x in 0..8u32 {
+            mask_data.push(if (x + y) % 2 == 0 { 255 } else { 0 });
+        }
+    }
+
+    let layer = PsdLayer {
+        name: "Masked Layer".to_string(),
+        visible: true,
+        opacity: 255,
+        blend_mode: BlendMode::Normal,
+        clip_to_below: false,
+        rect: PsdRect::from_xywh(0, 0, w, h),
+        pixel_data: vec![255, 128, 0, 255].repeat(64),
+        mask: Some(PsdMask {
+            rect: PsdRect::from_xywh(0, 0, w, h),
+            data: mask_data.clone(),
+            default_color: 0,
+        }),
+        group_kind: GroupKind::Normal,
+    };
+
+    let doc = PsdDocument {
+        width: w,
+        height: h,
+        depth: PsdDepth::Eight,
+        layers: vec![layer],
+        icc_profile: None,
+    };
+
+    let psd_bytes = write_psd(&doc);
+    let parsed = read_psd(&psd_bytes).unwrap();
+
+    assert_eq!(parsed.layers.len(), 1);
+    let parsed_layer = &parsed.layers[0];
+    assert_eq!(parsed_layer.name, "Masked Layer");
+    assert_eq!(parsed_layer.pixel_data, doc.layers[0].pixel_data);
+
+    let parsed_mask = parsed_layer.mask.as_ref().expect("mask should be present");
+    assert_eq!(parsed_mask.rect, PsdRect::from_xywh(0, 0, w, h));
+    assert_eq!(parsed_mask.data, mask_data);
+}
+
+/// Roundtrip with all 16 blend modes.
+#[test]
+fn roundtrip_all_blend_modes() {
+    let modes = [
+        BlendMode::Normal, BlendMode::Multiply, BlendMode::Screen, BlendMode::Overlay,
+        BlendMode::Darken, BlendMode::Lighten, BlendMode::ColorDodge, BlendMode::ColorBurn,
+        BlendMode::HardLight, BlendMode::SoftLight, BlendMode::Difference, BlendMode::Exclusion,
+        BlendMode::Hue, BlendMode::Saturation, BlendMode::Color, BlendMode::Luminosity,
+    ];
+
+    let mut layers = Vec::new();
+    for (i, mode) in modes.iter().enumerate() {
+        layers.push(solid_layer_8bit(
+            &format!("{mode:?}"), 0, 0, 4, 4,
+            i as u8 * 16, 128, 255, 255,
+            *mode, 200,
+        ));
+    }
+
+    let doc = PsdDocument {
+        width: 4,
+        height: 4,
+        depth: PsdDepth::Eight,
+        layers,
+        icc_profile: None,
+    };
+
+    let psd_bytes = write_psd(&doc);
+    let parsed = read_psd(&psd_bytes).unwrap();
+
+    assert_eq!(parsed.layers.len(), 16);
+    for (orig, parsed) in doc.layers.iter().zip(parsed.layers.iter()) {
+        assert_eq!(parsed.blend_mode, orig.blend_mode);
+        assert_eq!(parsed.opacity, orig.opacity);
+        assert_eq!(parsed.pixel_data, orig.pixel_data);
+    }
+}
+
+/// 16-bit gradient roundtrip — tests precision across full value range.
+#[test]
+fn roundtrip_16bit_gradient() {
+    let w = 256u32;
+    let h = 1u32;
+    let mut data = Vec::with_capacity(256 * 8);
+    for i in 0..256u16 {
+        let val = i * 257; // maps 0-255 to 0-65535 evenly
+        data.extend_from_slice(&val.to_be_bytes()); // R
+        data.extend_from_slice(&(65535 - val).to_be_bytes()); // G
+        data.extend_from_slice(&(val / 2).to_be_bytes()); // B
+        data.extend_from_slice(&[0xFF, 0xFF]); // A
+    }
+
+    let doc = PsdDocument {
+        width: w,
+        height: h,
+        depth: PsdDepth::Sixteen,
+        layers: vec![PsdLayer {
+            name: "Gradient".to_string(),
+            visible: true,
+            opacity: 255,
+            blend_mode: BlendMode::Normal,
+            clip_to_below: false,
+            rect: PsdRect::from_xywh(0, 0, w, h),
+            pixel_data: data.clone(),
+            mask: None,
+            group_kind: GroupKind::Normal,
+        }],
+        icc_profile: None,
+    };
+
+    let psd_bytes = write_psd(&doc);
+    let parsed = read_psd(&psd_bytes).unwrap();
+
+    assert_eq!(parsed.layers[0].pixel_data, data, "16-bit gradient pixel data should be exact");
+}
+
+// ─── Test doc builders ─────────────────────────────────────────────────
+
+fn build_test_doc_8bit() -> PsdDocument {
+    let w = 64u32;
+    let h = 64u32;
+
+    let bg = solid_layer_8bit("Background", 0, 0, w, h, 0, 0, 255, 255, BlendMode::Normal, 255);
+    let red = solid_layer_8bit("Red Overlay", 10, 10, 32, 32, 255, 0, 0, 255, BlendMode::Normal, 192);
+    let green = solid_layer_8bit("Green Multiply", 20, 20, 40, 40, 0, 255, 0, 255, BlendMode::Multiply, 255);
+
+    let group_end = PsdLayer {
+        name: "".to_string(),
+        visible: true,
+        opacity: 255,
+        blend_mode: BlendMode::Normal,
+        clip_to_below: false,
+        rect: PsdRect::new(0, 0, 0, 0),
+        pixel_data: Vec::new(),
+        mask: None,
+        group_kind: GroupKind::GroupEnd,
+    };
+
+    let gradient = gradient_layer_8bit("Gradient", 0, 0, w, h);
+
+    let group_open = PsdLayer {
+        name: "Test Group".to_string(),
+        visible: true,
+        opacity: 255,
+        blend_mode: BlendMode::Normal,
+        clip_to_below: false,
+        rect: PsdRect::new(0, 0, 0, 0),
+        pixel_data: Vec::new(),
+        mask: None,
+        group_kind: GroupKind::GroupOpen,
+    };
+
+    PsdDocument {
+        width: w,
+        height: h,
+        depth: PsdDepth::Eight,
+        layers: vec![bg, red, green, group_end, gradient, group_open],
+        icc_profile: None,
+    }
+}
+
+fn build_test_doc_16bit() -> PsdDocument {
+    let w = 32u32;
+    let h = 32u32;
+
+    let bg = solid_layer_16bit("Background", 0, 0, w, h, 65535, 65535, 65535, 65535, BlendMode::Normal, 255);
+    let red = solid_layer_16bit("Red 50%", 0, 0, w, h, 65535, 0, 0, 65535, BlendMode::Normal, 128);
+
+    PsdDocument {
+        width: w,
+        height: h,
+        depth: PsdDepth::Sixteen,
+        layers: vec![bg, red],
+        icc_profile: None,
+    }
+}
+
+fn solid_layer_8bit(
+    name: &str, x: i32, y: i32, w: u32, h: u32,
+    r: u8, g: u8, b: u8, a: u8,
+    mode: BlendMode, opacity: u8,
+) -> PsdLayer {
+    let pixel_count = (w * h) as usize;
+    let mut data = Vec::with_capacity(pixel_count * 4);
+    for _ in 0..pixel_count {
+        data.extend_from_slice(&[r, g, b, a]);
+    }
+    PsdLayer {
+        name: name.to_string(),
+        visible: true,
+        opacity,
+        blend_mode: mode,
+        clip_to_below: false,
+        rect: PsdRect::from_xywh(x, y, w, h),
+        pixel_data: data,
+        mask: None,
+        group_kind: GroupKind::Normal,
+    }
+}
+
+fn solid_layer_16bit(
+    name: &str, x: i32, y: i32, w: u32, h: u32,
+    r: u16, g: u16, b: u16, a: u16,
+    mode: BlendMode, opacity: u8,
+) -> PsdLayer {
+    let pixel_count = (w * h) as usize;
+    let mut data = Vec::with_capacity(pixel_count * 8);
+    for _ in 0..pixel_count {
+        data.extend_from_slice(&r.to_be_bytes());
+        data.extend_from_slice(&g.to_be_bytes());
+        data.extend_from_slice(&b.to_be_bytes());
+        data.extend_from_slice(&a.to_be_bytes());
+    }
+    PsdLayer {
+        name: name.to_string(),
+        visible: true,
+        opacity,
+        blend_mode: mode,
+        clip_to_below: false,
+        rect: PsdRect::from_xywh(x, y, w, h),
+        pixel_data: data,
+        mask: None,
+        group_kind: GroupKind::Normal,
+    }
+}
+
+fn gradient_layer_8bit(name: &str, x: i32, y: i32, w: u32, h: u32) -> PsdLayer {
+    let pixel_count = (w * h) as usize;
+    let mut data = Vec::with_capacity(pixel_count * 4);
+    for py in 0..h {
+        for px in 0..w {
+            let r = ((px as f32 / w as f32) * 255.0) as u8;
+            let g = ((py as f32 / h as f32) * 255.0) as u8;
+            let b = 128u8;
+            data.extend_from_slice(&[r, g, b, 255]);
+        }
+    }
+    PsdLayer {
+        name: name.to_string(),
+        visible: true,
+        opacity: 255,
+        blend_mode: BlendMode::Normal,
+        clip_to_below: false,
+        rect: PsdRect::from_xywh(x, y, w, h),
+        pixel_data: data,
+        mask: None,
+        group_kind: GroupKind::Normal,
+    }
+}

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/effects/shadow.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/effects/shadow.glsl
@@ -16,6 +16,10 @@ void main() {
     // Map document UV to layer-local UV, applying shadow offset
     vec2 docPos = v_uv * u_docSize;
     vec2 layerUV = (docPos - u_srcOffset - u_offset) / u_srcSize;
+    // Layer-local UV WITHOUT shadow offset — used to knock the shadow out
+    // from behind the layer's opaque pixels so the layer's blend mode operates
+    // against the original background, not the shadow color.
+    vec2 knockoutUV = (docPos - u_srcOffset) / u_srcSize;
     // Early out if far from layer bounds (with blur margin)
     vec2 marginUV = (u_blur + 1.0) * u_texelSize;
     if (layerUV.x < -marginUV.x || layerUV.x > 1.0 + marginUV.x ||
@@ -70,5 +74,13 @@ void main() {
         alpha = alpha > 0.001 ? pow(alpha, exponent) : 0.0;
     }
 
-    fragColor = vec4(u_shadowColor.rgb, alpha * u_shadowColor.a * u_opacity);
+    // Knock out the shadow behind the layer — Photoshop "Layer Knocks Out
+    // Drop Shadow" behavior. This ensures blend modes on the layer operate
+    // against the original background, not the shadow.
+    float knockoutAlpha = 0.0;
+    if (knockoutUV.x >= 0.0 && knockoutUV.x <= 1.0 && knockoutUV.y >= 0.0 && knockoutUV.y <= 1.0) {
+        knockoutAlpha = texture(u_srcTex, knockoutUV).a;
+    }
+
+    fragColor = vec4(u_shadowColor.rgb, alpha * u_shadowColor.a * u_opacity * (1.0 - knockoutAlpha));
 }

--- a/engine-rs/crates/lopsy-wasm/src/lib.rs
+++ b/engine-rs/crates/lopsy-wasm/src/lib.rs
@@ -2396,3 +2396,248 @@ pub fn magnetic_lasso_end(engine: &mut Engine) {
     engine.inner.magnetic_lasso_width = 0;
     engine.inner.magnetic_lasso_height = 0;
 }
+
+// ============================================================
+// PSD Export / Import
+// ============================================================
+
+/// Export the current document as a PSD file.
+///
+/// `layers_json`: JSON array of objects with layer metadata:
+///   `{ id, name, visible, opacity, blendMode, x, y, width, height, clipToBelow, groupKind, maskWidth?, maskHeight?, maskX?, maskY?, maskOffset?, maskLength?, maskDefaultColor? }`
+///
+/// `mask_data`: all mask pixel data concatenated. Each layer references its slice via maskOffset + maskLength.
+///
+/// `depth`: 8 or 16.
+///
+/// Returns the PSD file as bytes.
+#[wasm_bindgen(js_name = "exportPsd")]
+pub fn export_psd(
+    engine: &Engine,
+    layers_json: &str,
+    mask_data: &[u8],
+    depth: u8,
+) -> Result<Vec<u8>, JsError> {
+    use lopsy_core::psd::types::*;
+    use lopsy_core::psd::writer::write_psd;
+
+    let psd_depth = match depth {
+        16 => PsdDepth::Sixteen,
+        _ => PsdDepth::Eight,
+    };
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LayerMeta {
+        id: String,
+        name: String,
+        visible: bool,
+        opacity: u8,
+        blend_mode: u8,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        clip_to_below: bool,
+        group_kind: u8, // 0=Normal, 1=GroupOpen, 2=GroupClosed, 3=GroupEnd
+        mask_width: Option<u32>,
+        mask_height: Option<u32>,
+        mask_x: Option<i32>,
+        mask_y: Option<i32>,
+        mask_offset: Option<usize>,
+        mask_length: Option<usize>,
+        mask_default_color: Option<u8>,
+    }
+
+    let layer_metas: Vec<LayerMeta> = serde_json::from_str(layers_json)
+        .map_err(|e| JsError::new(&format!("invalid layers JSON: {e}")))?;
+
+    let mut psd_layers = Vec::with_capacity(layer_metas.len());
+
+    for meta in &layer_metas {
+        let blend_mode = BlendMode::from_u8(meta.blend_mode)
+            .unwrap_or(BlendMode::Normal);
+
+        let group_kind = match meta.group_kind {
+            1 => GroupKind::GroupOpen,
+            2 => GroupKind::GroupClosed,
+            3 => GroupKind::GroupEnd,
+            _ => GroupKind::Normal,
+        };
+
+        // Read pixel data from GPU for content layers
+        let pixel_data = if meta.width > 0 && meta.height > 0 && group_kind == GroupKind::Normal {
+            let gpu_pixels = layer_manager::read_pixels(&engine.inner, &meta.id)
+                .map_err(|e| JsError::new(&e))?;
+
+            match psd_depth {
+                PsdDepth::Eight => gpu_pixels,
+                PsdDepth::Sixteen => {
+                    // Upscale 8-bit GPU pixels to 16-bit big-endian
+                    let mut data16 = Vec::with_capacity(gpu_pixels.len() * 2);
+                    for &byte in &gpu_pixels {
+                        let val16 = (byte as u16) * 257; // 0-255 -> 0-65535
+                        data16.extend_from_slice(&val16.to_be_bytes());
+                    }
+                    data16
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        // Extract mask data
+        let mask = if let (Some(mw), Some(mh), Some(mx), Some(my), Some(offset), Some(length)) = (
+            meta.mask_width, meta.mask_height,
+            meta.mask_x, meta.mask_y,
+            meta.mask_offset, meta.mask_length,
+        ) {
+            if mw > 0 && mh > 0 && offset + length <= mask_data.len() {
+                Some(PsdMask {
+                    rect: PsdRect::from_xywh(mx, my, mw, mh),
+                    data: mask_data[offset..offset + length].to_vec(),
+                    default_color: meta.mask_default_color.unwrap_or(0),
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        psd_layers.push(PsdLayer {
+            name: meta.name.clone(),
+            visible: meta.visible,
+            opacity: meta.opacity,
+            blend_mode,
+            clip_to_below: meta.clip_to_below,
+            rect: PsdRect::from_xywh(meta.x, meta.y, meta.width, meta.height),
+            pixel_data,
+            mask,
+            group_kind,
+        });
+    }
+
+    let doc = PsdDocument {
+        width: engine.inner.doc_width,
+        height: engine.inner.doc_height,
+        depth: psd_depth,
+        layers: psd_layers,
+        icc_profile: None,
+    };
+
+    Ok(write_psd(&doc))
+}
+
+/// Parse a PSD file and return a JSON manifest describing the document.
+///
+/// Returns JSON: `{ width, height, depth, layers: [{ name, visible, opacity, blendMode, x, y, width, height, clipToBelow, groupKind, hasMask, maskX?, maskY?, maskWidth?, maskHeight? }] }`
+///
+/// Layer pixel data is extracted separately via `getPsdLayerPixels`.
+#[wasm_bindgen(js_name = "parsePsd")]
+pub fn parse_psd(data: &[u8]) -> Result<String, JsError> {
+    use lopsy_core::psd::reader::read_psd;
+
+    let doc = read_psd(data).map_err(|e| JsError::new(&e.to_string()))?;
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LayerInfo {
+        name: String,
+        visible: bool,
+        opacity: u8,
+        blend_mode: u8,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        clip_to_below: bool,
+        group_kind: u8,
+        has_mask: bool,
+        mask_x: Option<i32>,
+        mask_y: Option<i32>,
+        mask_width: Option<u32>,
+        mask_height: Option<u32>,
+    }
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct DocInfo {
+        width: u32,
+        height: u32,
+        depth: u8,
+        layers: Vec<LayerInfo>,
+    }
+
+    let layers: Vec<LayerInfo> = doc.layers.iter().map(|l| {
+        let group_kind = match l.group_kind {
+            lopsy_core::psd::types::GroupKind::Normal => 0u8,
+            lopsy_core::psd::types::GroupKind::GroupOpen => 1,
+            lopsy_core::psd::types::GroupKind::GroupClosed => 2,
+            lopsy_core::psd::types::GroupKind::GroupEnd => 3,
+        };
+
+        LayerInfo {
+            name: l.name.clone(),
+            visible: l.visible,
+            opacity: l.opacity,
+            blend_mode: l.blend_mode as u8,
+            x: l.rect.left,
+            y: l.rect.top,
+            width: l.rect.width(),
+            height: l.rect.height(),
+            clip_to_below: l.clip_to_below,
+            group_kind,
+            has_mask: l.mask.is_some(),
+            mask_x: l.mask.as_ref().map(|m| m.rect.left),
+            mask_y: l.mask.as_ref().map(|m| m.rect.top),
+            mask_width: l.mask.as_ref().map(|m| m.rect.width()),
+            mask_height: l.mask.as_ref().map(|m| m.rect.height()),
+        }
+    }).collect();
+
+    let doc_info = DocInfo {
+        width: doc.width,
+        height: doc.height,
+        depth: doc.depth.bits_per_channel() as u8,
+        layers,
+    };
+
+    serde_json::to_string(&doc_info)
+        .map_err(|e| JsError::new(&format!("JSON serialize: {e}")))
+}
+
+/// Get the RGBA pixel data for a specific layer from a parsed PSD file.
+/// Returns interleaved RGBA bytes (u8 for 8-bit, big-endian u16 pairs for 16-bit).
+#[wasm_bindgen(js_name = "getPsdLayerPixels")]
+pub fn get_psd_layer_pixels(data: &[u8], layer_index: u32) -> Result<Vec<u8>, JsError> {
+    use lopsy_core::psd::reader::read_psd;
+
+    let doc = read_psd(data).map_err(|e| JsError::new(&e.to_string()))?;
+    let idx = layer_index as usize;
+
+    if idx >= doc.layers.len() {
+        return Err(JsError::new(&format!("layer index {idx} out of range ({})", doc.layers.len())));
+    }
+
+    Ok(doc.layers[idx].pixel_data.clone())
+}
+
+/// Get the mask data for a specific layer from a parsed PSD file.
+/// Returns grayscale u8 data, or empty vec if no mask.
+#[wasm_bindgen(js_name = "getPsdLayerMask")]
+pub fn get_psd_layer_mask(data: &[u8], layer_index: u32) -> Result<Vec<u8>, JsError> {
+    use lopsy_core::psd::reader::read_psd;
+
+    let doc = read_psd(data).map_err(|e| JsError::new(&e.to_string()))?;
+    let idx = layer_index as usize;
+
+    if idx >= doc.layers.len() {
+        return Err(JsError::new(&format!("layer index {idx} out of range ({})", doc.layers.len())));
+    }
+
+    match &doc.layers[idx].mask {
+        Some(mask) => Ok(mask.data.clone()),
+        None => Ok(Vec::new()),
+    }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,6 +25,7 @@ import { useToolSettingsStore } from './tool-settings-store';
 import { drawShape } from '../tools/shape/shape';
 import { PixelBuffer } from '../engine/pixel-data';
 import { pasteOrOpenBlob } from './paste-or-open';
+import { importPsdFile } from './MenuBar/menus/file-menu';
 import { wrapWithSelectionMask } from './interactions/selection-mask-wrap';
 import { useCanvasRendering } from './useCanvasRendering';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
@@ -136,6 +137,13 @@ export function App() {
 
   const handleOpenFile = useCallback((file: File) => {
     const name = file.name.replace(/\.[^.]+$/, '');
+    if (/\.psd$/i.test(file.name)) {
+      file.arrayBuffer().then(async (buffer) => {
+        await importPsdFile(new Uint8Array(buffer), name);
+        setShowNewDocumentModal(false);
+      });
+      return;
+    }
     pasteOrOpenBlob(file, name).then(() => {
       setShowNewDocumentModal(false);
     });

--- a/src/app/MenuBar/menus/file-menu.ts
+++ b/src/app/MenuBar/menus/file-menu.ts
@@ -6,8 +6,22 @@ import { hasActiveAdjustments, applyAdjustmentsToImageData, aggregateGroupAdjust
 import { contextOptions, canvasColorSpace, createImageDataFromArray } from '../../../engine/color-space';
 import { seedBitmapFromBlob } from '../../../engine/bitmap-cache';
 import { getEngine } from '../../../engine-wasm/engine-state';
-import { compositeForExport, getCompositeSize } from '../../../engine-wasm/wasm-bridge';
+import {
+  compositeForExport,
+  getCompositeSize,
+  exportPsd,
+  parsePsd,
+  getPsdLayerPixels,
+  getPsdLayerMask,
+  initWasm,
+} from '../../../engine-wasm/wasm-bridge';
+import { resetTrackedState, flushLayerSync } from '../../../engine-wasm/engine-sync';
 import type { MenuDef } from './types';
+import type { BlendMode } from '../../../types/color';
+import type { Layer, GroupLayer, RasterLayer } from '../../../types/layers';
+import { DEFAULT_EFFECTS } from '../../../layers/layer-model';
+import { DEFAULT_ADJUSTMENTS } from '../../../filters/image-adjustments';
+import { finalizePendingStrokeGlobal } from '../../interactions/pending-stroke';
 
 const METADATA_NOTE = 'Made with Lopsy — http://lopsy.art';
 
@@ -20,10 +34,19 @@ export function openFileFromDisk(): void {
   if (!confirmIfDirty()) return;
   const input = document.createElement('input');
   input.type = 'file';
-  input.accept = 'image/*';
+  input.accept = 'image/*,.psd';
   input.onchange = () => {
     const file = input.files?.[0];
     if (!file) return;
+
+    // Route PSD files to the PSD importer
+    if (/\.psd$/i.test(file.name)) {
+      file.arrayBuffer().then((buffer) => {
+        importPsdFile(new Uint8Array(buffer), file.name.replace(/\.psd$/i, ''));
+      });
+      return;
+    }
+
     const img = new Image();
     const url = URL.createObjectURL(file);
     img.onload = () => {
@@ -42,6 +65,7 @@ export function openFileFromDisk(): void {
         // rebuilt from the canvas-round-tripped ImageData.
         const layerId = useEditorStore.getState().document.activeLayerId;
         if (layerId) seedBitmapFromBlob(layerId, file);
+        useEditorStore.getState().fitToView();
       }
       URL.revokeObjectURL(url);
     };
@@ -156,6 +180,376 @@ function finishCanvasExport(canvas: HTMLCanvasElement, width: number, height: nu
   }, mimeType, 0.92);
 }
 
+// ─── PSD Blend Mode Mapping ────────────────────────────────────────────
+
+const BLEND_MODE_TO_U8: Record<BlendMode, number> = {
+  'normal': 0,
+  'multiply': 1,
+  'screen': 2,
+  'overlay': 3,
+  'darken': 4,
+  'lighten': 5,
+  'color-dodge': 6,
+  'color-burn': 7,
+  'hard-light': 8,
+  'soft-light': 9,
+  'difference': 10,
+  'exclusion': 11,
+  'hue': 12,
+  'saturation': 13,
+  'color': 14,
+  'luminosity': 15,
+};
+
+const U8_TO_BLEND_MODE: BlendMode[] = [
+  'normal', 'multiply', 'screen', 'overlay', 'darken', 'lighten',
+  'color-dodge', 'color-burn', 'hard-light', 'soft-light',
+  'difference', 'exclusion', 'hue', 'saturation', 'color', 'luminosity',
+];
+
+// ─── PSD Export ────────────────────────────────────────────────────────
+
+function flattenLayerTreeForPsd(
+  layers: readonly Layer[],
+  layerOrder: readonly string[],
+): Array<{ layer: Layer; groupKind: number }> {
+  const layerMap = new Map<string, Layer>();
+  for (const l of layers) {
+    layerMap.set(l.id, l);
+  }
+
+  // Build set of layer IDs that are children of some group —
+  // these are emitted recursively via their group, not as top-level.
+  const childIds = new Set<string>();
+  for (const l of layers) {
+    if (l.type === 'group') {
+      for (const childId of (l as GroupLayer).children) {
+        childIds.add(childId);
+      }
+    }
+  }
+
+  const result: Array<{ layer: Layer; groupKind: number }> = [];
+
+  function emitLayer(id: string): void {
+    const layer = layerMap.get(id);
+    if (!layer) return;
+
+    if (layer.type === 'group') {
+      const group = layer as GroupLayer;
+      // PSD convention: bottom-to-top with group-end marker first,
+      // then children (bottom-to-top), then group-open marker.
+      result.push({ layer: group, groupKind: 3 }); // GroupEnd
+      for (const childId of group.children) {
+        emitLayer(childId);
+      }
+      result.push({ layer: group, groupKind: 1 }); // GroupOpen
+    } else {
+      result.push({ layer, groupKind: 0 });
+    }
+  }
+
+  // Only emit root-level entries from layerOrder — skip anything that's
+  // a child of a group (it will be emitted via the group's recursion).
+  for (const id of layerOrder) {
+    if (childIds.has(id)) continue;
+    emitLayer(id);
+  }
+
+  return result;
+}
+
+export function exportPsdFile(depth: 8 | 16 = 8): void {
+  const engine = getEngine();
+  if (!engine) return;
+
+  // Commit any in-progress brush stroke so its pixels are in the GPU texture
+  // before we read layer data.
+  finalizePendingStrokeGlobal();
+
+  const edState = useEditorStore.getState();
+  const { document: doc } = edState;
+
+  const flatLayers = flattenLayerTreeForPsd(doc.layers, doc.layerOrder);
+
+  // Build mask data buffer and layer metadata
+  const maskChunks: Uint8Array[] = [];
+  let maskOffset = 0;
+
+  interface LayerMeta {
+    id: string;
+    name: string;
+    visible: boolean;
+    opacity: number;
+    blendMode: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    clipToBelow: boolean;
+    groupKind: number;
+    maskWidth?: number;
+    maskHeight?: number;
+    maskX?: number;
+    maskY?: number;
+    maskOffset?: number;
+    maskLength?: number;
+    maskDefaultColor?: number;
+  }
+
+  const layerMetas: LayerMeta[] = flatLayers.map(({ layer, groupKind }) => {
+    const meta: LayerMeta = {
+      id: layer.id,
+      name: layer.name,
+      visible: layer.visible,
+      opacity: Math.round(layer.opacity * 255),
+      blendMode: BLEND_MODE_TO_U8[layer.blendMode] ?? 0,
+      x: layer.x,
+      y: layer.y,
+      width: (layer.type === 'raster' || layer.type === 'shape') ? (layer as RasterLayer).width : 0,
+      height: (layer.type === 'raster' || layer.type === 'shape') ? (layer as RasterLayer).height : 0,
+      clipToBelow: layer.clipToBelow,
+      groupKind,
+    };
+
+    // For group markers, zero out dimensions
+    if (groupKind !== 0) {
+      meta.width = 0;
+      meta.height = 0;
+    }
+
+    // Pack mask data
+    if (layer.mask && layer.mask.data.length > 0) {
+      const maskBytes = new Uint8Array(layer.mask.data.buffer);
+      meta.maskWidth = layer.mask.width;
+      meta.maskHeight = layer.mask.height;
+      meta.maskX = layer.x;
+      meta.maskY = layer.y;
+      meta.maskOffset = maskOffset;
+      meta.maskLength = maskBytes.length;
+      meta.maskDefaultColor = 0;
+      maskChunks.push(maskBytes);
+      maskOffset += maskBytes.length;
+    }
+
+    return meta;
+  });
+
+  // Concatenate mask data
+  const allMaskData = new Uint8Array(maskOffset);
+  let offset = 0;
+  for (const chunk of maskChunks) {
+    allMaskData.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const layersJson = JSON.stringify(layerMetas);
+  const psdBytes = exportPsd(engine, layersJson, allMaskData, depth);
+
+  // Download
+  const blob = new Blob([psdBytes.slice().buffer], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${doc.name || 'lopsy'}.psd`;
+  a.click();
+  URL.revokeObjectURL(url);
+  useEditorStore.getState().markClean();
+}
+
+// ─── PSD Import ────────────────────────────────────────────────────────
+
+export async function importPsdFile(data: Uint8Array, name: string): Promise<void> {
+  // Ensure the WASM module is initialized — when opening from the initial
+  // modal before any document exists, the engine hasn't been created yet.
+  await initWasm();
+
+  // Reset engine-sync tracking so it cleanly re-adds all layers on the next
+  // frame with the correct blend modes, opacities, and pixel data.
+  resetTrackedState();
+
+  const manifestJson = parsePsd(data);
+  const manifest = JSON.parse(manifestJson) as {
+    width: number;
+    height: number;
+    depth: number;
+    layers: Array<{
+      name: string;
+      visible: boolean;
+      opacity: number;
+      blendMode: number;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      clipToBelow: boolean;
+      groupKind: number;
+      hasMask: boolean;
+      maskX?: number;
+      maskY?: number;
+      maskWidth?: number;
+      maskHeight?: number;
+    }>;
+  };
+
+  // Create a new document with the PSD dimensions
+  // First set up via the store's createDocument, then populate layers
+  useEditorStore.getState().createDocument(manifest.width, manifest.height, true);
+
+  const edState = useEditorStore.getState();
+  const store = useEditorStore;
+
+  // Build layers from the PSD manifest.
+  // PSD layers are bottom-to-top; engine-sync handles the actual GPU upload
+  // on the next frame using the ImageData we stash in layerPixelData.
+  const newLayers: Layer[] = [];
+  const newLayerOrder: string[] = [];
+  const newPixelData = new Map<string, ImageData>();
+  const groupStack: { groupLayer: GroupLayer; children: string[] }[] = [];
+
+  for (let i = 0; i < manifest.layers.length; i++) {
+    const psdLayer = manifest.layers[i]!;
+    const layerId = crypto.randomUUID();
+
+    if (psdLayer.groupKind === 3) {
+      // GroupEnd — start collecting children
+      groupStack.push({ groupLayer: null as unknown as GroupLayer, children: [] });
+      continue;
+    }
+
+    if (psdLayer.groupKind === 1 || psdLayer.groupKind === 2) {
+      // GroupOpen — finalize the group
+      const groupInfo = groupStack.pop();
+      const groupLayer: GroupLayer = {
+        id: layerId,
+        name: psdLayer.name,
+        type: 'group',
+        visible: psdLayer.visible,
+        locked: false,
+        opacity: psdLayer.opacity / 255,
+        blendMode: U8_TO_BLEND_MODE[psdLayer.blendMode] ?? 'normal',
+        x: 0,
+        y: 0,
+        clipToBelow: false,
+        effects: DEFAULT_EFFECTS,
+        mask: null,
+        children: groupInfo?.children ?? [],
+        collapsed: psdLayer.groupKind === 2,
+        adjustments: { ...DEFAULT_ADJUSTMENTS },
+        adjustmentsEnabled: true,
+      };
+      newLayers.push(groupLayer);
+      // Lopsy's layerOrder is a flat list of ALL layer IDs; groups appear
+      // after their children (bottom-to-top rendering).
+      newLayerOrder.push(layerId);
+      const topGroup = groupStack[groupStack.length - 1];
+      if (topGroup) {
+        topGroup.children.push(layerId);
+      }
+      continue;
+    }
+
+    // Normal raster layer
+    let mask: RasterLayer['mask'] = null;
+    let pixelImageData: ImageData | null = null;
+
+    if (psdLayer.width > 0 && psdLayer.height > 0) {
+      const pixelData = getPsdLayerPixels(data, i);
+      // For 16-bit PSDs, pixel data is big-endian u16 pairs — downscale to 8-bit
+      let rgba8: Uint8Array;
+      if (manifest.depth === 16) {
+        const pixelCount = psdLayer.width * psdLayer.height;
+        rgba8 = new Uint8Array(pixelCount * 4);
+        for (let p = 0; p < pixelCount * 4; p++) {
+          rgba8[p] = pixelData[p * 2]!; // Take high byte as 8-bit approximation
+        }
+      } else {
+        rgba8 = pixelData;
+      }
+
+      // Stash pixels as ImageData so engine-sync uploads them with the right
+      // layer descriptor (correct blend mode, opacity, etc.) on the next frame.
+      // Copy into a fresh ArrayBuffer — ImageData requires a non-shared buffer.
+      const clamped = new Uint8ClampedArray(rgba8.length);
+      clamped.set(rgba8);
+      pixelImageData = new ImageData(clamped, psdLayer.width, psdLayer.height);
+
+      // Collect mask data (upload via engine-sync by storing on the layer)
+      if (psdLayer.hasMask && psdLayer.maskWidth && psdLayer.maskHeight) {
+        const maskData = getPsdLayerMask(data, i);
+        if (maskData.length > 0) {
+          mask = {
+            id: crypto.randomUUID(),
+            enabled: true,
+            data: new Uint8ClampedArray(maskData.buffer, maskData.byteOffset, maskData.byteLength),
+            width: psdLayer.maskWidth,
+            height: psdLayer.maskHeight,
+          };
+        }
+      }
+    }
+
+    const rasterLayer: RasterLayer = {
+      id: layerId,
+      name: psdLayer.name,
+      type: 'raster',
+      visible: psdLayer.visible,
+      locked: false,
+      opacity: psdLayer.opacity / 255,
+      blendMode: U8_TO_BLEND_MODE[psdLayer.blendMode] ?? 'normal',
+      x: psdLayer.x,
+      y: psdLayer.y,
+      clipToBelow: psdLayer.clipToBelow,
+      effects: DEFAULT_EFFECTS,
+      mask,
+      width: psdLayer.width,
+      height: psdLayer.height,
+    };
+
+    newLayers.push(rasterLayer);
+    if (pixelImageData) {
+      newPixelData.set(layerId, pixelImageData);
+    }
+    // Always push to the flat layerOrder (bottom-to-top render order)
+    newLayerOrder.push(layerId);
+    const topGroupForLayer = groupStack[groupStack.length - 1];
+    if (topGroupForLayer) {
+      topGroupForLayer.children.push(layerId);
+    }
+  }
+
+  // Update store with the new document structure
+  const activeLayerId: string | null = newLayerOrder.length > 0
+    ? newLayerOrder[newLayerOrder.length - 1] ?? null
+    : null;
+
+  // Mark every layer with pixel data as dirty so engine-sync uploads it.
+  const dirtyLayerIds = new Set<string>(newPixelData.keys());
+
+  store.setState({
+    document: {
+      ...edState.document,
+      name,
+      width: manifest.width,
+      height: manifest.height,
+      layers: newLayers,
+      layerOrder: newLayerOrder,
+      activeLayerId,
+    },
+    layerPixelData: newPixelData,
+    sparseLayerData: new Map(),
+    dirtyLayerIds,
+    isDirty: false,
+    renderVersion: edState.renderVersion + 1,
+  });
+
+  // Push the new state to the WASM engine immediately so the first frame
+  // renders with the correct blend modes, opacities, and pixel data.
+  flushLayerSync(store.getState());
+
+  store.getState().fitToView();
+}
+
 export const fileMenu: MenuDef = {
   label: 'File',
   items: [
@@ -166,5 +560,6 @@ export const fileMenu: MenuDef = {
     { label: 'Export JPEG', action: () => exportCanvas('jpeg') },
     { label: 'Export WebP', action: () => exportCanvas('webp') },
     { label: 'Export BMP', action: () => exportCanvas('bmp') },
+    { label: 'Export PSD', action: () => exportPsdFile(16) },
   ],
 };

--- a/src/components/NewDocumentModal/NewDocumentModal.tsx
+++ b/src/components/NewDocumentModal/NewDocumentModal.tsx
@@ -126,7 +126,7 @@ export function NewDocumentModal({ onCreateDocument, onOpenFile, onPasteClipboar
   const handleOpenFile = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = 'image/*';
+    input.accept = 'image/*,.psd';
     input.onchange = () => {
       const file = input.files?.[0];
       if (file) onOpenFile(file);

--- a/src/engine-wasm/wasm-bridge.ts
+++ b/src/engine-wasm/wasm-bridge.ts
@@ -167,6 +167,10 @@ import init, {
   clearBrushTip,
   setBrushTipState,
   clearAllLayers,
+  exportPsd,
+  parsePsd,
+  getPsdLayerPixels,
+  getPsdLayerMask,
 } from './pkg/lopsy_wasm';
 
 export type { Engine };
@@ -344,4 +348,8 @@ export {
   uploadBrushTip,
   clearBrushTip,
   setBrushTipState,
+  exportPsd,
+  parsePsd,
+  getPsdLayerPixels,
+  getPsdLayerMask,
 };


### PR DESCRIPTION
## Summary

Full PSD import/export in Rust/WASM, tailored to Lopsy's engine. No existing Rust crate supports PSD writing and the available readers are too limited (8-bit only, no masks), so this is homerolled.

- Writes and reads 8-bit and 16-bit RGB PSDs with PackBits RLE and ZIP-with-prediction compression, layer groups, masks, and all 16 blend modes
- Opens and validates in Photoshop, GIMP, and psd-tools (structural + pixel-exact roundtrip)
- Single **Open...** accepts both images and `.psd`; single **Export PSD** always writes 16-bit
- Fixes a Photoshop/compositor interaction: drop shadow now knocks out behind the layer so the layer's blend mode operates against the original background, not the shadow

## New module

`engine-rs/crates/lopsy-core/src/psd/`
- `types.rs`, `blend_keys.rs`, `packbits.rs`, `zip_predict.rs`, `flatten.rs`, `writer.rs`, `reader.rs`
- Pure Rust, one new dependency: `flate2` (already transitive via `png`)

## Photoshop compatibility details

- Header channel count = 3 (RGB); merged composite writes 3 planes, no alpha plane
- Layer flag bit `0x08` always set (PS 5+ marker)
- Group-end sentinels named `\"</Layer group>\"` (normalized back to empty on read)
- 16-bit layer info goes in an `Lr16` additional info block at the document level, body padded to 4-byte alignment; main layer info section is empty
- 16-bit merged composite uses raw compression for broad reader support

## WASM bridge / TS integration

- `exportPsd`, `parsePsd`, `getPsdLayerPixels`, `getPsdLayerMask`
- Import stashes pixel data in the Zustand `layerPixelData` map and calls `resetTrackedState()` so engine-sync cleanly registers every layer with correct blend modes, opacities, and pixel data — no direct WASM calls that would bypass the sync tracking

## Drop shadow knockout

Shadow shader now multiplies its output alpha by `(1 - layer_alpha_at_pixel)`, matching Photoshop's \"Layer Knocks Out Drop Shadow\". Previously, shadow blur bled under opaque layer pixels and contaminated the background that blend modes composited against.

## Test plan

- [x] 30 Rust unit tests (all submodules)
- [x] 7 integration roundtrip tests (8-bit, 16-bit, masks, all 16 blend modes, 16-bit gradient precision, groups)
- [x] `psd-tools` validates generated 8-bit and 16-bit files (structure + composite)
- [x] Photoshop opens 16-bit exports
- [x] GIMP opens 16-bit exports
- [ ] Manual check: open PSD from File menu, round-trip through Lopsy, verify layers, blend modes, groups, masks render correctly
- [ ] Manual check: open PSD from initial New Document modal
- [ ] Manual check: layer with blend mode + drop shadow — blend mode applies against original background, shadow shows around edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)