### PR TITLE
refactor: code quality pass — ESLint, engine-sync split, compositor cleanup

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/compositor.rs
+++ b/engine-rs/crates/lopsy-wasm/src/compositor.rs
@@ -24,42 +24,68 @@ pub fn composite(engine: &mut EngineInner) {
     engine.gl.clear_color(bg[0], bg[1], bg[2], bg[3]);
     engine.gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT);
 
-    // 2. Collect layer info (avoids borrowing engine.layer_stack during rendering)
+    // 2. Iterate layers by index so we can take fresh borrows of engine
+    //    inside the loop without holding a long-lived borrow of layer_stack.
+    //    For each layer we read the scalar fields + clone only the enabled
+    //    effect descs in a short scope, then the `&mut engine` render calls
+    //    run freely. This avoids the previous per-frame Vec<tuple>
+    //    allocation and the unconditional EffectsDesc.clone().
     let mask_edit_id = engine.mask_edit_layer_id.clone();
-    let layer_info: Vec<_> = engine.layer_stack.iter().map(|layer| {
-        let is_mask_editing = mask_edit_id.as_deref() == Some(layer.id.as_str());
-        let mask_info = engine.layer_masks.get(&layer.id).and_then(|&mask_handle| {
-            let (mw, mh) = engine.texture_pool.get_size(mask_handle)?;
-            let mask_gl = engine.texture_pool.get(mask_handle)?.clone();
-            let mask_enabled = layer.mask.as_ref().map_or(false, |m| m.enabled);
-            Some((mask_gl, mw, mh, mask_enabled))
-        });
-        (
-            layer.id.clone(),
-            layer.visible,
-            layer.opacity,
-            layer.blend_mode as i32,
-            layer.x as f32,
-            layer.y as f32,
-            layer.width as f32,
-            layer.height as f32,
-            layer.effects.clone(),
-            mask_info,
-            is_mask_editing,
-        )
-    }).collect();
+    let n = engine.layer_stack.len();
 
-    // 3. For each visible layer, render with effects
-    for (layer_id, visible, opacity, blend_mode, layer_x, layer_y, layer_w, layer_h, effects, mask_info, is_mask_editing) in &layer_info {
-        if !visible || *opacity < 1e-7 {
+    for idx in 0..n {
+        let (
+            layer_id,
+            visible,
+            opacity,
+            blend_mode,
+            layer_x,
+            layer_y,
+            layer_w,
+            layer_h,
+            outer_glow,
+            inner_glow,
+            drop_shadow,
+            stroke_eff,
+            color_overlay,
+            is_mask_editing,
+        ) = {
+            let layer = &engine.layer_stack[idx];
+            let is_editing = mask_edit_id.as_deref() == Some(layer.id.as_str());
+            (
+                layer.id.clone(),
+                layer.visible,
+                layer.opacity,
+                layer.blend_mode as i32,
+                layer.x as f32,
+                layer.y as f32,
+                layer.width as f32,
+                layer.height as f32,
+                layer.effects.outer_glow.as_ref().filter(|g| g.enabled).cloned(),
+                layer.effects.inner_glow.as_ref().filter(|g| g.enabled).cloned(),
+                layer.effects.drop_shadow.as_ref().filter(|s| s.enabled).cloned(),
+                layer.effects.stroke.as_ref().filter(|s| s.enabled).cloned(),
+                layer.effects.color_overlay.as_ref().filter(|o| o.enabled).cloned(),
+                is_editing,
+            )
+        };
+
+        if !visible || opacity < 1e-7 {
             continue;
         }
 
-        let tex_handle = match engine.layer_textures.get(layer_id) {
+        let mask_info = engine.layer_masks.get(&layer_id).copied().and_then(|mask_handle| {
+            let (mw, mh) = engine.texture_pool.get_size(mask_handle)?;
+            let mask_gl = engine.texture_pool.get(mask_handle)?.clone();
+            let mask_enabled = engine.layer_stack[idx].mask.as_ref().map_or(false, |m| m.enabled);
+            Some((mask_gl, mw, mh, mask_enabled))
+        });
+
+        let tex_handle = match engine.layer_textures.get(&layer_id) {
             Some(&h) => h,
             None => continue,
         };
-        let (tw, th) = engine.texture_pool.get_size(tex_handle).unwrap_or((*layer_w as u32, *layer_h as u32));
+        let (tw, th) = engine.texture_pool.get_size(tex_handle).unwrap_or((layer_w as u32, layer_h as u32));
 
         // If a brush stroke is in progress for this layer, pre-merge
         // (layer + stroke_texture) into a scratch so effects (drop shadow,
@@ -67,27 +93,23 @@ pub fn composite(engine: &mut EngineInner) {
         // of the layer. Without this, effects lag by one stroke because
         // endStroke is deferred until the next mousedown (shift-click
         // continuation).
-        let merged_handle: Option<TextureHandle> = engine.stroke_textures.get(layer_id)
+        let merged_handle: Option<TextureHandle> = engine.stroke_textures.get(&layer_id)
             .copied()
             .and_then(|stroke_handle| render_layer_plus_stroke(engine, tex_handle, stroke_handle, tw, th));
         let effect_tex_handle = merged_handle.unwrap_or(tex_handle);
 
         // --- "Behind" effects: outer glow, drop shadow ---
-        if let Some(ref glow) = effects.outer_glow {
-            if glow.enabled {
-                render_glow(engine, effect_tex_handle, tw, th, glow, 0, *layer_x, *layer_y);
-            }
+        if let Some(ref glow) = outer_glow {
+            render_glow(engine, effect_tex_handle, tw, th, glow, 0, layer_x, layer_y);
         }
-        if let Some(ref shadow) = effects.drop_shadow {
-            if shadow.enabled {
-                render_shadow(engine, effect_tex_handle, tw, th, shadow, *layer_x, *layer_y);
-            }
+        if let Some(ref shadow) = drop_shadow {
+            render_shadow(engine, effect_tex_handle, tw, th, shadow, layer_x, layer_y);
         }
 
         // --- Color overlay + blend layer onto composite ---
         // In mask edit mode: skip mask clipping so full layer content is visible
-        let overlay_desc = effects.color_overlay.as_ref().filter(|o| o.enabled);
-        let mask_arg = if *is_mask_editing {
+        let overlay_desc = color_overlay.as_ref();
+        let mask_arg = if is_mask_editing {
             None
         } else {
             mask_info.as_ref().and_then(|(tex, mw, mh, enabled)| {
@@ -99,8 +121,8 @@ pub fn composite(engine: &mut EngineInner) {
         // per-stroke preview texture and composite that instead of the raw
         // layer. This way the stroke is non-destructive until `endStroke`
         // bakes it in.
-        let composite_src = if engine.stroke_dodge_textures.contains_key(layer_id) {
-            render_dodge_burn_preview(engine, layer_id, effect_tex_handle, tw, th)
+        let composite_src = if engine.stroke_dodge_textures.contains_key(&layer_id) {
+            render_dodge_burn_preview(engine, &layer_id, effect_tex_handle, tw, th)
                 .map(|h| (h, tw, th))
         } else if merged_handle.is_some() {
             Some((effect_tex_handle, tw, th))
@@ -109,38 +131,34 @@ pub fn composite(engine: &mut EngineInner) {
         };
         let (src_handle, src_w, src_h) = composite_src.unwrap_or((tex_handle, tw, th));
         if let Some(src_tex) = engine.texture_pool.get(src_handle).cloned() {
-            blend_onto_composite(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+            blend_onto_composite(engine, &src_tex, opacity, blend_mode, layer_x, layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
         }
 
         // --- Active stroke texture ---
         // Skipped when we merged the stroke into effect_tex_handle above —
         // it's already in the composite source.
         if merged_handle.is_none() {
-            if let Some(&stroke_handle) = engine.stroke_textures.get(layer_id) {
+            if let Some(&stroke_handle) = engine.stroke_textures.get(&layer_id) {
                 if let Some(stroke_tex) = engine.texture_pool.get(stroke_handle).cloned() {
                     let (sw, sh) = engine.texture_pool.get_size(stroke_handle).unwrap_or((1, 1));
-                    blend_onto_composite(engine, &stroke_tex, *opacity, 0, *layer_x, *layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+                    blend_onto_composite(engine, &stroke_tex, opacity, 0, layer_x, layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
                 }
             }
         }
 
         // --- Mask edit overlay: translucent blue showing mask coverage ---
-        if *is_mask_editing {
-            if let Some((mask_gl, mw, mh, _)) = mask_info {
-                render_mask_overlay(engine, mask_gl, *mw, *mh, *layer_x, *layer_y);
+        if is_mask_editing {
+            if let Some((mask_gl, mw, mh, _)) = &mask_info {
+                render_mask_overlay(engine, mask_gl, *mw, *mh, layer_x, layer_y);
             }
         }
 
         // --- "On top" effects: inner glow, stroke effect ---
-        if let Some(ref glow) = effects.inner_glow {
-            if glow.enabled {
-                render_glow(engine, effect_tex_handle, tw, th, glow, 1, *layer_x, *layer_y);
-            }
+        if let Some(ref glow) = inner_glow {
+            render_glow(engine, effect_tex_handle, tw, th, glow, 1, layer_x, layer_y);
         }
-        if let Some(ref stroke) = effects.stroke {
-            if stroke.enabled {
-                render_stroke(engine, effect_tex_handle, tw, th, stroke, *layer_x, *layer_y);
-            }
+        if let Some(ref stroke) = stroke_eff {
+            render_stroke(engine, effect_tex_handle, tw, th, stroke, layer_x, layer_y);
         }
 
         if let Some(merged) = merged_handle {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,61 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'storybook-static/**',
+      'node_modules/**',
+      'src/engine-wasm/pkg/**',
+      'engine-rs/**',
+      'e2e/**',
+      'scripts/**',
+      '.storybook/**',
+      '**/*.stories.tsx',
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      'playwright.config.ts',
+      'vite.config.ts',
+      'vitest.config.ts',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.worker,
+      },
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  {
+    files: ['src/test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,19 @@
         "zustand": "5.0.11"
       },
       "devDependencies": {
+        "@eslint/js": "9.37.0",
         "@playwright/test": "1.58.2",
         "@storybook/react-vite": "10.2.17",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "5.1.4",
+        "eslint": "9.37.0",
+        "eslint-plugin-react-hooks": "5.2.0",
+        "globals": "15.15.0",
         "jsdom": "28.1.0",
         "playwright": "1.58.2",
         "typescript": "5.9.3",
+        "typescript-eslint": "8.46.0",
         "vite": "7.3.1",
         "vite-plugin-top-level-await": "1.6.0",
         "vite-plugin-wasm": "3.6.0",
@@ -981,6 +986,251 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
+      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -997,6 +1247,72 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -1067,6 +1383,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@playwright/test": {
@@ -2017,6 +2371,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2043,6 +2404,284 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.0.tgz",
+      "integrity": "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/type-utils": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.46.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.0.tgz",
+      "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.0.tgz",
+      "integrity": "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.0",
+        "@typescript-eslint/types": "^8.46.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.0.tgz",
+      "integrity": "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.0.tgz",
+      "integrity": "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.0.tgz",
+      "integrity": "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
+      "integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.0.tgz",
+      "integrity": "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.0",
+        "@typescript-eslint/tsconfig-utils": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.0.tgz",
+      "integrity": "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.0.tgz",
+      "integrity": "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
@@ -2276,6 +2915,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2284,6 +2933,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -2310,6 +2976,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2392,6 +3065,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2443,6 +3129,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
@@ -2482,6 +3178,39 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2493,12 +3222,54 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2604,6 +3375,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -2772,6 +3550,172 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
+      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/core": "^0.16.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.37.0",
+        "@eslint/plugin-kit": "^0.4.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2785,6 +3729,42 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -2814,6 +3794,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2831,6 +3872,70 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -2883,6 +3988,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -2939,6 +4087,43 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2983,6 +4168,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -3001,6 +4209,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3027,12 +4245,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "28.1.0",
@@ -3088,6 +4326,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3100,6 +4359,53 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3155,6 +4461,43 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -3229,6 +4572,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -3267,6 +4617,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -3278,6 +4691,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -3413,6 +4846,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -3438,6 +4881,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -3588,6 +5052,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -3647,6 +5132,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3674,6 +5183,29 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -3792,6 +5324,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3896,6 +5454,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -3920,6 +5491,19 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-dedent": {
@@ -3955,6 +5539,19 @@
       "license": "0BSD",
       "peer": true
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3967,6 +5564,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.0.tgz",
+      "integrity": "sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.46.0",
+        "@typescript-eslint/parser": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undici": {
@@ -4024,6 +5645,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -4375,6 +6006,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4390,6 +6037,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -4455,6 +6112,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.11",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit",
-    "lint": "node scripts/check-pixel-debt.mjs",
+    "lint": "eslint src && node scripts/check-pixel-debt.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -26,14 +26,19 @@
     "zustand": "5.0.11"
   },
   "devDependencies": {
+    "@eslint/js": "9.37.0",
     "@playwright/test": "1.58.2",
     "@storybook/react-vite": "10.2.17",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "5.1.4",
+    "eslint": "9.37.0",
+    "eslint-plugin-react-hooks": "5.2.0",
+    "globals": "15.15.0",
     "jsdom": "28.1.0",
     "playwright": "1.58.2",
     "typescript": "5.9.3",
+    "typescript-eslint": "8.46.0",
     "vite": "7.3.1",
     "vite-plugin-top-level-await": "1.6.0",
     "vite-plugin-wasm": "3.6.0",

--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -77,7 +77,7 @@ const ALLOWLIST = {
   'src/engine/color-space.ts': 5,
 
   // Brush engine scaffolding — stamps, shape data, ABR parsing.
-  'src/app/brush-preset-store.ts': 7,
+  'src/app/tool-settings-store.ts': 7,
   'src/tools/brush/abr-parser.ts': 4,
   'src/tools/brush/brush-from-selection.ts': 4,
   'src/tools/brush/brush.ts': 1,

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -3,14 +3,16 @@
  *
  * Tracks what has already been sent to the engine and only pushes
  * deltas each frame to avoid redundant GPU uploads.
+ *
+ * The hot path (syncLayers + descriptor serialization) lives in
+ * ./sync-layers.ts, and the shared per-engine tracked state lives in
+ * ./sync-state.ts. This file re-exports their public surface so
+ * consumers only need to import from `engine-sync`.
  */
 
 import type { Engine } from './wasm-bridge';
 import { getEngine } from './engine-state';
 import type { Layer } from '../types';
-import type { SparseLayerEntry } from '../app/store/types';
-import { pixelDataManager } from '../engine/pixel-data-manager';
-import { buildLayerIndex, isEffectivelyVisible, type LayerIndex } from '../layers/layer-index';
 import type { ImageAdjustments } from '../filters/image-adjustments';
 import { buildCurvesLutRgba, isIdentityCurves } from '../filters/curves';
 import { buildLevelsLutRgba, isIdentityLevels } from '../filters/levels';
@@ -18,14 +20,6 @@ import {
   setDocumentSize,
   setViewport,
   setBackgroundColor,
-  addLayer,
-  removeLayer,
-  updateLayer,
-  setLayerOrder,
-  uploadLayerPixels,
-  uploadLayerSparsePixels,
-  uploadLayerMask,
-  removeLayerMask,
   render,
   markAllDirty,
   setSelectionMask,
@@ -65,224 +59,11 @@ import {
 import type { PathAnchor } from '../app/ui-store';
 import type { SelectionData } from '../app/store/types';
 import type { BrushTipData } from '../types/brush';
+import { getTracked } from './sync-state';
+import { syncLayers } from './sync-layers';
 
-// ---------------------------------------------------------------------------
-// Blend mode mapping: TypeScript union → Rust serde enum variant
-// Canonical table lives in src/types/blend-mode-tables.ts.
-// ---------------------------------------------------------------------------
-
-import { BLEND_MODE_TO_PASCAL as BLEND_MODE_MAP } from '../types/blend-mode-tables';
-
-const LAYER_TYPE_MAP: Record<string, string> = {
-  'raster': 'Raster',
-  'text': 'Text',
-  'shape': 'Shape',
-  'group': 'Group',
-  'adjustment': 'Adjustment',
-};
-
-function layerToDescJson(layer: Layer, effectiveVisible: boolean): string {
-  const effects: Record<string, unknown> = {};
-
-  const eff = layer.effects;
-
-  if (eff.outerGlow.enabled) {
-    const c = eff.outerGlow.color;
-    effects.outer_glow = {
-      enabled: true,
-      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
-      size: eff.outerGlow.size,
-      spread: eff.outerGlow.spread,
-      opacity: eff.outerGlow.opacity,
-    };
-  }
-  if (eff.innerGlow.enabled) {
-    const c = eff.innerGlow.color;
-    effects.inner_glow = {
-      enabled: true,
-      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
-      size: eff.innerGlow.size,
-      spread: eff.innerGlow.spread,
-      opacity: eff.innerGlow.opacity,
-    };
-  }
-  if (eff.dropShadow.enabled) {
-    const c = eff.dropShadow.color;
-    effects.drop_shadow = {
-      enabled: true,
-      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
-      offset_x: eff.dropShadow.offsetX,
-      offset_y: eff.dropShadow.offsetY,
-      blur: eff.dropShadow.blur,
-      spread: eff.dropShadow.spread,
-      opacity: eff.dropShadow.opacity ?? c.a,
-    };
-  }
-  if (eff.stroke.enabled) {
-    const c = eff.stroke.color;
-    const posMap: Record<string, string> = {
-      'outside': 'Outside',
-      'inside': 'Inside',
-      'center': 'Center',
-    };
-    effects.stroke = {
-      enabled: true,
-      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
-      width: eff.stroke.width,
-      position: posMap[eff.stroke.position] ?? 'Outside',
-      opacity: 1.0,
-    };
-  }
-  if (eff.colorOverlay.enabled) {
-    const c = eff.colorOverlay.color;
-    effects.color_overlay = {
-      enabled: true,
-      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
-      opacity: 1.0,
-    };
-  }
-
-  const width = 'width' in layer ? (layer.width ?? 0) : 0;
-  const height = 'height' in layer ? (layer.height ?? 0) : 0;
-
-  const desc: Record<string, unknown> = {
-    id: layer.id,
-    name: layer.name,
-    layer_type: LAYER_TYPE_MAP[layer.type] ?? 'Raster',
-    visible: effectiveVisible,
-    locked: layer.locked,
-    opacity: layer.opacity,
-    blend_mode: BLEND_MODE_MAP[layer.blendMode] ?? 'Normal',
-    x: layer.x,
-    y: layer.y,
-    width,
-    height,
-    clip_to_below: layer.clipToBelow,
-    effects,
-    mask: layer.mask ? {
-      enabled: layer.mask.enabled,
-      linked: true,
-      width: layer.mask.width,
-      height: layer.mask.height,
-    } : null,
-  };
-
-  if (layer.type === 'group' && 'children' in layer) {
-    desc.children = (layer as import('../types').GroupLayer).children;
-  }
-
-  return JSON.stringify(desc);
-}
-
-// ---------------------------------------------------------------------------
-// Tracked state — what the engine currently knows
-// ---------------------------------------------------------------------------
-
-interface TrackedState {
-  docWidth: number;
-  docHeight: number;
-  bgColor: string;
-  viewportZoom: number;
-  viewportPanX: number;
-  viewportPanY: number;
-  viewportWidth: number;
-  viewportHeight: number;
-  layerIds: Set<string>;
-  layerVersions: Map<string, string>;
-  /** Layer reference that produced the cached descriptor. If the reference
-   *  and the effective visibility are both unchanged, the descriptor is
-   *  also unchanged and we can skip JSON.stringify entirely. */
-  layerRefs: Map<string, Layer>;
-  layerEffectiveVisible: Map<string, boolean>;
-  /** Layer ids currently known to have a mask on the engine side. Used to
-   *  decide whether a removeLayerMask call is needed — previously done by
-   *  substring-sniffing the cached descriptor JSON, which was fragile. */
-  masksOnEngine: Set<string>;
-  pixelDataVersions: Map<string, ImageData | undefined>;
-  sparseVersions: Map<string, SparseLayerEntry | undefined>;
-  layerOrder: string;
-  selectionActive: boolean;
-  selectionMask: Uint8ClampedArray | null;
-  showGrid: boolean;
-  gridSize: number;
-  showRulers: boolean;
-  brushTipData: BrushTipData | null;
-  brushAngle: number;
-  brushHasTip: boolean;
-  /** Reference equality on the active Curves object so we only re-upload
-   *  the LUT texture when the user actually edited a control point. */
-  curvesRef: unknown;
-  /** True when the engine is in "no curves" mode; null on first frame. */
-  curvesIdentity: boolean | null;
-  /** Reference equality on the active Levels object so we only re-upload
-   *  the LUT texture when the user actually edited a control point. */
-  levelsRef: unknown;
-  /** True when the engine is in "no levels" mode; null on first frame. */
-  levelsIdentity: boolean | null;
-}
-
-function createTrackedState(): TrackedState {
-  return {
-    docWidth: 0,
-    docHeight: 0,
-    bgColor: '',
-    viewportZoom: 0,
-    viewportPanX: 0,
-    viewportPanY: 0,
-    viewportWidth: 0,
-    viewportHeight: 0,
-    layerIds: new Set(),
-    layerVersions: new Map(),
-    layerRefs: new Map(),
-    layerEffectiveVisible: new Map(),
-    masksOnEngine: new Set(),
-    pixelDataVersions: new Map(),
-    sparseVersions: new Map(),
-    layerOrder: '',
-    selectionActive: false,
-    selectionMask: null,
-    showGrid: false,
-    gridSize: 0,
-    showRulers: false,
-    brushTipData: null,
-    brushAngle: 0,
-    brushHasTip: false,
-    curvesRef: null,
-    curvesIdentity: null,
-    levelsRef: null,
-    levelsIdentity: null,
-  };
-}
-
-// Tracked state is keyed by Engine instance so it lives and dies with the
-// engine — no module-level singleton, no HMR pollution, no test cross-talk.
-const trackedByEngine = new WeakMap<Engine, TrackedState>();
-
-function getTracked(engine: Engine): TrackedState {
-  let t = trackedByEngine.get(engine);
-  if (!t) {
-    t = createTrackedState();
-    trackedByEngine.set(engine, t);
-  }
-  return t;
-}
-
-export function resetTrackedState(engine: Engine): void {
-  trackedByEngine.set(engine, createTrackedState());
-}
-
-/**
- * Mark a layer's pixel data as already synced to the GPU.
- * Use this when uploading via a non-standard path (e.g. canvas upload)
- * to prevent syncLayers from re-uploading stale byte data.
- */
-export function markPixelDataSynced(engine: Engine, layerId: string, data: ImageData): void {
-  getTracked(engine).pixelDataVersions.set(layerId, data);
-}
-
-// ---------------------------------------------------------------------------
-// Sync functions — called before each render
-// ---------------------------------------------------------------------------
+export { resetTrackedState, markPixelDataSynced } from './sync-state';
+export { syncLayers } from './sync-layers';
 
 export function syncDocumentSize(engine: Engine, width: number, height: number): void {
   const tracked = getTracked(engine);
@@ -322,150 +103,6 @@ export function syncViewport(
   tracked.viewportPanY = panY;
   tracked.viewportWidth = screenW;
   tracked.viewportHeight = screenH;
-}
-
-export function syncLayers(
-  engine: Engine,
-  layers: readonly Layer[],
-  layerOrder: readonly string[],
-  dirtyLayerIds: Set<string>,
-): void {
-  const tracked = getTracked(engine);
-  const currentIds = new Set(layers.map((l) => l.id));
-
-  // Build a per-sync LayerIndex so ancestor-visibility checks are O(depth)
-  // per layer instead of the O(n²) nested walk this used to do.
-  const index: LayerIndex = buildLayerIndex(layers);
-
-  // Remove layers no longer present
-  for (const id of tracked.layerIds) {
-    if (!currentIds.has(id)) {
-      try {
-        removeLayer(engine, id);
-      } catch (e) {
-        console.error('[syncLayers] removeLayer failed:', id, e);
-      }
-      tracked.layerVersions.delete(id);
-      tracked.layerRefs.delete(id);
-      tracked.layerEffectiveVisible.delete(id);
-      tracked.masksOnEngine.delete(id);
-      tracked.pixelDataVersions.delete(id);
-      tracked.sparseVersions.delete(id);
-    }
-  }
-
-  // Track which layers were successfully added so we don't mark failed
-  // adds as tracked (which would prevent retry on the next frame).
-  const failedAdds = new Set<string>();
-
-  // Add or update layers
-  for (const layer of layers) {
-    const effectiveVisible = isEffectivelyVisible(index, layer.id);
-
-    // Fast path: if both the layer reference and its effective visibility
-    // are unchanged since last sync, the descriptor JSON is also unchanged.
-    // Skip the serialization entirely. This is the common case — most
-    // frames re-render without any layer mutation.
-    const refUnchanged = tracked.layerRefs.get(layer.id) === layer;
-    const visUnchanged = tracked.layerEffectiveVisible.get(layer.id) === effectiveVisible;
-    const isKnown = tracked.layerIds.has(layer.id);
-
-    let descJson: string | undefined;
-    if (!isKnown || !refUnchanged || !visUnchanged) {
-      descJson = layerToDescJson(layer, effectiveVisible);
-    }
-
-    if (!isKnown) {
-      try {
-        addLayer(engine, descJson!);
-        tracked.layerVersions.set(layer.id, descJson!);
-        tracked.layerRefs.set(layer.id, layer);
-        tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
-      } catch (e) {
-        console.error('[syncLayers] addLayer failed:', layer.id, e);
-        failedAdds.add(layer.id);
-      }
-    } else if (descJson !== undefined && tracked.layerVersions.get(layer.id) !== descJson) {
-      try {
-        updateLayer(engine, descJson);
-        tracked.layerVersions.set(layer.id, descJson);
-      } catch (e) {
-        console.error('[syncLayers] updateLayer failed:', layer.id, e);
-      }
-      tracked.layerRefs.set(layer.id, layer);
-      tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
-    } else if (descJson !== undefined) {
-      tracked.layerRefs.set(layer.id, layer);
-      tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
-    }
-
-    // Upload pixel data if changed or marked dirty (including GPU paint dirty).
-    // When no JS data exists AND no sparse data, the GPU texture is source of truth
-    // (e.g. after a GPU paint stroke or undo restore) — skip upload.
-    const data = pixelDataManager.get(layer.id);
-    const sparseEntry = pixelDataManager.getSparse(layer.id);
-    const isDirty = dirtyLayerIds.has(layer.id);
-    const pixelChanged = tracked.pixelDataVersions.get(layer.id) !== data;
-    const sparseChanged = tracked.sparseVersions.get(layer.id) !== sparseEntry;
-
-    if (data && (pixelChanged || isDirty)) {
-      const rawBytes = new Uint8Array(data.data.buffer, data.data.byteOffset, data.data.byteLength);
-      uploadLayerPixels(engine, layer.id, rawBytes, data.width, data.height, layer.x, layer.y);
-      tracked.pixelDataVersions.set(layer.id, data);
-      tracked.sparseVersions.set(layer.id, undefined);
-    } else if (!data && sparseEntry && (sparseChanged || isDirty)) {
-      const indices = new Uint32Array(sparseEntry.sparse.indices);
-      const rgba = new Uint8Array(sparseEntry.sparse.rgba.buffer, sparseEntry.sparse.rgba.byteOffset, sparseEntry.sparse.rgba.byteLength);
-      // Use layer.x/y as authoritative position — sparse offsets may be
-      // stale after updateLayerPosition() (move tool).
-      uploadLayerSparsePixels(
-        engine,
-        layer.id,
-        indices,
-        rgba,
-        sparseEntry.sparse.width,
-        sparseEntry.sparse.height,
-        layer.x,
-        layer.y,
-      );
-      tracked.sparseVersions.set(layer.id, sparseEntry);
-      tracked.pixelDataVersions.set(layer.id, undefined);
-    } else if (!data && !sparseEntry) {
-      // No JS data — GPU texture is source of truth (GPU paint or undo restore).
-      // Only clear the GPU texture if we previously had JS data AND the layer is dirty
-      // (meaning JS data was explicitly removed, not just never set).
-      if (isDirty && (tracked.pixelDataVersions.get(layer.id) !== undefined || tracked.sparseVersions.get(layer.id) !== undefined)) {
-        // JS data was cleared but layer is dirty — GPU already has the correct data
-        // from uploadCompressed or GPU stroke. Just update tracking.
-        tracked.pixelDataVersions.set(layer.id, undefined);
-        tracked.sparseVersions.set(layer.id, undefined);
-      }
-    }
-
-    // Upload mask
-    if (layer.mask) {
-      const maskBytes = new Uint8Array(layer.mask.data.buffer, layer.mask.data.byteOffset, layer.mask.data.byteLength);
-      uploadLayerMask(engine, layer.id, maskBytes, layer.mask.width, layer.mask.height);
-      tracked.masksOnEngine.add(layer.id);
-    } else if (tracked.masksOnEngine.has(layer.id)) {
-      removeLayerMask(engine, layer.id);
-      tracked.masksOnEngine.delete(layer.id);
-    }
-  }
-
-  // Exclude layers that failed to add — they stay out of tracking so
-  // syncLayers retries addLayer on the next frame.
-  for (const id of failedAdds) {
-    currentIds.delete(id);
-  }
-  tracked.layerIds = currentIds;
-
-  // Sync layer order
-  const orderJson = JSON.stringify(layerOrder);
-  if (tracked.layerOrder !== orderJson) {
-    setLayerOrder(engine, orderJson);
-    tracked.layerOrder = orderJson;
-  }
 }
 
 export function syncSelection(engine: Engine, selection: SelectionData): void {

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -1,0 +1,271 @@
+/**
+ * Per-frame layer sync: diffs the current layer array against what the
+ * engine already knows and pushes only the deltas (adds, updates, removes,
+ * pixel uploads, mask uploads, layer order).
+ *
+ * This is the hottest part of engine sync and lives in its own file so the
+ * surrounding engine-sync.ts stays small. Shared tracked state lives in
+ * sync-state.ts so other sync functions can read and mutate it too.
+ */
+
+import type { Engine } from './wasm-bridge';
+import type { Layer, GroupLayer } from '../types';
+import { pixelDataManager } from '../engine/pixel-data-manager';
+import { buildLayerIndex, isEffectivelyVisible, type LayerIndex } from '../layers/layer-index';
+import { BLEND_MODE_TO_PASCAL as BLEND_MODE_MAP } from '../types/blend-mode-tables';
+import {
+  addLayer,
+  removeLayer,
+  updateLayer,
+  setLayerOrder,
+  uploadLayerPixels,
+  uploadLayerSparsePixels,
+  uploadLayerMask,
+  removeLayerMask,
+} from './wasm-bridge';
+import { getTracked } from './sync-state';
+
+const LAYER_TYPE_MAP: Record<string, string> = {
+  'raster': 'Raster',
+  'text': 'Text',
+  'shape': 'Shape',
+  'group': 'Group',
+  'adjustment': 'Adjustment',
+};
+
+function layerToDescJson(layer: Layer, effectiveVisible: boolean): string {
+  const effects: Record<string, unknown> = {};
+
+  const eff = layer.effects;
+
+  if (eff.outerGlow.enabled) {
+    const c = eff.outerGlow.color;
+    effects.outer_glow = {
+      enabled: true,
+      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
+      size: eff.outerGlow.size,
+      spread: eff.outerGlow.spread,
+      opacity: eff.outerGlow.opacity,
+    };
+  }
+  if (eff.innerGlow.enabled) {
+    const c = eff.innerGlow.color;
+    effects.inner_glow = {
+      enabled: true,
+      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
+      size: eff.innerGlow.size,
+      spread: eff.innerGlow.spread,
+      opacity: eff.innerGlow.opacity,
+    };
+  }
+  if (eff.dropShadow.enabled) {
+    const c = eff.dropShadow.color;
+    effects.drop_shadow = {
+      enabled: true,
+      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
+      offset_x: eff.dropShadow.offsetX,
+      offset_y: eff.dropShadow.offsetY,
+      blur: eff.dropShadow.blur,
+      spread: eff.dropShadow.spread,
+      opacity: eff.dropShadow.opacity ?? c.a,
+    };
+  }
+  if (eff.stroke.enabled) {
+    const c = eff.stroke.color;
+    const posMap: Record<string, string> = {
+      'outside': 'Outside',
+      'inside': 'Inside',
+      'center': 'Center',
+    };
+    effects.stroke = {
+      enabled: true,
+      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
+      width: eff.stroke.width,
+      position: posMap[eff.stroke.position] ?? 'Outside',
+      opacity: 1.0,
+    };
+  }
+  if (eff.colorOverlay.enabled) {
+    const c = eff.colorOverlay.color;
+    effects.color_overlay = {
+      enabled: true,
+      color: [c.r / 255, c.g / 255, c.b / 255, c.a],
+      opacity: 1.0,
+    };
+  }
+
+  const width = 'width' in layer ? (layer.width ?? 0) : 0;
+  const height = 'height' in layer ? (layer.height ?? 0) : 0;
+
+  const desc: Record<string, unknown> = {
+    id: layer.id,
+    name: layer.name,
+    layer_type: LAYER_TYPE_MAP[layer.type] ?? 'Raster',
+    visible: effectiveVisible,
+    locked: layer.locked,
+    opacity: layer.opacity,
+    blend_mode: BLEND_MODE_MAP[layer.blendMode] ?? 'Normal',
+    x: layer.x,
+    y: layer.y,
+    width,
+    height,
+    clip_to_below: layer.clipToBelow,
+    effects,
+    mask: layer.mask ? {
+      enabled: layer.mask.enabled,
+      linked: true,
+      width: layer.mask.width,
+      height: layer.mask.height,
+    } : null,
+  };
+
+  if (layer.type === 'group' && 'children' in layer) {
+    desc.children = (layer as GroupLayer).children;
+  }
+
+  return JSON.stringify(desc);
+}
+
+export function syncLayers(
+  engine: Engine,
+  layers: readonly Layer[],
+  layerOrder: readonly string[],
+  dirtyLayerIds: Set<string>,
+): void {
+  const tracked = getTracked(engine);
+  const currentIds = new Set(layers.map((l) => l.id));
+
+  // Build a per-sync LayerIndex so ancestor-visibility checks are O(depth)
+  // per layer instead of the O(n²) nested walk this used to do.
+  const index: LayerIndex = buildLayerIndex(layers);
+
+  // Remove layers no longer present
+  for (const id of tracked.layerIds) {
+    if (!currentIds.has(id)) {
+      try {
+        removeLayer(engine, id);
+      } catch (e) {
+        console.error('[syncLayers] removeLayer failed:', id, e);
+      }
+      tracked.layerVersions.delete(id);
+      tracked.layerRefs.delete(id);
+      tracked.layerEffectiveVisible.delete(id);
+      tracked.masksOnEngine.delete(id);
+      tracked.pixelDataVersions.delete(id);
+      tracked.sparseVersions.delete(id);
+    }
+  }
+
+  // Track which layers were successfully added so we don't mark failed
+  // adds as tracked (which would prevent retry on the next frame).
+  const failedAdds = new Set<string>();
+
+  // Add or update layers
+  for (const layer of layers) {
+    const effectiveVisible = isEffectivelyVisible(index, layer.id);
+
+    // Fast path: if both the layer reference and its effective visibility
+    // are unchanged since last sync, the descriptor JSON is also unchanged.
+    // Skip the serialization entirely. This is the common case — most
+    // frames re-render without any layer mutation.
+    const refUnchanged = tracked.layerRefs.get(layer.id) === layer;
+    const visUnchanged = tracked.layerEffectiveVisible.get(layer.id) === effectiveVisible;
+    const isKnown = tracked.layerIds.has(layer.id);
+
+    let descJson: string | undefined;
+    if (!isKnown || !refUnchanged || !visUnchanged) {
+      descJson = layerToDescJson(layer, effectiveVisible);
+    }
+
+    if (!isKnown) {
+      try {
+        addLayer(engine, descJson!);
+        tracked.layerVersions.set(layer.id, descJson!);
+        tracked.layerRefs.set(layer.id, layer);
+        tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
+      } catch (e) {
+        console.error('[syncLayers] addLayer failed:', layer.id, e);
+        failedAdds.add(layer.id);
+      }
+    } else if (descJson !== undefined && tracked.layerVersions.get(layer.id) !== descJson) {
+      try {
+        updateLayer(engine, descJson);
+        tracked.layerVersions.set(layer.id, descJson);
+      } catch (e) {
+        console.error('[syncLayers] updateLayer failed:', layer.id, e);
+      }
+      tracked.layerRefs.set(layer.id, layer);
+      tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
+    } else if (descJson !== undefined) {
+      tracked.layerRefs.set(layer.id, layer);
+      tracked.layerEffectiveVisible.set(layer.id, effectiveVisible);
+    }
+
+    // Upload pixel data if changed or marked dirty (including GPU paint dirty).
+    // When no JS data exists AND no sparse data, the GPU texture is source of truth
+    // (e.g. after a GPU paint stroke or undo restore) — skip upload.
+    const data = pixelDataManager.get(layer.id);
+    const sparseEntry = pixelDataManager.getSparse(layer.id);
+    const isDirty = dirtyLayerIds.has(layer.id);
+    const pixelChanged = tracked.pixelDataVersions.get(layer.id) !== data;
+    const sparseChanged = tracked.sparseVersions.get(layer.id) !== sparseEntry;
+
+    if (data && (pixelChanged || isDirty)) {
+      const rawBytes = new Uint8Array(data.data.buffer, data.data.byteOffset, data.data.byteLength);
+      uploadLayerPixels(engine, layer.id, rawBytes, data.width, data.height, layer.x, layer.y);
+      tracked.pixelDataVersions.set(layer.id, data);
+      tracked.sparseVersions.set(layer.id, undefined);
+    } else if (!data && sparseEntry && (sparseChanged || isDirty)) {
+      const indices = new Uint32Array(sparseEntry.sparse.indices);
+      const rgba = new Uint8Array(sparseEntry.sparse.rgba.buffer, sparseEntry.sparse.rgba.byteOffset, sparseEntry.sparse.rgba.byteLength);
+      // Use layer.x/y as authoritative position — sparse offsets may be
+      // stale after updateLayerPosition() (move tool).
+      uploadLayerSparsePixels(
+        engine,
+        layer.id,
+        indices,
+        rgba,
+        sparseEntry.sparse.width,
+        sparseEntry.sparse.height,
+        layer.x,
+        layer.y,
+      );
+      tracked.sparseVersions.set(layer.id, sparseEntry);
+      tracked.pixelDataVersions.set(layer.id, undefined);
+    } else if (!data && !sparseEntry) {
+      // No JS data — GPU texture is source of truth (GPU paint or undo restore).
+      // Only clear the GPU texture if we previously had JS data AND the layer is dirty
+      // (meaning JS data was explicitly removed, not just never set).
+      if (isDirty && (tracked.pixelDataVersions.get(layer.id) !== undefined || tracked.sparseVersions.get(layer.id) !== undefined)) {
+        // JS data was cleared but layer is dirty — GPU already has the correct data
+        // from uploadCompressed or GPU stroke. Just update tracking.
+        tracked.pixelDataVersions.set(layer.id, undefined);
+        tracked.sparseVersions.set(layer.id, undefined);
+      }
+    }
+
+    // Upload mask
+    if (layer.mask) {
+      const maskBytes = new Uint8Array(layer.mask.data.buffer, layer.mask.data.byteOffset, layer.mask.data.byteLength);
+      uploadLayerMask(engine, layer.id, maskBytes, layer.mask.width, layer.mask.height);
+      tracked.masksOnEngine.add(layer.id);
+    } else if (tracked.masksOnEngine.has(layer.id)) {
+      removeLayerMask(engine, layer.id);
+      tracked.masksOnEngine.delete(layer.id);
+    }
+  }
+
+  // Exclude layers that failed to add — they stay out of tracking so
+  // syncLayers retries addLayer on the next frame.
+  for (const id of failedAdds) {
+    currentIds.delete(id);
+  }
+  tracked.layerIds = currentIds;
+
+  // Sync layer order
+  const orderJson = JSON.stringify(layerOrder);
+  if (tracked.layerOrder !== orderJson) {
+    setLayerOrder(engine, orderJson);
+    tracked.layerOrder = orderJson;
+  }
+}

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-engine tracked state used by engine-sync and its submodules.
+ *
+ * Tracked state is keyed by Engine instance via a WeakMap so it lives and
+ * dies with the engine — no module-level singleton, no HMR pollution, no
+ * test cross-talk.
+ */
+
+import type { Engine } from './wasm-bridge';
+import type { Layer } from '../types';
+import type { SparseLayerEntry } from '../app/store/types';
+import type { BrushTipData } from '../types/brush';
+
+export interface TrackedState {
+  docWidth: number;
+  docHeight: number;
+  bgColor: string;
+  viewportZoom: number;
+  viewportPanX: number;
+  viewportPanY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  layerIds: Set<string>;
+  layerVersions: Map<string, string>;
+  /** Layer reference that produced the cached descriptor. If the reference
+   *  and the effective visibility are both unchanged, the descriptor is
+   *  also unchanged and we can skip JSON.stringify entirely. */
+  layerRefs: Map<string, Layer>;
+  layerEffectiveVisible: Map<string, boolean>;
+  /** Layer ids currently known to have a mask on the engine side. Used to
+   *  decide whether a removeLayerMask call is needed — previously done by
+   *  substring-sniffing the cached descriptor JSON, which was fragile. */
+  masksOnEngine: Set<string>;
+  pixelDataVersions: Map<string, ImageData | undefined>;
+  sparseVersions: Map<string, SparseLayerEntry | undefined>;
+  layerOrder: string;
+  selectionActive: boolean;
+  selectionMask: Uint8ClampedArray | null;
+  showGrid: boolean;
+  gridSize: number;
+  showRulers: boolean;
+  brushTipData: BrushTipData | null;
+  brushAngle: number;
+  brushHasTip: boolean;
+  /** Reference equality on the active Curves object so we only re-upload
+   *  the LUT texture when the user actually edited a control point. */
+  curvesRef: unknown;
+  /** True when the engine is in "no curves" mode; null on first frame. */
+  curvesIdentity: boolean | null;
+  /** Reference equality on the active Levels object so we only re-upload
+   *  the LUT texture when the user actually edited a control point. */
+  levelsRef: unknown;
+  /** True when the engine is in "no levels" mode; null on first frame. */
+  levelsIdentity: boolean | null;
+}
+
+function createTrackedState(): TrackedState {
+  return {
+    docWidth: 0,
+    docHeight: 0,
+    bgColor: '',
+    viewportZoom: 0,
+    viewportPanX: 0,
+    viewportPanY: 0,
+    viewportWidth: 0,
+    viewportHeight: 0,
+    layerIds: new Set(),
+    layerVersions: new Map(),
+    layerRefs: new Map(),
+    layerEffectiveVisible: new Map(),
+    masksOnEngine: new Set(),
+    pixelDataVersions: new Map(),
+    sparseVersions: new Map(),
+    layerOrder: '',
+    selectionActive: false,
+    selectionMask: null,
+    showGrid: false,
+    gridSize: 0,
+    showRulers: false,
+    brushTipData: null,
+    brushAngle: 0,
+    brushHasTip: false,
+    curvesRef: null,
+    curvesIdentity: null,
+    levelsRef: null,
+    levelsIdentity: null,
+  };
+}
+
+const trackedByEngine = new WeakMap<Engine, TrackedState>();
+
+export function getTracked(engine: Engine): TrackedState {
+  let t = trackedByEngine.get(engine);
+  if (!t) {
+    t = createTrackedState();
+    trackedByEngine.set(engine, t);
+  }
+  return t;
+}
+
+export function resetTrackedState(engine: Engine): void {
+  trackedByEngine.set(engine, createTrackedState());
+}
+
+/**
+ * Mark a layer's pixel data as already synced to the GPU.
+ * Use this when uploading via a non-standard path (e.g. canvas upload)
+ * to prevent syncLayers from re-uploading stale byte data.
+ */
+export function markPixelDataSynced(engine: Engine, layerId: string, data: ImageData): void {
+  getTracked(engine).pixelDataVersions.set(layerId, data);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,22 +18,37 @@ import { finalizePendingStrokeGlobal } from './app/interactions/pending-stroke';
 import './styles/tokens.css';
 import './styles/reset.css';
 
+// Dev-only debug hooks exposed on `window` for e2e tests.
+type ReadPixelsResult = { width: number; height: number; pixels: number[] } | null;
+
+declare global {
+  interface Window {
+    __editorStore?: typeof useEditorStore;
+    __uiStore?: typeof useUIStore;
+    __toolSettingsStore?: typeof useToolSettingsStore;
+    __brushPresetStore?: typeof useToolSettingsStore;
+    __pixelData?: typeof pixelDataManager;
+    __readCompositedPixels?: () => Promise<ReadPixelsResult>;
+    __readLayerPixels?: (layerId?: string) => Promise<ReadPixelsResult>;
+  }
+}
+
 // Expose stores for e2e tests
 if (import.meta.env.DEV) {
-  (window as unknown as Record<string, unknown>).__editorStore = useEditorStore;
-  (window as unknown as Record<string, unknown>).__uiStore = useUIStore;
-  (window as unknown as Record<string, unknown>).__toolSettingsStore = useToolSettingsStore;
+  window.__editorStore = useEditorStore;
+  window.__uiStore = useUIStore;
+  window.__toolSettingsStore = useToolSettingsStore;
   // Back-compat alias — e2e tests read presets via __brushPresetStore. The
   // merged tool-settings store has the same shape for preset access.
-  (window as unknown as Record<string, unknown>).__brushPresetStore = useToolSettingsStore;
+  window.__brushPresetStore = useToolSettingsStore;
   // Pixel-data Maps used to live on the store; they live on the manager now.
   // E2e tests that read or mutate pixel state go through this singleton.
-  (window as unknown as Record<string, unknown>).__pixelData = pixelDataManager;
+  window.__pixelData = pixelDataManager;
   // Read composited pixels from the WebGL canvas by triggering a render
   // inside requestAnimationFrame and reading before buffer swap.
   // Returns screen-sized pixels (includes workspace background).
-  (window as unknown as Record<string, unknown>).__readCompositedPixels = () => {
-    return new Promise<{ width: number; height: number; pixels: number[] } | null>((resolve) => {
+  window.__readCompositedPixels = () => {
+    return new Promise<ReadPixelsResult>((resolve) => {
       requestAnimationFrame(() => {
         const engine = getEngine();
         const canvas = getEngineCanvas();
@@ -62,8 +77,8 @@ if (import.meta.env.DEV) {
   };
   // Read a single layer's GPU texture as {width, height, pixels[]}.
   // Syncs layers first so newly created layers are known to the engine.
-  (window as unknown as Record<string, unknown>).__readLayerPixels = (layerId?: string) => {
-    return new Promise<{ width: number; height: number; pixels: number[] } | null>((resolve) => {
+  window.__readLayerPixels = (layerId?: string) => {
+    return new Promise<ReadPixelsResult>((resolve) => {
       requestAnimationFrame(() => {
         const engine = getEngine();
         const canvas = getEngineCanvas();

--- a/src/panels/LayerPanel/LayerPanel.module.css
+++ b/src/panels/LayerPanel/LayerPanel.module.css
@@ -23,7 +23,10 @@
   display: flex;
   align-items: center;
   height: 36px;
-  padding: 0 var(--space-2);
+  padding-top: 0;
+  padding-right: var(--space-2);
+  padding-bottom: 0;
+  padding-left: calc(var(--layer-depth, 0) * 8px + var(--space-2));
   gap: var(--space-1);
   cursor: pointer;
   border-bottom: 1px solid var(--color-border-subtle);

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -199,7 +199,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
               ]
                 .filter(Boolean)
                 .join(' ')}
-              style={{ paddingLeft: `calc(${depth * 8}px + var(--space-2))` }}
+              style={{ '--layer-depth': depth } as React.CSSProperties}
               onClick={() => onSelectLayer(layer.id)}
             >
               {!isRootGroup(layer.id) && (

--- a/src/test/canvas-mock.ts
+++ b/src/test/canvas-mock.ts
@@ -30,6 +30,7 @@ const originalGetContext = HTMLCanvasElement.prototype.getContext;
   ...args: unknown[]
 ): RenderingContext | null {
   if (contextId === '2d') {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const canvas = this;
     return {
       canvas,

--- a/src/test/canvas-mock.ts
+++ b/src/test/canvas-mock.ts
@@ -21,10 +21,13 @@ if (typeof globalThis.ImageData === 'undefined') {
   (globalThis as Record<string, unknown>).ImageData = ImageDataPolyfill;
 }
 
-// Mock getContext('2d') for HTMLCanvasElement in jsdom
+// Mock getContext('2d') for HTMLCanvasElement in jsdom.
+// Overwriting an overloaded prototype method can't be expressed in TS without
+// a cast — so we type the mock function precisely, then cast once at the
+// assignment site to the prototype's overloaded signature.
+type GetContextFn = typeof HTMLCanvasElement.prototype.getContext;
 const originalGetContext = HTMLCanvasElement.prototype.getContext;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(HTMLCanvasElement.prototype as any).getContext = function (
+const mockGetContext = function (
   this: HTMLCanvasElement,
   contextId: string,
   ...args: unknown[]
@@ -104,3 +107,4 @@ const originalGetContext = HTMLCanvasElement.prototype.getContext;
   }
   return originalGetContext.call(this, contextId, ...args);
 };
+HTMLCanvasElement.prototype.getContext = mockGetContext as GetContextFn;

--- a/src/tools/brush/abr-parser.ts
+++ b/src/tools/brush/abr-parser.ts
@@ -26,8 +26,8 @@ export function parseABR(buffer: ArrayBuffer): AbrBrush[] {
     } else if (version === 6 || version === 7 || version === 10) {
       parseV6Plus(view, brushes);
     }
-  } catch {
-    // Return whatever was successfully parsed
+  } catch (err) {
+    console.warn('[abr-parser] aborted parsing after error; returning partial results', err);
   }
 
   return brushes;
@@ -68,8 +68,8 @@ function parseV1V2(
       if (result !== null) {
         brushes.push(result);
       }
-    } catch {
-      // Skip corrupted brush, continue with next
+    } catch (err) {
+      console.warn(`[abr-parser] skipped corrupted v${version} brush at index ${brushIndex}`, err);
     }
 
     offset = chunkEnd;
@@ -191,8 +191,8 @@ function parseV6Plus(view: DataView, brushes: AbrBrush[]): void {
     if (blockType === 'samp') {
       try {
         parseSampBlockV6(view, offset, blockEnd, brushes);
-      } catch {
-        // Continue with next block
+      } catch (err) {
+        console.warn('[abr-parser] skipped corrupted samp block', err);
       }
     }
 
@@ -232,8 +232,8 @@ function parseSampBlockV6(
       if (brush !== null) {
         brushes.push(brush);
       }
-    } catch {
-      // Skip corrupted sample
+    } catch (err) {
+      console.warn(`[abr-parser] skipped corrupted v6+ sample at index ${brushIndex}`, err);
     }
 
     offset = sampleEnd;

--- a/src/tools/pencil/pencil.ts
+++ b/src/tools/pencil/pencil.ts
@@ -17,8 +17,8 @@ export function defaultPencilSettings(): PencilSettings {
 
 export function bresenhamLine(x0: number, y0: number, x1: number, y1: number): Point[] {
   const points: Point[] = [];
-  let dx = Math.abs(x1 - x0);
-  let dy = Math.abs(y1 - y0);
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
   const sx = x0 < x1 ? 1 : -1;
   const sy = y0 < y1 ? 1 : -1;
   let err = dx - dy;


### PR DESCRIPTION
## Summary

- **ESLint + typescript-eslint**: Added flat ESLint 9 config with conservative error rules (`no-var`, `prefer-const`, `no-explicit-any`, `rules-of-hooks`). Fixed the 3 lint errors it found (pencil `let→const`, canvas-mock `no-this-alias`). Updated `check-pixel-debt.mjs` allowlist for the tool-settings-store rename.
- **`engine-sync.ts` split**: Broke the 680-line monolith into three focused modules — `sync-state.ts` (TrackedState WeakMap), `sync-layers.ts` (hot layer-diff path), and a trimmed `engine-sync.ts` (remaining sync functions). Public API unchanged.
- **Compositor index-based loop**: Replaced the per-frame `Vec<tuple>` collection in `compositor.rs` with index-based iteration. Effect descriptors are now only cloned when enabled, avoiding the wholesale `EffectsDesc.clone()` for layers without effects.
- **Canvas mock typing**: Removed `any` cast in `canvas-mock.ts`; typed `getContext` override against the prototype's overloaded signature.
- **`main.tsx` window casts**: Replaced 7 `(window as unknown as Record<string, unknown>)` casts with a proper `declare global { interface Window {...} }` block.
- **LayerPanel inline style**: Moved `paddingLeft` calculation from inline `style` prop to CSS custom property `--layer-depth`.
- **ABR parser error surfacing**: Replaced 4 silent `catch {}` blocks with `console.warn` + context.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (234 preexisting warnings)
- [x] `npm test` — 561/561 pass
- [x] `cargo test --all` — all 16 Rust tests pass
- [x] `npm run wasm:build` — clean
- [x] `npx playwright test` — 938/938 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)