### PR TITLE
fix: new document from clipboard replaces existing document

### DIFF
--- a/src/app/paste-or-open.ts
+++ b/src/app/paste-or-open.ts
@@ -14,33 +14,43 @@ import { decodeImageBlob } from './decode-image';
 export async function pasteOrOpenBlob(blob: Blob, fallbackName: string, forceNewDocument = false): Promise<void> {
   const store = useEditorStore.getState();
 
-  // Generate a layer ID up front so the WASM decoder can upload directly to it
-  const layerId = crypto.randomUUID();
-
-  const result = await decodeImageBlob(blob, layerId);
-
-  if (store.documentReady && !forceNewDocument) {
-    // Add as a new layer
+  if (forceNewDocument && store.documentReady) {
+    const bitmap = await createImageBitmap(blob);
+    const { width, height } = bitmap;
+    bitmap.close();
+    store.createDocument(width, height, true);
+    const bgLayerId = useEditorStore.getState().document.layerOrder[0];
+    if (bgLayerId) store.removeLayer(bgLayerId);
+    const layerId = crypto.randomUUID();
+    const result = await decodeImageBlob(blob, layerId);
+    if (result.gpuUploaded) {
+      store.pasteGpuLayer(layerId, result.width, result.height);
+    } else if (result.imageData) {
+      store.pasteImageData(result.imageData);
+    }
+    const doc = useEditorStore.getState().document;
+    useEditorStore.setState({
+      undoStack: [],
+      redoStack: [],
+      isDirty: false,
+      document: { ...doc, name: fallbackName },
+    });
+  } else if (store.documentReady) {
+    const layerId = crypto.randomUUID();
+    const result = await decodeImageBlob(blob, layerId);
     if (result.gpuUploaded) {
       store.pasteGpuLayer(layerId, result.width, result.height);
     } else if (result.imageData) {
       store.pasteImageData(result.imageData);
     }
   } else {
-    // No document — open as a new document
+    const layerId = crypto.randomUUID();
+    const result = await decodeImageBlob(blob, layerId);
     if (result.gpuUploaded) {
-      // WASM already uploaded pixels; create document around the existing texture.
-      // We open via openImageAsDocument with a dummy ImageData to set up the
-      // document model, then the engine-sync will pick up the already-uploaded texture.
-      // openImageAsDocument will create its own layer id and upload, but since the
-      // WASM path already put pixels on layerId, we need a different approach.
-      // Instead, use pasteGpuLayer after creating a blank document.
       store.createDocument(result.width, result.height, true);
-      // Remove the default background layer and replace with our decoded layer
       const bgLayerId = useEditorStore.getState().document.layerOrder[0];
       if (bgLayerId) store.removeLayer(bgLayerId);
       store.pasteGpuLayer(layerId, result.width, result.height);
-      // Clear undo stack and set name since this is a fresh open, not a user edit
       const doc = useEditorStore.getState().document;
       useEditorStore.setState({
         undoStack: [],

--- a/src/app/paste-or-open.ts
+++ b/src/app/paste-or-open.ts
@@ -35,6 +35,7 @@ export async function pasteOrOpenBlob(blob: Blob, fallbackName: string, forceNew
       isDirty: false,
       document: { ...doc, name: fallbackName },
     });
+    useEditorStore.getState().fitToView();
   } else if (store.documentReady) {
     const layerId = crypto.randomUUID();
     const result = await decodeImageBlob(blob, layerId);

--- a/src/app/paste-or-open.ts
+++ b/src/app/paste-or-open.ts
@@ -11,7 +11,7 @@ import { useEditorStore } from './editor-store';
 import { seedBitmapFromBlob } from '../engine/bitmap-cache';
 import { decodeImageBlob } from './decode-image';
 
-export async function pasteOrOpenBlob(blob: Blob, fallbackName: string): Promise<void> {
+export async function pasteOrOpenBlob(blob: Blob, fallbackName: string, forceNewDocument = false): Promise<void> {
   const store = useEditorStore.getState();
 
   // Generate a layer ID up front so the WASM decoder can upload directly to it
@@ -19,7 +19,7 @@ export async function pasteOrOpenBlob(blob: Blob, fallbackName: string): Promise
 
   const result = await decodeImageBlob(blob, layerId);
 
-  if (store.documentReady) {
+  if (store.documentReady && !forceNewDocument) {
     // Add as a new layer
     if (result.gpuUploaded) {
       store.pasteGpuLayer(layerId, result.width, result.height);

--- a/src/components/ModalHost/ModalHost.tsx
+++ b/src/components/ModalHost/ModalHost.tsx
@@ -56,7 +56,7 @@ export function ModalHost() {
           .catch((err) => notifyError(`Failed to import PSD: ${describeError(err)}`));
         return;
       }
-      pasteOrOpenBlob(file, name)
+      pasteOrOpenBlob(file, name, true)
         .then(() => closeModal())
         .catch((err) => notifyError(`Failed to open file: ${describeError(err)}`));
     },
@@ -65,7 +65,7 @@ export function ModalHost() {
 
   const handlePasteClipboard = useCallback(
     (blob: Blob) => {
-      pasteOrOpenBlob(blob, 'Copied File')
+      pasteOrOpenBlob(blob, 'Copied File', true)
         .then(() => closeModal())
         .catch((err) => notifyError(`Failed to paste image: ${describeError(err)}`));
     },


### PR DESCRIPTION
## Summary
- When a document was already open, **File > New > From Clipboard** pasted the clipboard as a layer on the existing canvas instead of creating a new document sized to the clipboard content
- Root cause: `pasteOrOpenBlob` checked `store.documentReady` and took the "add as layer" branch — the New Document modal never signaled that it wanted a fresh document
- Added a `forceNewDocument` flag to `pasteOrOpenBlob` and pass `true` from the ModalHost's new-document handlers (both clipboard and file open)

## Test plan
- [ ] Open a small document (e.g. 100x100), fill with a color
- [ ] Copy a large image to the system clipboard
- [ ] File > New > From Clipboard — verify the canvas resizes to the clipboard image dimensions and shows only the clipboard content
- [ ] Verify normal Cmd+V paste still adds as a layer (not a new document)
- [ ] Verify opening a file from the New Document modal also creates a new document, not a layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)