### PR TITLE
fix: correct GitHub link in new document tips

### DIFF
--- a/src/components/NewDocumentModal/NewDocumentModal.tsx
+++ b/src/components/NewDocumentModal/NewDocumentModal.tsx
@@ -35,7 +35,7 @@ const TIPS = [
   'Lopsy supports raw image formats like DNG and TIF.',
   'Load custom brushes with ABR files.',
   'New features added almost every day!',
-  'Lopsy is fully open source. Check our <a href="https://github.com/lopsy-art/lopsy" target="_blank" rel="noopener noreferrer">github</a>.',
+  'Lopsy is fully open source. Check our <a href="https://github.com/theseamusjames/lopsy.art" target="_blank" rel="noopener noreferrer">github</a>.',
 ];
 
 function toPixels(value: number, unit: Unit, dpi: number): number {


### PR DESCRIPTION
## Summary
- Fixed the GitHub URL in the new document modal tips from `github.com/lopsy-art/lopsy` to `github.com/theseamusjames/lopsy.art`

🤖 Generated with [Claude Code](https://claude.com/claude-code)