### PR TITLE
fix(filter): boost positive barrel distortion strength

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/filters/lens_distortion.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/filters/lens_distortion.glsl
@@ -20,6 +20,9 @@ bool inBounds(vec2 uv) {
 
 void main() {
     float k = u_strength;
+    if (k > 0.0) {
+        k *= 1.0 + 2.0 * k;
+    }
 
     if (abs(u_fringing) > 0.001) {
         float spread = u_fringing * 0.3;


### PR DESCRIPTION
## Summary
- Positive (barrel) lens distortion was too subtle at high strength values — the linear `k` coefficient only produced ~25% displacement at edge midpoints
- Applied a smooth quadratic boost (`k *= 1 + 2k`) for positive values, ramping effective strength to 3x at max while keeping the derivative continuous at zero (no visible jump crossing from pincushion to barrel)
- Negative (pincushion) distortion is unchanged

## Test plan
- [ ] Open the Lens Distortion filter and drag Strength slider to +100 — barrel distortion should be visibly pronounced in the center
- [ ] Verify low positive values (10–30) still look subtle and natural
- [ ] Verify negative values (pincushion) are unchanged
- [ ] Test with Chromatic Fringing enabled to confirm it still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)