### PR TITLE
perf(brush): stop per-dab full GPU readback + feed coalesced events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ engine-rs/target/
 # Playwright test artifacts
 test-results/
 engine-rs/test-output/
+tests/screenshots/

--- a/e2e/brush-perf-1080.spec.ts
+++ b/e2e/brush-perf-1080.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from './fixtures';
+import { waitForStore } from './helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function spiralPath(cx: number, cy: number, maxRadius: number, revolutions: number, numPoints: number) {
+  const pts: Array<{ x: number; y: number }> = [];
+  for (let i = 0; i < numPoints; i++) {
+    const t = i / (numPoints - 1);
+    const angle = t * revolutions * 2 * Math.PI;
+    const r = t * maxRadius;
+    pts.push({ x: Math.round(cx + Math.cos(angle) * r), y: Math.round(cy + Math.sin(angle) * r) });
+  }
+  return pts;
+}
+
+test.describe('Brush perf — 1080x1080 profile', () => {
+  test.use({ allowConsoleErrors: [/.*/] });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+  });
+
+  test('profile sustained spiral on 1080x1080', async ({ page }) => {
+    test.setTimeout(300_000);
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { createDocument: (w: number, h: number, t: boolean) => void };
+      };
+      store.getState().createDocument(1080, 1080, false);
+    });
+
+    await page.evaluate(() => {
+      const uiStore = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { setActiveTool: (t: string) => void };
+      };
+      uiStore.getState().setActiveTool('brush');
+      const toolStore = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setBrushSize: (s: number) => void; setBrushHardness: (h: number) => void };
+      };
+      toolStore.getState().setBrushSize(10);
+      toolStore.getState().setBrushHardness(80);
+    });
+
+    const container = page.locator('[data-testid="canvas-container"]');
+    const box = await container.boundingBox();
+    expect(box).not.toBeNull();
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    const maxRadius = Math.min(box!.width, box!.height) * 0.35;
+
+    const client = await page.context().newCDPSession(page);
+    await client.send('Profiler.enable');
+    await client.send('Profiler.setSamplingInterval', { interval: 200 });
+    await client.send('Profiler.start');
+
+    const durationMs = 2_000;
+    const pointsPerSecond = 60;
+    const totalPoints = Math.round((durationMs / 1000) * pointsPerSecond);
+    const points = spiralPath(cx, cy, maxRadius, 3, totalPoints);
+
+    const moveTimestamps: number[] = [];
+    const overallStart = Date.now();
+
+    await page.mouse.move(points[0]!.x, points[0]!.y);
+    await page.mouse.down();
+    const strokeStart = Date.now();
+    for (let i = 1; i < points.length; i++) {
+      await page.mouse.move(points[i]!.x, points[i]!.y);
+      moveTimestamps.push(Date.now());
+      const elapsed = Date.now() - strokeStart;
+      const targetTime = (i / points.length) * durationMs;
+      if (targetTime > elapsed) {
+        await page.waitForTimeout(Math.min(targetTime - elapsed, 4));
+      }
+    }
+    await page.mouse.up();
+
+    const totalElapsed = Date.now() - overallStart;
+
+    const { profile } = await client.send('Profiler.stop');
+    await client.send('Profiler.disable');
+    await client.detach();
+
+    interface ProfileNode {
+      id: number;
+      callFrame: { functionName: string; url: string; lineNumber: number; columnNumber: number };
+      hitCount?: number;
+      children?: number[];
+    }
+    const nodes = (profile as { nodes: ProfileNode[] }).nodes;
+    const samples = (profile as { samples: number[] }).samples;
+    const timeDeltas = (profile as { timeDeltas: number[] }).timeDeltas;
+
+    const selfTime = new Map<number, number>();
+    for (let i = 0; i < samples.length; i++) {
+      const id = samples[i]!;
+      selfTime.set(id, (selfTime.get(id) ?? 0) + (timeDeltas[i]! ?? 0));
+    }
+    const totalSampleTime = timeDeltas.reduce((a, b) => a + b, 0);
+
+    const hotNodes = nodes
+      .map((n) => ({
+        name: n.callFrame.functionName || '(anon)',
+        url: n.callFrame.url,
+        line: n.callFrame.lineNumber,
+        self: selfTime.get(n.id) ?? 0,
+      }))
+      .filter((n) => n.self > 0)
+      .sort((a, b) => b.self - a.self)
+      .slice(0, 40);
+
+    const moveDeltas: number[] = [];
+    for (let i = 1; i < moveTimestamps.length; i++) {
+      moveDeltas.push(moveTimestamps[i]! - moveTimestamps[i - 1]!);
+    }
+    moveDeltas.sort((a, b) => a - b);
+    const p50 = moveDeltas[Math.floor(moveDeltas.length * 0.5)] ?? 0;
+    const p95 = moveDeltas[Math.floor(moveDeltas.length * 0.95)] ?? 0;
+    const p99 = moveDeltas[Math.floor(moveDeltas.length * 0.99)] ?? 0;
+    const maxD = moveDeltas[moveDeltas.length - 1] ?? 0;
+
+    const dir = path.join(process.cwd(), 'tests', 'screenshots');
+    fs.mkdirSync(dir, { recursive: true });
+    const profilePath = path.join(dir, 'brush-spiral-1080.cpuprofile');
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+
+    let report = `Brush Perf — 1080x1080 spiral (${totalElapsed}ms)\n`;
+    report += `==========================================\n\n`;
+    report += `Profile sample time: ${(totalSampleTime / 1000).toFixed(1)}ms\n`;
+    report += `Move events: ${moveTimestamps.length}\n`;
+    report += `Move-to-move p50 ${p50}ms p95 ${p95}ms p99 ${p99}ms max ${maxD}ms\n\n`;
+    report += `Top 40 self-time functions:\n`;
+    for (const n of hotNodes) {
+      const pct = ((n.self / totalSampleTime) * 100).toFixed(1);
+      const short = n.url.replace(/^https?:\/\/[^/]+\//, '/').replace(/\?.*$/, '');
+      report += `  ${(n.self / 1000).toFixed(2)}ms ${pct}%  ${n.name}  ${short}:${n.line}\n`;
+    }
+
+    console.log(report);
+    fs.writeFileSync(path.join(dir, 'brush-spiral-1080-report.txt'), report);
+
+    expect(moveTimestamps.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/hooks/useCanvasPointerHandlers.ts
+++ b/src/app/hooks/useCanvasPointerHandlers.ts
@@ -317,7 +317,20 @@ export function useCanvasPointerHandlers({
         deps.setPan(deps.pointerMode.startPanX + dx, deps.pointerMode.startPanY + dy);
       } else if (isToolPointer) {
         deps.updateHoveredHandle(canvasPos);
-        deps.handleToolMove(e as unknown as React.PointerEvent);
+        // Feed every hardware sample to the tool. Browsers cap pointermove
+        // delivery at display refresh (~60 Hz) but stylus/high-polling-rate
+        // input reports at 120–240 Hz; the intermediate samples live on
+        // event.getCoalescedEvents(). Without them, brush interpolation
+        // connects coarse positions with straight lines, producing the
+        // visible polygonal segments on fast strokes.
+        const coalesced = typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
+        if (coalesced.length > 1) {
+          for (const ce of coalesced) {
+            deps.handleToolMove(ce as unknown as React.PointerEvent);
+          }
+        } else {
+          deps.handleToolMove(e as unknown as React.PointerEvent);
+        }
       } else if (toolPointerIdRef.current === null && inside) {
         deps.updateHoveredHandle(canvasPos);
       }

--- a/src/panels/LayerPanel/LayerThumbnail.tsx
+++ b/src/panels/LayerPanel/LayerThumbnail.tsx
@@ -1,15 +1,20 @@
 import { useEffect, useRef } from 'react';
-import { useEditorStore } from '../../app/editor-store';
 import { contextOptions } from '../../engine/color-space';
 import { usePixelDataVersion } from '../../engine/usePixelDataVersion';
+import { readLayerThumbnail } from '../../engine-wasm/gpu-pixel-access';
 import type { Layer } from '../../types';
 import styles from './LayerPanel.module.css';
+
+const THUMB_SIZE = 24;
 
 export function LayerThumbnail({ layer }: { layer: Layer }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
+  // Subscribe only to this layer's pixel version — bumps on actual pixel
+  // mutation (including stroke-end when clearJsPixelData() removes the
+  // JS cache). Subscribing to store-wide renderVersion here used to fire
+  // on every brush dab, triggering a full-layer glReadPixels per dab.
   const pixelVersion = usePixelDataVersion(layer.id);
-  const renderVersion = useEditorStore((s) => s.renderVersion);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -19,32 +24,33 @@ export function LayerThumbnail({ layer }: { layer: Layer }) {
       const ctx = canvas.getContext('2d', contextOptions);
       if (!ctx) return;
 
-      const thumbSize = 24;
-      canvas.width = thumbSize;
-      canvas.height = thumbSize;
+      canvas.width = THUMB_SIZE;
+      canvas.height = THUMB_SIZE;
 
-      const pixelData = useEditorStore.getState().resolvePixelData(layer.id);
-      if (!pixelData) {
-        ctx.clearRect(0, 0, thumbSize, thumbSize);
+      // GPU-downscaled readback — returns a small ImageData (at most
+      // THUMB_SIZE on the longest edge) instead of the full layer texture.
+      const thumb = readLayerThumbnail(layer.id, THUMB_SIZE);
+      if (!thumb) {
+        ctx.clearRect(0, 0, THUMB_SIZE, THUMB_SIZE);
         return;
       }
 
       const tempCanvas = document.createElement('canvas');
-      tempCanvas.width = pixelData.width;
-      tempCanvas.height = pixelData.height;
+      tempCanvas.width = thumb.width;
+      tempCanvas.height = thumb.height;
       const tempCtx = tempCanvas.getContext('2d', contextOptions);
       if (!tempCtx) return;
-      tempCtx.putImageData(pixelData, 0, 0);
+      tempCtx.putImageData(thumb, 0, 0);
 
-      ctx.clearRect(0, 0, thumbSize, thumbSize);
-      const scale = Math.min(thumbSize / pixelData.width, thumbSize / pixelData.height);
-      const w = pixelData.width * scale;
-      const h = pixelData.height * scale;
-      ctx.drawImage(tempCanvas, (thumbSize - w) / 2, (thumbSize - h) / 2, w, h);
+      ctx.clearRect(0, 0, THUMB_SIZE, THUMB_SIZE);
+      const scale = Math.min(THUMB_SIZE / thumb.width, THUMB_SIZE / thumb.height);
+      const w = thumb.width * scale;
+      const h = thumb.height * scale;
+      ctx.drawImage(tempCanvas, (THUMB_SIZE - w) / 2, (THUMB_SIZE - h) / 2, w, h);
     });
 
     return () => cancelAnimationFrame(rafId);
-  }, [layer.id, pixelVersion, renderVersion]);
+  }, [layer.id, pixelVersion]);
 
   return <canvas ref={canvasRef} className={styles.thumbnailCanvas} />;
 }


### PR DESCRIPTION
## Summary

Two independent fixes that together restore smooth brushing on large canvases. Rebased on `main` (scissor fix from #178 is already there).

**1. LayerThumbnail was doing a full-layer `glReadPixels` on every brush dab.** It subscribed to the store-wide `renderVersion` (bumped by `notifyRender()` per dab) and called `resolvePixelData()` — which falls through to a full GPU readback when the GPU owns the pixels. On a 1080×1080 layer that's ~4.6MB of synchronous readback per dab (~275MB/s pipeline stall). This dominated the CPU profile: **84% readPixels, p50 move-to-move 760ms**.

Fix: switch to the existing GPU-downscaled `readLayerThumbnail()` path and drop the `renderVersion` dep so the thumbnail only refreshes when the layer's pixel version actually changes (stroke end, undo, filters, etc.).

**2. Pointermove delivery is capped at display refresh (~60Hz)** but stylus and high-polling-rate mice report at 120–240Hz. The intermediate samples live on `event.getCoalescedEvents()`; without them, fast strokes show visible polygonal segments between coarse positions. Drain every coalesced event into `handleToolMove`.

## Profiler results (2s spiral, 1080×1080, brush size 10)

| metric | before | after |
|---|---|---|
| `readPixels` self-time | 84.4% | 2.6% |
| move-to-move p50 | 760ms | 303ms |
| CPU idle | — | 93.7% |

(Residual 303ms p50 is Playwright/CDP dispatch overhead in headless mode; CPU is idle 93%+.)

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings/errors)
- [x] `e2e/brush-perf-1080.spec.ts` passes and confirms the `readPixels` drop
- [ ] Manual: paint a fast spiral on a 1080×1080 and 4000×4000 canvas, confirm smooth curve with no polygonal segments and no dab gaps
- [ ] Manual: confirm layer thumbnails still update correctly after a stroke, undo, filter, and fill

https://claude.ai/code/session_01W7xED6KePFSHF6AjYVniNt