### PR TITLE
fix: raw file extra layer + feat: spray tool

### DIFF
--- a/src/app/OptionsBar/tool-options/SprayOptions.tsx
+++ b/src/app/OptionsBar/tool-options/SprayOptions.tsx
@@ -1,0 +1,22 @@
+import { useToolSettingsStore } from '../../tool-settings-store';
+import { Slider } from '../../../components/Slider/Slider';
+
+export function SprayOptions() {
+  const spraySize = useToolSettingsStore((s) => s.spraySize);
+  const sprayDensity = useToolSettingsStore((s) => s.sprayDensity);
+  const sprayOpacity = useToolSettingsStore((s) => s.sprayOpacity);
+  const sprayHardness = useToolSettingsStore((s) => s.sprayHardness);
+  const setSpraySize = useToolSettingsStore((s) => s.setSpraySize);
+  const setSprayDensity = useToolSettingsStore((s) => s.setSprayDensity);
+  const setSprayOpacity = useToolSettingsStore((s) => s.setSprayOpacity);
+  const setSprayHardness = useToolSettingsStore((s) => s.setSprayHardness);
+
+  return (
+    <>
+      <Slider label="Size" value={spraySize} min={1} max={500} onChange={setSpraySize} />
+      <Slider label="Density" value={sprayDensity} min={1} max={100} onChange={setSprayDensity} />
+      <Slider label="Opacity" value={sprayOpacity} min={1} max={100} onChange={setSprayOpacity} />
+      <Slider label="Softness" value={sprayHardness} min={0} max={100} onChange={setSprayHardness} />
+    </>
+  );
+}

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -336,9 +336,17 @@ interface ToolSettings {
   foregroundColor: Color;
   backgroundColor: Color;
   recentColors: readonly Color[];
+  spraySize: number;
+  sprayDensity: number;
+  sprayOpacity: number;
+  sprayHardness: number;
   presets: BrushPreset[];
   activePresetId: string | null;
 
+  setSpraySize: (size: number) => void;
+  setSprayDensity: (density: number) => void;
+  setSprayOpacity: (opacity: number) => void;
+  setSprayHardness: (hardness: number) => void;
   setBrushSize: (size: number) => void;
   setBrushFade: (fade: number) => void;
   setBrushSpacing: (spacing: number) => void;
@@ -451,9 +459,17 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
   backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
   recentColors: Array.from({ length: MAX_RECENT_COLORS }, () => ({ r: 46, g: 46, b: 46, a: 1 })),
+  spraySize: 40,
+  sprayDensity: 20,
+  sprayOpacity: 60,
+  sprayHardness: 30,
   presets: BUILTIN_PRESETS,
   activePresetId: 'builtin-hard-round',
 
+  setSpraySize: (size) => set({ spraySize: Math.max(1, Math.min(500, size)) }),
+  setSprayDensity: (density) => set({ sprayDensity: Math.max(1, Math.min(100, density)) }),
+  setSprayOpacity: (opacity) => set({ sprayOpacity: Math.max(1, Math.min(100, opacity)) }),
+  setSprayHardness: (hardness) => set({ sprayHardness: Math.max(0, Math.min(100, hardness)) }),
   setBrushSize: (size) => set({ brushSize: Math.max(1, Math.min(2000, size)) }),
   setBrushFade: (fade) => set({ brushFade: Math.max(0, Math.min(2000, fade)) }),
   setBrushSpacing: (spacing) => set({ brushSpacing: Math.max(0, Math.min(200, spacing)) }),

--- a/src/io/dng.ts
+++ b/src/io/dng.ts
@@ -54,6 +54,7 @@ import { useUIStore } from '../app/ui-store';
 import { getEngine } from '../engine-wasm/engine-state';
 import { decodeAndUploadDng, initWasm } from '../engine-wasm/wasm-bridge';
 import { resetTrackedState } from '../engine-wasm/engine-sync';
+import { pixelDataManager } from '../engine/pixel-data-manager';
 import { notifyError } from '../app/notifications-store';
 import { DEFAULT_ADJUSTMENTS, type ImageAdjustments } from '../filters/image-adjustments';
 import { IDENTITY_CURVES } from '../filters/curves';
@@ -129,6 +130,11 @@ async function importDngFileInner(data: Uint8Array, name: string): Promise<void>
     store.setGroupAdjustments(rootGroupId, RAW_DEFAULT_ADJUSTMENTS);
     store.setGroupAdjustmentsEnabled(rootGroupId, true);
   }
+
+  // The DNG decoder uploaded pixels directly to the GPU texture. Clear the
+  // stale 1x1 placeholder from the JS pixel data store so that
+  // resetTrackedState doesn't cause engine-sync to overwrite the GPU texture.
+  pixelDataManager.remove(activeLayerId);
 
   resetTrackedState(engine);
   useEditorStore.getState().fitToView();

--- a/src/io/dng.ts
+++ b/src/io/dng.ts
@@ -80,7 +80,7 @@ export async function importDngFile(data: Uint8Array, name: string): Promise<voi
 async function importDngFileInner(data: Uint8Array, name: string): Promise<void> {
   await initWasm();
 
-  useEditorStore.getState().createDocument(1, 1, false);
+  useEditorStore.getState().createDocument(1, 1, true);
 
   const engine = await waitForEngine();
   if (!engine) {

--- a/src/io/dng.ts
+++ b/src/io/dng.ts
@@ -95,11 +95,12 @@ async function importDngFileInner(data: Uint8Array, name: string): Promise<void>
     return;
   }
 
-  // Yield one frame so the render loop can sync the initial document size
-  // before we take a long &mut Engine borrow for the DNG decode. Without
-  // this, the render loop fires during decode and hits a recursive borrow
-  // in wasm_bindgen's RefCell (setDocumentSize vs decodeAndUploadDng both
-  // need &mut Engine).
+  // Yield two frames: the first lets the render loop sync the initial
+  // document size (avoiding a recursive borrow in wasm_bindgen's RefCell),
+  // the second ensures the browser actually paints the loading modal before
+  // we block the main thread with the WASM decode. rAF callbacks run before
+  // paint, so a single yield would commit the DOM but never paint it.
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
   const metaJson = decodeAndUploadDng(engine, activeLayerId, data);

--- a/src/toolbox/Toolbox.tsx
+++ b/src/toolbox/Toolbox.tsx
@@ -15,6 +15,7 @@ import {
   PenTool,
   Magnet,
   Pointer,
+  SprayCan,
 } from 'lucide-react';
 import { IconButton } from '../components/IconButton/IconButton';
 import { useUIStore } from '../app/ui-store';
@@ -74,6 +75,7 @@ const toolGroups: ToolDef[][] = [
   [
     { id: 'brush', icon: <Paintbrush size={ICON_SIZE} />, label: 'Brush (B)' },
     { id: 'pencil', icon: <Pen size={ICON_SIZE} />, label: 'Pencil (N)' },
+    { id: 'spray', icon: <SprayCan size={ICON_SIZE} />, label: 'Spray (J)' },
     { id: 'eraser', icon: <Eraser size={ICON_SIZE} />, label: 'Eraser (E)' },
   ],
   [

--- a/src/tools/spray/spray-interaction.ts
+++ b/src/tools/spray/spray-interaction.ts
@@ -1,0 +1,110 @@
+import { useEditorStore } from '../../app/editor-store';
+import { useToolSettingsStore } from '../../app/tool-settings-store';
+import { getEngine } from '../../engine-wasm/engine-state';
+import { applyBrushDab as gpuBrushDab } from '../../engine-wasm/wasm-bridge';
+import { generateSprayDots } from './spray';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function emitSprayDabs(
+  engine: NonNullable<ReturnType<typeof getEngine>>,
+  layerId: string,
+  centerX: number,
+  centerY: number,
+  brushRadius: number,
+  density: number,
+  hardness: number,
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+  baseOpacity: number,
+): void {
+  const dots = generateSprayDots(centerX, centerY, brushRadius, density, baseOpacity);
+  for (const dot of dots) {
+    gpuBrushDab(engine, layerId, dot.x, dot.y, dot.radius * 2, hardness, r, g, b, a, dot.opacity, 1);
+  }
+}
+
+export function handleSprayDown(
+  ctx: InteractionContext,
+): InteractionState | undefined {
+  const { layerPos, activeLayer, activeLayerId } = ctx;
+  const toolSettings = useToolSettingsStore.getState();
+  const editorState = useEditorStore.getState();
+
+  editorState.pushHistory();
+
+  const strokeColor = toolSettings.foregroundColor;
+  const state: InteractionState = {
+    drawing: true,
+    lastPoint: layerPos,
+    pixelBuffer: null,
+    originalPixelBuffer: null,
+    layerId: activeLayerId,
+    tool: 'spray',
+    startPoint: null,
+    layerStartX: activeLayer.x,
+    layerStartY: activeLayer.y,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    strokeColor,
+  };
+
+  const engine = getEngine();
+  if (!engine) return state;
+
+  const size = toolSettings.spraySize;
+  const density = toolSettings.sprayDensity;
+  const opacity = toolSettings.sprayOpacity / 100;
+  const hardness = toolSettings.sprayHardness / 100;
+  const color = strokeColor;
+  toolSettings.addRecentColor(color);
+  const r = color.r / 255;
+  const g = color.g / 255;
+  const b = color.b / 255;
+
+  emitSprayDabs(engine, activeLayerId, layerPos.x, layerPos.y, size / 2, density, hardness, r, g, b, color.a, opacity);
+  editorState.notifyRender();
+
+  return state;
+}
+
+export function handleSprayMove(
+  ctx: InteractionContext,
+  state: InteractionState,
+): void {
+  if (!state.lastPoint || !state.layerId) return;
+
+  const toolSettings = useToolSettingsStore.getState();
+  const engine = getEngine();
+  if (!engine) return;
+
+  const layerLocalPos = ctx.layerPos;
+  const size = toolSettings.spraySize;
+  const density = toolSettings.sprayDensity;
+  const opacity = toolSettings.sprayOpacity / 100;
+  const hardness = toolSettings.sprayHardness / 100;
+  const color = state.strokeColor ?? toolSettings.foregroundColor;
+  const r = color.r / 255;
+  const g = color.g / 255;
+  const b = color.b / 255;
+  const brushRadius = size / 2;
+  const spacing = Math.max(1, size * 0.3);
+
+  const dx = layerLocalPos.x - state.lastPoint.x;
+  const dy = layerLocalPos.y - state.lastPoint.y;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+
+  if (dist < spacing) return;
+
+  const steps = Math.max(1, Math.floor(dist / spacing));
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const x = state.lastPoint.x + dx * t;
+    const y = state.lastPoint.y + dy * t;
+    emitSprayDabs(engine, state.layerId, x, y, brushRadius, density, hardness, r, g, b, color.a, opacity);
+  }
+
+  state.lastPoint = layerLocalPos;
+  useEditorStore.getState().notifyRender();
+}

--- a/src/tools/spray/spray-interaction.ts
+++ b/src/tools/spray/spray-interaction.ts
@@ -6,7 +6,7 @@ import { generateSprayDots } from './spray';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 
-const SPRAY_INTERVAL_MS = 333;
+const SPRAY_INTERVAL_MS = 166;
 
 let sprayTimer: ReturnType<typeof setInterval> | null = null;
 

--- a/src/tools/spray/spray-interaction.ts
+++ b/src/tools/spray/spray-interaction.ts
@@ -6,6 +6,17 @@ import { generateSprayDots } from './spray';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 
+const SPRAY_INTERVAL_MS = 333;
+
+let sprayTimer: ReturnType<typeof setInterval> | null = null;
+
+function clearSprayTimer(): void {
+  if (sprayTimer !== null) {
+    clearInterval(sprayTimer);
+    sprayTimer = null;
+  }
+}
+
 function emitSprayDabs(
   engine: NonNullable<ReturnType<typeof getEngine>>,
   layerId: string,
@@ -24,6 +35,26 @@ function emitSprayDabs(
   for (const dot of dots) {
     gpuBrushDab(engine, layerId, dot.x, dot.y, dot.radius * 2, hardness, r, g, b, a, dot.opacity, 1);
   }
+}
+
+function sprayAtCurrentPosition(state: InteractionState): void {
+  if (!state.lastPoint || !state.layerId) return;
+
+  const engine = getEngine();
+  if (!engine) return;
+
+  const toolSettings = useToolSettingsStore.getState();
+  const size = toolSettings.spraySize;
+  const density = toolSettings.sprayDensity;
+  const opacity = toolSettings.sprayOpacity / 100;
+  const hardness = toolSettings.sprayHardness / 100;
+  const color = state.strokeColor ?? toolSettings.foregroundColor;
+  const r = color.r / 255;
+  const g = color.g / 255;
+  const b = color.b / 255;
+
+  emitSprayDabs(engine, state.layerId, state.lastPoint.x, state.lastPoint.y, size / 2, density, hardness, r, g, b, color.a, opacity);
+  useEditorStore.getState().notifyRender();
 }
 
 export function handleSprayDown(
@@ -66,6 +97,9 @@ export function handleSprayDown(
   emitSprayDabs(engine, activeLayerId, layerPos.x, layerPos.y, size / 2, density, hardness, r, g, b, color.a, opacity);
   editorState.notifyRender();
 
+  clearSprayTimer();
+  sprayTimer = setInterval(() => sprayAtCurrentPosition(state), SPRAY_INTERVAL_MS);
+
   return state;
 }
 
@@ -95,7 +129,10 @@ export function handleSprayMove(
   const dy = layerLocalPos.y - state.lastPoint.y;
   const dist = Math.sqrt(dx * dx + dy * dy);
 
-  if (dist < spacing) return;
+  if (dist < spacing) {
+    state.lastPoint = layerLocalPos;
+    return;
+  }
 
   const steps = Math.max(1, Math.floor(dist / spacing));
   for (let i = 1; i <= steps; i++) {
@@ -107,4 +144,8 @@ export function handleSprayMove(
 
   state.lastPoint = layerLocalPos;
   useEditorStore.getState().notifyRender();
+}
+
+export function handleSprayUp(): void {
+  clearSprayTimer();
 }

--- a/src/tools/spray/spray.test.ts
+++ b/src/tools/spray/spray.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { generateSprayDots, defaultSpraySettings } from './spray';
+
+describe('generateSprayDots', () => {
+  it('returns the requested number of dots', () => {
+    const dots = generateSprayDots(100, 100, 20, 15, 0.5);
+    expect(dots).toHaveLength(15);
+  });
+
+  it('places dots within the brush radius', () => {
+    const cx = 50;
+    const cy = 50;
+    const radius = 30;
+    const dots = generateSprayDots(cx, cy, radius, 200, 0.8);
+
+    for (const dot of dots) {
+      const dx = dot.x - cx;
+      const dy = dot.y - cy;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      expect(dist).toBeLessThanOrEqual(radius + dot.radius);
+    }
+  });
+
+  it('generates dots with varying size and opacity', () => {
+    const dots = generateSprayDots(100, 100, 40, 50, 0.6);
+    const radii = new Set(dots.map((d) => d.radius));
+    const opacities = new Set(dots.map((d) => Math.round(d.opacity * 100)));
+    expect(radii.size).toBeGreaterThan(1);
+    expect(opacities.size).toBeGreaterThan(1);
+  });
+
+  it('caps opacity at 1', () => {
+    const dots = generateSprayDots(0, 0, 10, 100, 1);
+    for (const dot of dots) {
+      expect(dot.opacity).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('ensures minimum dot radius of 1', () => {
+    const dots = generateSprayDots(0, 0, 5, 50, 0.5);
+    for (const dot of dots) {
+      expect(dot.radius).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('defaultSpraySettings', () => {
+  it('returns sensible defaults', () => {
+    const settings = defaultSpraySettings();
+    expect(settings.size).toBeGreaterThan(0);
+    expect(settings.density).toBeGreaterThan(0);
+    expect(settings.opacity).toBeGreaterThan(0);
+    expect(settings.hardness).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/tools/spray/spray.ts
+++ b/src/tools/spray/spray.ts
@@ -1,0 +1,44 @@
+export interface SpraySettings {
+  readonly size: number;
+  readonly density: number;
+  readonly opacity: number;
+  readonly hardness: number;
+}
+
+export function defaultSpraySettings(): SpraySettings {
+  return { size: 40, density: 20, opacity: 60, hardness: 30 };
+}
+
+export interface SprayDot {
+  readonly x: number;
+  readonly y: number;
+  readonly radius: number;
+  readonly opacity: number;
+}
+
+export function generateSprayDots(
+  centerX: number,
+  centerY: number,
+  brushRadius: number,
+  density: number,
+  baseOpacity: number,
+): SprayDot[] {
+  const dots: SprayDot[] = [];
+  const count = Math.max(1, Math.round(density));
+  const minDotRadius = Math.max(1, brushRadius * 0.02);
+  const maxDotRadius = Math.max(2, brushRadius * 0.12);
+
+  for (let i = 0; i < count; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const dist = Math.sqrt(Math.random()) * brushRadius;
+    const x = centerX + Math.cos(angle) * dist;
+    const y = centerY + Math.sin(angle) * dist;
+    const radius = minDotRadius + Math.random() * (maxDotRadius - minDotRadius);
+    const distFalloff = 1 - (dist / brushRadius) * 0.3;
+    const opacity = baseOpacity * (0.4 + Math.random() * 0.6) * distFalloff;
+
+    dots.push({ x, y, radius: Math.round(Math.max(1, radius)), opacity: Math.min(1, opacity) });
+  }
+
+  return dots;
+}

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -15,7 +15,7 @@ import { handleCropDown, handleCropMove, handleCropUp } from './crop/crop-intera
 import { handlePathDown, handlePathMove, handlePathUp } from './path/path-interaction';
 import { handleShapeDown, handleShapeMove, handleShapeUp } from './shape/shape-interaction';
 import { handleGradientDown, handleGradientMove } from './gradient/gradient-interaction';
-import { handleSprayDown, handleSprayMove } from './spray/spray-interaction';
+import { handleSprayDown, handleSprayMove, handleSprayUp } from './spray/spray-interaction';
 
 import { MoveOptions } from '../app/OptionsBar/tool-options/MoveOptions';
 import { BrushOptions } from '../app/OptionsBar/tool-options/BrushOptions';
@@ -287,6 +287,7 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
     handler: {
       down: (ctx) => handleSprayDown(ctx),
       move: (ctx, state) => handleSprayMove(ctx, state),
+      up: () => handleSprayUp(),
     },
   },
 };

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -15,6 +15,7 @@ import { handleCropDown, handleCropMove, handleCropUp } from './crop/crop-intera
 import { handlePathDown, handlePathMove, handlePathUp } from './path/path-interaction';
 import { handleShapeDown, handleShapeMove, handleShapeUp } from './shape/shape-interaction';
 import { handleGradientDown, handleGradientMove } from './gradient/gradient-interaction';
+import { handleSprayDown, handleSprayMove } from './spray/spray-interaction';
 
 import { MoveOptions } from '../app/OptionsBar/tool-options/MoveOptions';
 import { BrushOptions } from '../app/OptionsBar/tool-options/BrushOptions';
@@ -32,6 +33,7 @@ import { PathOptions } from '../app/OptionsBar/tool-options/PathOptions';
 import { TextOptions } from '../app/OptionsBar/tool-options/TextOptions';
 import { MagneticLassoOptions } from '../app/OptionsBar/tool-options/MagneticLassoOptions';
 import { CropOptions } from '../app/OptionsBar/tool-options/CropOptions';
+import { SprayOptions } from '../app/OptionsBar/tool-options/SprayOptions';
 
 import { useToolSettingsStore } from '../app/tool-settings-store';
 
@@ -273,6 +275,18 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
       down: (ctx) => handlePathDown(ctx),
       move: (ctx, state) => handlePathMove(state, ctx.layerPos),
       up: () => handlePathUp(),
+    },
+  },
+  spray: {
+    id: 'spray',
+    label: 'Spray',
+    shortcut: 'j',
+    optionsComponent: SprayOptions,
+    isPaint: true,
+    isGpu: true,
+    handler: {
+      down: (ctx) => handleSprayDown(ctx),
+      move: (ctx, state) => handleSprayMove(ctx, state),
     },
   },
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -19,7 +19,8 @@ export type ToolId =
   | 'shape'
   | 'text'
   | 'crop'
-  | 'path';
+  | 'path'
+  | 'spray';
 
 export interface PixelSurface {
   readonly width: number;


### PR DESCRIPTION
## Summary

- **Fix**: Opening DNG/ProRAW files no longer creates an extra background layer. The `createDocument` call was using `transparentBg=false`, which creates both a Background and Layer 1 — raw imports only need one layer.
- **Feature**: New spray tool that places randomized soft dots within the brush radius. Each dot varies slightly in size and opacity for a natural spray-paint effect. Includes options for size, density, opacity, and softness. Keyboard shortcut: `J`.

## Test plan

- [ ] Open a DNG/ProRAW file — verify only one layer appears in the layers panel
- [ ] Select the spray tool from the toolbox (or press J)
- [ ] Paint on canvas — verify random dots appear within the brush area
- [ ] Adjust size, density, opacity, and softness sliders — verify they affect the output
- [ ] Verify existing brush/pencil/eraser tools still work normally
- [ ] Run `npm run test` — all unit tests pass including new spray tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)