### PR TITLE
fix: marching ants follow rotation + thumbnail race condition

### DIFF
--- a/src/app/rendering/render-selection.ts
+++ b/src/app/rendering/render-selection.ts
@@ -14,11 +14,23 @@ export function renderSelectionAnts(
   selection: SelectionData,
   zoom: number,
   antPhase: number,
+  transform?: TransformState | null,
 ): void {
   if (!selection.active || !selection.mask) return;
 
   ctx.save();
   ctx.imageSmoothingEnabled = false;
+
+  if (transform) {
+    const ob = transform.originalBounds;
+    const cx = ob.x + ob.width / 2;
+    const cy = ob.y + ob.height / 2;
+    ctx.translate(cx + transform.translateX, cy + transform.translateY);
+    ctx.rotate(transform.rotation);
+    ctx.scale(transform.scaleX, transform.scaleY);
+    ctx.translate(-cx, -cy);
+  }
+
   const lw = 1.5 / zoom;
   ctx.lineWidth = lw;
   const dashLen = 8 / zoom;

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -103,6 +103,14 @@ function syncPixelDataToGpu(
     const rawBytes = new Uint8Array(data.data.buffer, data.data.byteOffset, data.data.byteLength);
     uploadLayerPixels(engine, layerId, rawBytes, data.width, data.height, lx, ly);
   }
+  // Bump pixel versions after GPU upload so thumbnail reads happen after
+  // data is on the GPU. The initial bump from pixelDataManager.replace()
+  // fires before the upload, causing thumbnails to read empty textures.
+  requestAnimationFrame(() => {
+    for (const layerId of pixelData.keys()) {
+      pixelDataManager.bumpVersion(layerId);
+    }
+  });
 }
 
 function createInitialDocument() {

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -159,7 +159,7 @@ function renderFrameGpu(
       renderGrid(overlayCtx, doc.width, doc.height, gridSize, viewport.zoom);
     }
 
-    renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhaseRef.current);
+    renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhaseRef.current, transform);
     renderTransformHandles(overlayCtx, selection, transform, viewport.zoom);
     const selectedPath = editorState.selectedPathId
       ? editorState.paths.find((p) => p.id === editorState.selectedPathId)

--- a/src/engine/pixel-data-manager.ts
+++ b/src/engine/pixel-data-manager.ts
@@ -133,6 +133,10 @@ export class PixelDataManager {
     };
   }
 
+  bumpVersion(layerId: string): void {
+    this.bump(layerId);
+  }
+
   private bump(layerId: string): void {
     this.layerVersions.set(layerId, (this.layerVersions.get(layerId) ?? 0) + 1);
     this.globalVersion++;


### PR DESCRIPTION
## Summary
- **Marching ants follow transform**: Selection contour ants now rotate/scale/translate with the content during transform handle interactions, instead of staying frozen at their original position
- **Thumbnail race condition**: Background layer thumbnail on new document creation now correctly shows white instead of a transparent checkerboard — fixed by deferring the pixel version bump until after the GPU upload completes

## Test plan
- [ ] Manual: draw content, cmd+click layer to select, rotate via handle — ants should follow
- [ ] Manual: create new doc with white background — Background thumbnail should show white immediately
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)