### PR TITLE
perf(brush): scissor each dab to its bounding box

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/brush_gpu.rs
+++ b/engine-rs/crates/lopsy-wasm/src/brush_gpu.rs
@@ -168,15 +168,40 @@ pub fn apply_dab_batch(
         }
     }
 
-    // Render each dab as a separate draw call
+    // Scissor each dab to its bounding box so the fragment shader only
+    // runs on the pixels it will actually write. Without this, every dab
+    // runs the FS on the full stroke texture (e.g. 2550x3300 for a letter
+    // canvas) and discards >99.98% of invocations for a typical brush size.
+    //
+    // The bounding half-extent uses sqrt(2)/2 * size so rotated custom
+    // brush tips (whose sampled region is a rotated unit square scaled by
+    // size) fit inside. +2 px covers the smoothstep edge feather and any
+    // sub-pixel drift from the float→int conversion.
+    let tex_w_i = w as i32;
+    let tex_h_i = h as i32;
+    let half_extent = (size * 0.5 * std::f32::consts::SQRT_2).ceil() as i32 + 2;
+    gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
+
+    let u_center_loc = shader.location(gl, "u_center");
     for chunk in points.chunks(2) {
         if chunk.len() < 2 { break; }
-        if let Some(loc) = shader.location(gl, "u_center") {
-            gl.uniform2f(Some(&loc), chunk[0] as f32, chunk[1] as f32);
+        let cx = chunk[0] as f32;
+        let cy = chunk[1] as f32;
+
+        let x0 = (cx.floor() as i32 - half_extent).max(0);
+        let y0 = (cy.floor() as i32 - half_extent).max(0);
+        let x1 = (cx.ceil() as i32 + half_extent).min(tex_w_i);
+        let y1 = (cy.ceil() as i32 + half_extent).min(tex_h_i);
+        if x1 <= x0 || y1 <= y0 { continue; }
+        gl.scissor(x0, y0, x1 - x0, y1 - y0);
+
+        if let Some(loc) = &u_center_loc {
+            gl.uniform2f(Some(loc), cx, cy);
         }
         engine.draw_fullscreen_quad();
     }
 
+    gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
     gl.disable(WebGl2RenderingContext::BLEND);
     // Reset blend equation to default ADD for subsequent passes
     gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);


### PR DESCRIPTION
apply_dab_batch ran the brush fragment shader across the entire stroke
texture for every dab — on a 2550×3300 letter-sized canvas with a 40px
brush, >99.98% of fragment invocations were discarded. Compounded by
the 16-bit RGBA16F pipeline (2x memory bandwidth per fragment), this
made sustained strokes GPU-bound: move events backed up and dabs landed
with visible gaps, producing the "jagged and angular" symptom.

Enable GL_SCISSOR_TEST and set a per-dab scissor box around u_center
with a half-extent of ceil(size·sqrt(2)/2) + 2 — sized to fully contain
rotated custom brush tips (rotated unit squares scaled by size) plus
the 1px smoothstep feather. Skip dabs whose clamped box is empty so
off-texture dabs cost nothing.

Hoist the u_center uniform location lookup out of the loop while we're
here.

https://claude.ai/code/session_01W7xED6KePFSHF6AjYVniNt