### PR TITLE
feat: accessibility labels, landmarks, and roles

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { WebGL2Warning, checkWebGL2Support } from '../components/WebGL2Warning/WebGL2Warning';
 import { Toolbox } from '../toolbox/Toolbox';
 import { LayerPanel } from '../panels/LayerPanel/LayerPanel';
@@ -58,7 +58,16 @@ export function App() {
   const setActiveLayer = useEditorStore((s) => s.setActiveLayer);
 
   const documentReady = useEditorStore((s) => s.documentReady);
+  const createDocument = useEditorStore((s) => s.createDocument);
   const showEffectsDrawer = useUIStore((s) => s.showEffectsDrawer);
+
+  useEffect(() => {
+    if (documentReady) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('lighthouse')) {
+      createDocument(1080, 1080, false);
+    }
+  }, [documentReady, createDocument]);
   const visiblePanels = useUIStore((s) => s.visiblePanels);
 
   const [pointerMode, setPointerMode] = useState<PointerMode>(POINTER_IDLE);
@@ -155,7 +164,7 @@ export function App() {
       </div>
       <div className={styles.body}>
         <Toolbox />
-        <div
+        <main
           ref={containerRef}
           data-testid="canvas-container"
           className={styles.canvas}
@@ -163,11 +172,11 @@ export function App() {
           onDragOver={handleDragOver}
           onDrop={handleDrop}
         >
-          <canvas ref={canvasRef} />
-          <canvas ref={overlayCanvasRef} className={styles.overlayCanvas} />
+          <canvas ref={canvasRef} aria-label="Drawing canvas" />
+          <canvas ref={overlayCanvasRef} className={styles.overlayCanvas} aria-hidden="true" />
           <TextActionButtons containerRef={containerRef} />
           <CanvasRenderer canvasRef={canvasRef} containerRef={containerRef} overlayCanvasRef={overlayCanvasRef} />
-        </div>
+        </main>
         {contextMenu.visible && (
           <ContextMenu
             items={contextMenu.items}

--- a/src/app/MenuBar/MenuBar.tsx
+++ b/src/app/MenuBar/MenuBar.tsx
@@ -126,7 +126,7 @@ export function MenuBar() {
 
   return (
     <>
-      <div ref={barRef} className={styles.bar}>
+      <nav ref={barRef} className={styles.bar} aria-label="Application menu">
         {menus.map((menu, i) => (
           <div key={menu.label} className={styles.menuItem}>
             <button
@@ -134,28 +134,32 @@ export function MenuBar() {
               onClick={() => handleMenuClick(i)}
               onMouseEnter={() => handleMenuEnter(i)}
               type="button"
+              aria-haspopup="menu"
+              aria-expanded={openMenu === i}
             >
               {menu.label}
             </button>
             {openMenu === i && (
-              <div className={styles.dropdown}>
+              <div className={styles.dropdown} role="menu" aria-label={menu.label}>
                 {menu.items.map((item, j) =>
                   item.separator ? (
-                    <div key={j} className={styles.separator} />
+                    <div key={j} className={styles.separator} role="separator" />
                   ) : (
                     <button
                       key={j}
                       className={`${styles.dropdownItem} ${item.disabled ? styles.dropdownItemDisabled : ''}`}
                       onClick={() => handleItemClick(item)}
                       type="button"
+                      role="menuitem"
+                      aria-disabled={item.disabled}
                     >
                       <span>
                         {item.checked !== undefined && (
-                          <span className={styles.checkmark}>{item.checked ? '\u2713' : ''}</span>
+                          <span className={styles.checkmark} aria-hidden="true">{item.checked ? '\u2713' : ''}</span>
                         )}
                         {item.label}
                       </span>
-                      {item.shortcut && <span className={styles.shortcut}>{item.shortcut}</span>}
+                      {item.shortcut && <span className={styles.shortcut} aria-hidden="true">{item.shortcut}</span>}
                     </button>
                   ),
                 )}
@@ -163,8 +167,8 @@ export function MenuBar() {
             )}
           </div>
         ))}
-        <span className={styles.logo}>LOPSY</span>
-      </div>
+        <span className={styles.logo} aria-hidden="true">LOPSY</span>
+      </nav>
       {filterDef && (
         <FilterDialog
           title={filterDef.title}

--- a/src/app/OptionsBar/OptionsBar.tsx
+++ b/src/app/OptionsBar/OptionsBar.tsx
@@ -41,7 +41,7 @@ export function OptionsBar() {
   const hasTrailing = showGrid || showSeamlessPattern;
 
   return (
-    <div className={styles.bar}>
+    <div className={styles.bar} role="toolbar" aria-label={`${label} options`}>
       <span className={styles.toolName}>{label}</span>
       <div className={styles.separator} />
       <div className={styles.options}>
@@ -62,6 +62,8 @@ export function OptionsBar() {
                   ? gridStops.indexOf(gridSize)
                   : gridStops.reduce((best, s, i) =>
                       Math.abs(s - gridSize) < Math.abs(gridStops[best]! - gridSize) ? i : best, 0)}
+                aria-label="Grid size"
+                aria-valuetext={`${gridSize} pixels`}
                 onChange={(e) => setGridSize(gridStops[Number(e.target.value)]!)}
               />
               <span className={styles.gridValue}>{gridSize}px</span>

--- a/src/app/OptionsBar/tool-options/AspectRatioControl.tsx
+++ b/src/app/OptionsBar/tool-options/AspectRatioControl.tsx
@@ -20,21 +20,25 @@ export function AspectRatioControl() {
           min={1}
           step={1}
           value={aspectRatioW}
+          aria-label="Aspect ratio width"
           onChange={(e) => setAspectRatioW(Number(e.target.value))}
         />
-        <span className={styles.ratioSeparator}>:</span>
+        <span className={styles.ratioSeparator} aria-hidden="true">:</span>
         <input
           className={styles.ratioInput}
           type="number"
           min={1}
           step={1}
           value={aspectRatioH}
+          aria-label="Aspect ratio height"
           onChange={(e) => setAspectRatioH(Number(e.target.value))}
         />
         <button
           className={`${styles.lockBtn} ${aspectRatioLocked ? styles.lockBtnActive : ''}`}
           type="button"
           onClick={() => setAspectRatioLocked(!aspectRatioLocked)}
+          aria-label={aspectRatioLocked ? 'Unlock aspect ratio' : 'Lock aspect ratio'}
+          aria-pressed={aspectRatioLocked}
           title={aspectRatioLocked ? 'Unlock aspect ratio' : 'Lock aspect ratio'}
         >
           {aspectRatioLocked ? <Lock size={12} /> : <Unlock size={12} />}

--- a/src/app/OptionsBar/tool-options/BrushOptions.tsx
+++ b/src/app/OptionsBar/tool-options/BrushOptions.tsx
@@ -32,7 +32,7 @@ export function BrushOptions() {
   return (
     <>
       {activePreset && (
-        <button className={styles.tipButton} onClick={handleOpenBrushModal} title="Open brush presets">
+        <button className={styles.tipButton} onClick={handleOpenBrushModal} aria-label="Open brush presets" title="Open brush presets">
           <BrushThumbnail preset={activePreset} size={24} />
         </button>
       )}

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -13,11 +13,12 @@ export function DodgeOptions() {
 
   return (
     <>
-      <span className={styles.label}>Mode</span>
+      <label className={styles.label} id="dodge-mode-label">Mode</label>
       <select
         className={styles.select}
         value={dodgeMode}
         onChange={(e) => setDodgeMode(e.target.value as DodgeMode)}
+        aria-labelledby="dodge-mode-label"
       >
         <option value="dodge">Dodge</option>
         <option value="burn">Burn</option>

--- a/src/app/OptionsBar/tool-options/GradientOptions.tsx
+++ b/src/app/OptionsBar/tool-options/GradientOptions.tsx
@@ -26,11 +26,12 @@ export function GradientOptions() {
 
   return (
     <>
-      <span className={styles.label}>Type</span>
+      <label className={styles.label} id="gradient-type-label">Type</label>
       <select
         className={styles.select}
         value={gradientType}
         onChange={(e) => setGradientType(e.target.value as GradientType)}
+        aria-labelledby="gradient-type-label"
       >
         <option value="linear">Linear</option>
         <option value="radial">Radial</option>
@@ -42,6 +43,7 @@ export function GradientOptions() {
         className={gradientStyles.swatch}
         style={{ background: buildGradientCss(sorted) }}
         onClick={handleOpenModal}
+        aria-label="Edit gradient stops"
         title="Edit gradient stops"
         data-testid="gradient-swatch"
       />

--- a/src/app/OptionsBar/tool-options/ShapeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/ShapeOptions.tsx
@@ -79,21 +79,23 @@ export function ShapeOptions() {
 
   return (
     <>
-      <span className={styles.label}>Shape</span>
+      <label className={styles.label} id="shape-mode-label">Shape</label>
       <select
         className={styles.select}
         value={shapeMode}
         onChange={(e) => setShapeMode(e.target.value as ShapeMode)}
+        aria-labelledby="shape-mode-label"
       >
         <option value="ellipse">Ellipse</option>
         <option value="polygon">Polygon</option>
       </select>
 
-      <span className={styles.label}>Output</span>
+      <label className={styles.label} id="shape-output-label">Output</label>
       <select
         className={styles.select}
         value={shapeOutput}
         onChange={(e) => setShapeOutput(e.target.value as ShapeOutput)}
+        aria-labelledby="shape-output-label"
       >
         <option value="pixels">Pixels</option>
         <option value="path">Path</option>
@@ -101,8 +103,9 @@ export function ShapeOptions() {
 
       {shapeMode === 'polygon' && (
         <>
-          <span className={styles.label}>Sides</span>
+          <label className={styles.label} htmlFor="polygon-sides">Sides</label>
           <input
+            id="polygon-sides"
             className={styles.numberInput}
             type="number"
             min={3}
@@ -131,6 +134,7 @@ export function ShapeOptions() {
           <button
             className={styles.noColor}
             type="button"
+            aria-label="Add fill color"
             onClick={() => {
               setShapeFillColor({ r: 255, g: 255, b: 255, a: 1 });
               setOpenPopover('fill');
@@ -163,6 +167,7 @@ export function ShapeOptions() {
           <button
             className={styles.noColor}
             type="button"
+            aria-label="Add stroke color"
             onClick={() => {
               setShapeStrokeColor({ r: 0, g: 0, b: 0, a: 1 });
               setOpenPopover('stroke');

--- a/src/app/OptionsBar/tool-options/TextOptions.tsx
+++ b/src/app/OptionsBar/tool-options/TextOptions.tsx
@@ -35,11 +35,12 @@ export function TextOptions() {
   return (
     <>
       <Slider label="Size" value={textFontSize} min={1} max={500} onChange={setTextFontSize} />
-      <span className={styles.label}>Font</span>
+      <label className={styles.label} id="text-font-label">Font</label>
       <select
         className={styles.select}
         value={textFontFamily}
         onChange={(e) => setTextFontFamily(e.target.value)}
+        aria-labelledby="text-font-label"
       >
         {FONT_OPTIONS.map((font) => (
           <option key={font.value} value={font.value}>
@@ -51,6 +52,7 @@ export function TextOptions() {
         className={styles.select}
         value={textFontWeight}
         onChange={(e) => setTextFontWeight(Number(e.target.value))}
+        aria-label="Font weight"
       >
         <option value={400}>Normal</option>
         <option value={700}>Bold</option>
@@ -59,15 +61,17 @@ export function TextOptions() {
         className={styles.select}
         value={textFontStyle}
         onChange={(e) => setTextFontStyle(e.target.value as FontStyle)}
+        aria-label="Font style"
       >
         <option value="normal">Normal</option>
         <option value="italic">Italic</option>
       </select>
-      <span className={styles.label}>Align</span>
+      <label className={styles.label} id="text-align-label">Align</label>
       <select
         className={styles.select}
         value={textAlign}
         onChange={(e) => setTextAlign(e.target.value as TextAlign)}
+        aria-labelledby="text-align-label"
       >
         <option value="left">Left</option>
         <option value="center">Center</option>

--- a/src/app/OptionsBar/tool-options/TransformControls.tsx
+++ b/src/app/OptionsBar/tool-options/TransformControls.tsx
@@ -115,6 +115,9 @@ export function TransformControls() {
               key={id}
               className={`${styles.modeButton} ${currentMode === id ? styles.active : ''}`}
               onClick={() => handleModeChange(id)}
+              type="button"
+              aria-pressed={currentMode === id}
+              aria-label={`Transform mode: ${label}`}
             >
               {label}
             </button>

--- a/src/app/StatusBar/StatusBar.tsx
+++ b/src/app/StatusBar/StatusBar.tsx
@@ -13,10 +13,13 @@ export function StatusBar() {
   const cursorY = useUIStore((s) => s.cursorPosition.y);
 
   return (
-    <div className={styles.bar}>
+    <footer className={styles.bar} role="status" aria-label="Status bar">
       <span
         className={styles.item}
         onDoubleClick={() => useEditorStore.getState().setZoom(1)}
+        role="button"
+        tabIndex={0}
+        aria-label={`Zoom ${Math.round(zoom * 100)}%, double-click to reset`}
       >
         {Math.round(zoom * 100)}%
       </span>
@@ -32,6 +35,6 @@ export function StatusBar() {
       </span>
       <span className={styles.spacer} />
       <span className={styles.item}>{colorSpaceLabel}</span>
-    </div>
+    </footer>
   );
 }

--- a/src/components/AboutModal/AboutModal.tsx
+++ b/src/components/AboutModal/AboutModal.tsx
@@ -7,7 +7,7 @@ interface AboutModalProps {
 export function AboutModal({ onClose }: AboutModalProps) {
   return (
     <div className={styles.overlay} onMouseDown={onClose}>
-      <div className={styles.modal} onMouseDown={(e) => e.stopPropagation()}>
+      <div className={styles.modal} role="dialog" aria-label="About Lopsy" onMouseDown={(e) => e.stopPropagation()}>
         <div className={styles.body}>
           <h2 className={styles.title}>Lopsy</h2>
           <p className={styles.description}>
@@ -25,6 +25,7 @@ export function AboutModal({ onClose }: AboutModalProps) {
           <textarea
             className={styles.license}
             readOnly
+            aria-label="License text"
             rows={8}
             value={`"Commons Clause" License Condition v1.0\n\nThe Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.\n\nWithout limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.\n\nFor purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software.\n\nSoftware: Lopsy\nLicense: MIT\nLicensor: Seamus James\n\n---\n\nMIT License\n\nCopyright (c) 2026 Seamus James\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`}
           />

--- a/src/components/BrushModal/AngleControl.tsx
+++ b/src/components/BrushModal/AngleControl.tsx
@@ -52,6 +52,13 @@ export function AngleControl({ angle, onAngleChange }: AngleControlProps) {
         ref={svgRef}
         className={styles.circle}
         viewBox="0 0 64 64"
+        role="slider"
+        aria-label="Brush angle"
+        aria-valuemin={0}
+        aria-valuemax={360}
+        aria-valuenow={angle}
+        aria-valuetext={`${angle} degrees`}
+        tabIndex={0}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -99,7 +99,7 @@ export function BrushModal() {
 
   return (
     <div className={styles.overlay} onMouseDown={handleOverlayClick}>
-      <div className={styles.modal}>
+      <div className={styles.modal} role="dialog" aria-label="Brushes">
         <div className={styles.header}>
           <h2>Brushes</h2>
         </div>
@@ -111,6 +111,8 @@ export function BrushModal() {
                   key={preset.id}
                   className={`${styles.presetItem}${preset.id === activePresetId ? ` ${styles.presetItemActive}` : ''}`}
                   onClick={() => setActivePreset(preset.id)}
+                  aria-label={`Brush preset: ${preset.name}`}
+                  aria-pressed={preset.id === activePresetId}
                   title={preset.name}
                 >
                   <BrushThumbnail preset={preset} size={44} />
@@ -134,6 +136,7 @@ export function BrushModal() {
               type="file"
               accept=".abr"
               className={styles.hiddenInput}
+              aria-label="Import ABR brush file"
               onChange={handleFileChange}
             />
           </div>

--- a/src/components/CanvasSizeModal/CanvasSizeModal.tsx
+++ b/src/components/CanvasSizeModal/CanvasSizeModal.tsx
@@ -43,8 +43,8 @@ export function CanvasSizeModal({ onClose }: CanvasSizeModalProps) {
   ];
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label="Canvas Size" onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>Canvas Size</h2>
         </div>
@@ -85,6 +85,8 @@ export function CanvasSizeModal({ onClose }: CanvasSizeModalProps) {
                   type="button"
                   className={`${styles.anchorDot} ${anchorX === pos.x && anchorY === pos.y ? styles.anchorDotActive : ''}`}
                   onClick={() => { setAnchorX(pos.x); setAnchorY(pos.y); }}
+                  aria-label={`Anchor ${pos.x === 0 ? 'left' : pos.x === 0.5 ? 'center' : 'right'} ${pos.y === 0 ? 'top' : pos.y === 0.5 ? 'middle' : 'bottom'}`}
+                  aria-pressed={anchorX === pos.x && anchorY === pos.y}
                 />
               ))}
             </div>

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -264,17 +264,17 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
   const alphaCursorX = `${color.a * 100}%`;
 
   return (
-    <div className={styles.picker}>
-      <div ref={svContainerRef} className={styles.svArea} onMouseDown={handleSVDown}>
-        <canvas ref={svCanvasRef} />
+    <div className={styles.picker} role="group" aria-label="Color picker">
+      <div ref={svContainerRef} className={styles.svArea} onMouseDown={handleSVDown} role="slider" aria-label="Saturation and brightness" aria-valuetext={`Saturation ${Math.round(hsv.s)}%, Brightness ${Math.round(hsv.v)}%`} tabIndex={0}>
+        <canvas ref={svCanvasRef} aria-hidden="true" />
         <div className={styles.svCursor} style={{ left: svCursorX, top: svCursorY }} />
       </div>
-      <div ref={hueContainerRef} className={styles.hueBar} onMouseDown={handleHueDown}>
-        <canvas ref={hueCanvasRef} />
+      <div ref={hueContainerRef} className={styles.hueBar} onMouseDown={handleHueDown} role="slider" aria-label="Hue" aria-valuemin={0} aria-valuemax={360} aria-valuenow={Math.round(hsv.h)} tabIndex={0}>
+        <canvas ref={hueCanvasRef} aria-hidden="true" />
         <div className={styles.hueCursor} style={{ left: hueCursorX }} />
       </div>
-      <div ref={alphaContainerRef} className={styles.alphaBar} onMouseDown={handleAlphaDown}>
-        <canvas ref={alphaCanvasRef} />
+      <div ref={alphaContainerRef} className={styles.alphaBar} onMouseDown={handleAlphaDown} role="slider" aria-label="Opacity" aria-valuemin={0} aria-valuemax={100} aria-valuenow={Math.round(color.a * 100)} tabIndex={0}>
+        <canvas ref={alphaCanvasRef} aria-hidden="true" />
         <div className={styles.alphaCursor} style={{ left: alphaCursorX }} />
       </div>
     </div>

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -51,6 +51,8 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps) {
       <div
         ref={menuRef}
         className={styles.menu}
+        role="menu"
+        aria-label="Context menu"
       >
         {items.map((item, i) => {
           if (item.separator) {
@@ -61,6 +63,7 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps) {
               key={i}
               className={styles.item}
               disabled={item.disabled}
+              role="menuitem"
               onClick={() => {
                 item.action();
                 onClose();

--- a/src/components/FilterDialog/FilterDialog.tsx
+++ b/src/components/FilterDialog/FilterDialog.tsx
@@ -91,8 +91,8 @@ export function FilterDialog({ title, params, onApply, onCancel, onPreviewChange
   }, [handleApply, handleCancel]);
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label={title} onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>{title}</h2>
         </div>

--- a/src/components/FilterDialog/NoiseDialog.tsx
+++ b/src/components/FilterDialog/NoiseDialog.tsx
@@ -36,8 +36,8 @@ export function NoiseDialog({ title, onApply, onCancel }: NoiseDialogProps) {
   }, [handleApply, onCancel]);
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label={title} onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>{title}</h2>
         </div>
@@ -114,8 +114,8 @@ export function FillNoiseDialog({ title, onApply, onCancel }: FillNoiseDialogPro
   }, [handleApply, onCancel]);
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label={title} onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>{title}</h2>
         </div>

--- a/src/components/GradientEditor/GradientEditor.tsx
+++ b/src/components/GradientEditor/GradientEditor.tsx
@@ -87,6 +87,8 @@ export function GradientEditor({ stops, selectedIndex, onStopsChange, onSelectSt
         ref={barRef}
         className={styles.barContainer}
         onClick={handleBarClick}
+        role="group"
+        aria-label="Gradient bar — click to add stops"
         data-testid="gradient-bar"
       >
         <div
@@ -103,6 +105,12 @@ export function GradientEditor({ stops, selectedIndex, onStopsChange, onSelectSt
               left: `${stop.position * 100}%`,
               backgroundColor: `rgb(${stop.color.r},${stop.color.g},${stop.color.b})`,
             }}
+            role="slider"
+            aria-label={`Gradient stop ${index + 1}`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(stop.position * 100)}
+            tabIndex={0}
             onMouseDown={(e) => handleHandleMouseDown(e, index)}
             data-testid={`gradient-stop-${index}`}
           />

--- a/src/components/GradientModal/GradientModal.tsx
+++ b/src/components/GradientModal/GradientModal.tsx
@@ -55,7 +55,7 @@ export function GradientModal({ onClose }: GradientModalProps) {
 
   return (
     <div className={styles.overlay} onClick={handleOverlayClick} onKeyDown={handleKeyDown}>
-      <div className={styles.modal}>
+      <div className={styles.modal} role="dialog" aria-label="Gradient Editor">
         <div className={styles.header}>
           <h2>Gradient Editor</h2>
         </div>

--- a/src/components/ImageSizeModal/ImageSizeModal.tsx
+++ b/src/components/ImageSizeModal/ImageSizeModal.tsx
@@ -57,8 +57,8 @@ export function ImageSizeModal({ onClose }: ImageSizeModalProps) {
   const pctH = Math.round((parseInt(height, 10) || docHeight) / docHeight * 100);
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label="Image Size" onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>Image Size</h2>
         </div>

--- a/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal/KeyboardShortcutsModal.tsx
@@ -77,7 +77,7 @@ const sections: ShortcutSection[] = [
 export function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsModalProps) {
   return (
     <div className={styles.overlay} onMouseDown={onClose}>
-      <div className={styles.modal} onMouseDown={(e) => e.stopPropagation()}>
+      <div className={styles.modal} role="dialog" aria-label="Keyboard Shortcuts" onMouseDown={(e) => e.stopPropagation()}>
         <div className={styles.header}>
           <h2>Keyboard Shortcuts</h2>
         </div>

--- a/src/components/NewDocumentModal/NewDocumentModal.tsx
+++ b/src/components/NewDocumentModal/NewDocumentModal.tsx
@@ -145,8 +145,8 @@ export function NewDocumentModal({ onCreateDocument, onOpenFile, onPasteClipboar
   }, [handleCreate, onCancel]);
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modal} onKeyDown={handleKeyDown}>
+    <div className={styles.overlay} role="presentation">
+      <div className={styles.modal} role="dialog" aria-label="New Document" onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>New Document</h2>
         </div>

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -72,6 +72,7 @@ export function NumberInput({
           type="text"
           className={styles.input}
           value={isFocused ? localValue : String(value)}
+          aria-label={label ?? 'Number value'}
           onChange={(e) => setLocalValue(e.target.value)}
           onFocus={() => {
             setIsFocused(true);

--- a/src/components/ShapeSizeModal/ShapeSizeModal.tsx
+++ b/src/components/ShapeSizeModal/ShapeSizeModal.tsx
@@ -33,7 +33,7 @@ export function ShapeSizeModal({ onConfirm, onCancel }: ShapeSizeModalProps) {
 
   return (
     <div className={styles.overlay} onMouseDown={onCancel}>
-      <div className={styles.modal} onMouseDown={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
+      <div className={styles.modal} role="dialog" aria-label="Shape Size" onMouseDown={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>Shape Size</h2>
         </div>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -93,6 +93,7 @@ export function Slider({
         min={min}
         max={max}
         step={step}
+        aria-label={label ?? 'Value'}
         onChange={(e) => {
           const iv = Number(e.target.value);
           const v = scale === 'log' ? valLog(iv, min, max) : iv;
@@ -105,6 +106,7 @@ export function Slider({
             type="text"
             className={styles.valueInput}
             value={isFocused ? localValue : String(value)}
+            aria-label={label ? `${label} value` : 'Value'}
             onChange={(e) => setLocalValue(e.target.value)}
             onFocus={(e) => {
               setIsFocused(true);

--- a/src/components/StrokePathModal/StrokePathModal.tsx
+++ b/src/components/StrokePathModal/StrokePathModal.tsx
@@ -54,7 +54,7 @@ export function StrokePathModal() {
 
   return (
     <div className={styles.overlay} onMouseDown={handleCancel}>
-      <div className={styles.modal} onMouseDown={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
+      <div className={styles.modal} role="dialog" aria-label="Stroke Path" onMouseDown={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
         <div className={styles.header}>
           <h2>Stroke Path</h2>
         </div>

--- a/src/components/WebGL2Warning/WebGL2Warning.tsx
+++ b/src/components/WebGL2Warning/WebGL2Warning.tsx
@@ -78,7 +78,7 @@ export function WebGL2Warning() {
 
   return (
     <div className={styles.overlay}>
-      <div className={styles.card}>
+      <div className={styles.card} role="alert">
         <div className={styles.heading}>
           <div className={styles.icon}>
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -139,9 +139,11 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
           />
         </div>
       )}
-      <div className={styles.tabs}>
+      <div className={styles.tabs} role="tablist" aria-label="Adjustment type">
         <button
           type="button"
+          role="tab"
+          aria-selected={activeTab === 'values'}
           className={`${styles.tab} ${activeTab === 'values' ? styles.tabActive : ''}`}
           onClick={() => setActiveTab('values')}
         >
@@ -149,6 +151,8 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
         </button>
         <button
           type="button"
+          role="tab"
+          aria-selected={activeTab === 'levels'}
           className={`${styles.tab} ${activeTab === 'levels' ? styles.tabActive : ''}`}
           onClick={() => setActiveTab('levels')}
         >
@@ -156,6 +160,8 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
         </button>
         <button
           type="button"
+          role="tab"
+          aria-selected={activeTab === 'colors'}
           className={`${styles.tab} ${activeTab === 'colors' ? styles.tabActive : ''}`}
           onClick={() => setActiveTab('colors')}
         >
@@ -218,6 +224,7 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
           type="button"
           className={`${styles.iconBtn} ${!adjustmentsEnabled ? styles.iconBtnOff : ''}`}
           onClick={() => setGroupAdjustmentsEnabled(group.id, !adjustmentsEnabled)}
+          aria-label={adjustmentsEnabled ? 'Disable adjustments' : 'Enable adjustments'}
         >
           {adjustmentsEnabled ? <Eye size={14} /> : <EyeOff size={14} />}
         </button>

--- a/src/panels/ColorPanel/ColorPanel.tsx
+++ b/src/panels/ColorPanel/ColorPanel.tsx
@@ -122,7 +122,7 @@ export function ColorPanel() {
         </div>
         {!collapsed && <ColorPicker color={activeColor} onChange={handlePickerChange} />}
         {!collapsed && <div className={styles.hexRow}>
-          <span className={styles.hexLabel}>#</span>
+          <span className={styles.hexLabel} aria-hidden="true">#</span>
           <input
             className={styles.hexInput}
             value={hexInput}
@@ -130,6 +130,7 @@ export function ColorPanel() {
             onBlur={handleHexBlur}
             onKeyDown={handleHexKeyDown}
             maxLength={6}
+            aria-label="Hex color value"
           />
         </div>}
         {!collapsed && <div className={styles.sliders}>

--- a/src/panels/LayerEffectsPanel/ColorOverlayForm.tsx
+++ b/src/panels/LayerEffectsPanel/ColorOverlayForm.tsx
@@ -16,6 +16,7 @@ export function ColorOverlayForm({ overlay, onChange }: ColorOverlayFormProps) {
           type="color"
           className={styles.colorInput}
           value={colorToHex(overlay.color)}
+          aria-label="Overlay color"
           onChange={(e) => onChange({ ...overlay, color: hexToColor(e.target.value, overlay.color.a) })}
         />
       </label>

--- a/src/panels/LayerEffectsPanel/DropShadowForm.tsx
+++ b/src/panels/LayerEffectsPanel/DropShadowForm.tsx
@@ -14,10 +14,12 @@ export function DropShadowForm({ shadow, onChange }: DropShadowFormProps) {
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Color</span>
         <label className={styles.colorSwatch} style={{ backgroundColor: `rgb(${shadow.color.r}, ${shadow.color.g}, ${shadow.color.b})` }}>
+          <span className={styles.srOnly}>Shadow color</span>
           <input
             type="color"
             className={styles.colorInput}
             value={colorToHex(shadow.color)}
+            aria-label="Shadow color"
             onChange={(e) => onChange({ ...shadow, color: hexToColor(e.target.value, shadow.color.a) })}
           />
         </label>

--- a/src/panels/LayerEffectsPanel/GlowForm.tsx
+++ b/src/panels/LayerEffectsPanel/GlowForm.tsx
@@ -18,6 +18,7 @@ export function GlowForm({ glow, onChange }: GlowFormProps) {
             type="color"
             className={styles.colorInput}
             value={colorToHex(glow.color)}
+            aria-label="Glow color"
             onChange={(e) => onChange({ ...glow, color: hexToColor(e.target.value, glow.color.a) })}
           />
         </label>

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -139,11 +139,12 @@ export function LayerEffectsPanel() {
         />
       </div>
       <div className={styles.blendModeRow}>
-        <span className={styles.fieldLabel}>Blend</span>
+        <label className={styles.fieldLabel} id="blend-mode-label">Blend</label>
         <select
           className={styles.blendModeSelect}
           value={activeLayer.blendMode}
           onChange={handleBlendModeChange}
+          aria-labelledby="blend-mode-label"
         >
           {BLEND_MODE_GROUPS.map((group) => (
             <optgroup key={group.label} label={group.label}>
@@ -157,7 +158,7 @@ export function LayerEffectsPanel() {
         </select>
       </div>
       <div className={styles.split}>
-        <div className={styles.effectList}>
+        <div className={styles.effectList} role="listbox" aria-label="Layer effects">
           {EFFECT_LIST.map(({ key, label }) => {
             const isEnabled = effects?.[key]?.enabled ?? false;
             const isSelected = selectedEffect === key;
@@ -166,11 +167,14 @@ export function LayerEffectsPanel() {
                 key={key}
                 className={`${styles.effectRow} ${isSelected ? styles.effectRowSelected : ''}`}
                 onClick={() => setSelectedEffect(key)}
+                role="option"
+                aria-selected={isSelected}
               >
                 <input
                   type="checkbox"
                   className={styles.checkbox}
                   checked={isEnabled}
+                  aria-label={`Enable ${label}`}
                   onChange={() => {
                     handleToggle(key);
                     setSelectedEffect(key);

--- a/src/panels/LayerEffectsPanel/StrokeForm.tsx
+++ b/src/panels/LayerEffectsPanel/StrokeForm.tsx
@@ -18,6 +18,7 @@ export function StrokeForm({ stroke, onChange }: StrokeFormProps) {
             type="color"
             className={styles.colorInput}
             value={colorToHex(stroke.color)}
+            aria-label="Stroke color"
             onChange={(e) => onChange({ ...stroke, color: hexToColor(e.target.value, stroke.color.a) })}
           />
         </label>
@@ -37,6 +38,8 @@ export function StrokeForm({ stroke, onChange }: StrokeFormProps) {
               type="button"
               className={`${styles.positionBtn} ${stroke.position === pos ? styles.positionBtnActive : ''}`}
               onClick={() => onChange({ ...stroke, position: pos })}
+              aria-pressed={stroke.position === pos}
+              aria-label={`Stroke position: ${pos}`}
             >
               {pos}
             </button>

--- a/src/panels/LayerPanel/LayerPanel.module.css
+++ b/src/panels/LayerPanel/LayerPanel.module.css
@@ -200,6 +200,9 @@
 }
 
 .opacity {
+  appearance: none;
+  background: none;
+  border: none;
   font-size: var(--font-size-xs);
   font-family: var(--font-mono);
   color: var(--color-text-secondary);

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -206,6 +206,9 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                 <span
                   className={styles.dragHandle}
                   onPointerDown={(e) => handleGripDown(e, ri)}
+                  role="button"
+                  aria-label={`Drag to reorder ${layer.name}`}
+                  tabIndex={0}
                 >
                   <GripVertical size={12} />
                 </span>
@@ -218,6 +221,8 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                     toggleGroupCollapsed(layer.id);
                   }}
                   type="button"
+                  aria-expanded={!layer.collapsed}
+                  aria-label={`${layer.collapsed ? 'Expand' : 'Collapse'} group ${layer.name}`}
                 >
                   {layer.collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
                 </button>
@@ -236,6 +241,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                 <input
                   className={styles.nameInput}
                   value={renameValue}
+                  aria-label="Layer name"
                   onChange={(e) => setRenameValue(e.target.value)}
                   onBlur={() => {
                     if (renameValue.trim()) {
@@ -277,21 +283,24 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   }
                 }}
                 type="button"
+                aria-label={isGroupLayer(layer) ? `Group effects for ${layer.name}` : `Layer effects for ${layer.name}`}
                 title={isGroupLayer(layer) ? 'Group effects' : 'Layer effects'}
               >
                 <Sparkles size={12} />
               </button>
               {!isRootGroup(layer.id) && (
-                <span
+                <button
                   className={styles.opacity}
                   onClick={(e) => {
                     e.stopPropagation();
                     setEditingOpacityId(editingOpacityId === layer.id ? null : layer.id);
                   }}
+                  type="button"
+                  aria-label={`Opacity ${Math.round(layer.opacity * 100)}% for ${layer.name}`}
                   title="Click to adjust opacity"
                 >
                   {Math.round(layer.opacity * 100)}%
-                </span>
+                </button>
               )}
               <button
                 className={`${styles.lockBtn} ${layer.locked ? styles.lockBtnActive : ''}`}
@@ -325,6 +334,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   min={0}
                   max={100}
                   value={Math.round(layer.opacity * 100)}
+                  aria-label={`${layer.name} opacity`}
                   onPointerDown={() => useEditorStore.getState().pushHistory('Change Opacity')}
                   onChange={(e) => onUpdateOpacity(layer.id, Number(e.target.value) / 100)}
                 />
@@ -343,6 +353,9 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                     onSelectLayer(layer.id);
                     setMaskEditMode(!maskEditMode || layer.id !== activeLayerId);
                   }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Edit mask for ${layer.name}`}
                   title="Click to edit mask"
                 >
                   <MaskThumbnail layer={layer} />
@@ -355,6 +368,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                     handleConvertMaskToMarquee(layer.id);
                   }}
                   type="button"
+                  aria-label="Convert mask to selection"
                   title="Convert mask to selection"
                 >
                   <SquareDashed size={12} />
@@ -367,6 +381,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                     setMaskEditMode(false);
                   }}
                   type="button"
+                  aria-label="Delete mask"
                   title="Delete mask"
                 >
                   <X size={12} />

--- a/src/panels/PanelContainer/PanelContainer.tsx
+++ b/src/panels/PanelContainer/PanelContainer.tsx
@@ -16,14 +16,14 @@ export function PanelContainer({
   onToggle,
 }: PanelContainerProps) {
   return (
-    <div className={styles.panel}>
-      <button className={styles.header} onClick={onToggle} type="button">
-        <span className={styles.chevron}>
+    <section className={styles.panel} aria-label={title}>
+      <button className={styles.header} onClick={onToggle} type="button" aria-expanded={!collapsed} aria-label={`${title} panel`}>
+        <span className={styles.chevron} aria-hidden="true">
           {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
         </span>
         <span className={styles.title}>{title}</span>
       </button>
       <div className={styles.content}>{children}</div>
-    </div>
+    </section>
   );
 }

--- a/src/panels/PanelToolbar/PanelToolbar.tsx
+++ b/src/panels/PanelToolbar/PanelToolbar.tsx
@@ -24,7 +24,7 @@ export function PanelToolbar() {
   const togglePanel = useUIStore((s) => s.togglePanel);
 
   return (
-    <div className={styles.toolbar}>
+    <div className={styles.toolbar} role="toolbar" aria-label="Panel visibility">
       {panels.map((panel) => (
         <IconButton
           key={panel.id}

--- a/src/panels/PathsPanel/PathsPanel.tsx
+++ b/src/panels/PathsPanel/PathsPanel.tsx
@@ -42,7 +42,7 @@ export function PathsPanel() {
   return (
     <PanelContainer title="Paths" collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)}>
       <div className={styles.panel}>
-        <div className={collapsed ? styles.listCollapsed : styles.list}>
+        <div className={collapsed ? styles.listCollapsed : styles.list} role="listbox" aria-label="Paths">
           {paths.length === 0 && (
             <div className={styles.empty}>No paths</div>
           )}
@@ -56,6 +56,9 @@ export function PathsPanel() {
                 .filter(Boolean)
                 .join(' ')}
               onClick={() => handleSelect(path.id)}
+              role="option"
+              aria-selected={path.id === selectedPathId}
+              tabIndex={0}
               data-testid={`path-item-${path.id}`}
             >
               <span className={styles.name}>{path.name}</span>

--- a/src/toolbox/Toolbox.tsx
+++ b/src/toolbox/Toolbox.tsx
@@ -25,7 +25,7 @@ const ICON_SIZE = 16;
 
 function MarqueeRectIcon({ size }: { size: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
       <rect x="3" y="3" width="18" height="18" rx="1" strokeDasharray="4 3" />
     </svg>
   );
@@ -33,7 +33,7 @@ function MarqueeRectIcon({ size }: { size: number }) {
 
 function MarqueeEllipseIcon({ size }: { size: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
       <ellipse cx="12" cy="12" rx="9" ry="9" strokeDasharray="4 3" />
     </svg>
   );
@@ -42,7 +42,7 @@ function MarqueeEllipseIcon({ size }: { size: number }) {
 
 function GradientIcon({ size }: { size: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
       <defs>
         <linearGradient id="grad-icon" x1="0" y1="0" x2="1" y2="0">
           <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
@@ -101,10 +101,10 @@ export function Toolbox() {
   const setActiveTool = useUIStore((s) => s.setActiveTool);
 
   return (
-    <div className={styles.toolbox}>
+    <div className={styles.toolbox} role="toolbar" aria-label="Drawing tools">
       <div className={styles.tools}>
         {toolGroups.map((group, gi) => (
-          <div key={gi} className={styles.group}>
+          <div key={gi} className={styles.group} role="group">
             {group.map((tool) => (
               <IconButton
                 key={tool.id}


### PR DESCRIPTION
## Summary
- Comprehensive accessibility pass across 42 files — ARIA labels on all form elements (sliders, inputs, selects, checkboxes), `role="dialog"` on all modals, `role="menu"`/`role="menuitem"` on menus, `role="toolbar"` on toolbars, semantic HTML landmarks (`<main>`, `<nav>`, `<footer>`, `<section>`), `aria-expanded`/`aria-pressed`/`aria-selected` state attributes, and `aria-hidden` on decorative elements
- Canvas container changed from `<div>` to `<main>` to satisfy Lighthouse "main landmark" requirement
- Added `?lighthouse` query param that skips the new document modal and loads a 1080×1080 canvas for automated accessibility audits

## Test plan
- [ ] Run Lighthouse accessibility audit with `?lighthouse` param — verify improved score
- [ ] Screen reader test: tab through toolbox, panels, and options bar — verify all controls are announced
- [ ] Verify modals are announced as dialogs
- [ ] Verify menu bar keyboard navigation works with proper ARIA roles
- [ ] Visual regression: confirm no layout changes from `<span>` → `<button>` on layer opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)