### PR TITLE
chore: update pixel-debt allowlist for pattern store and selection handlers

### DIFF
--- a/docs/pixel-data-debt.md
+++ b/docs/pixel-data-debt.md
@@ -93,6 +93,7 @@ additive/subtractive mask coverage. A proper migration wants:
 | Brush/eraser touching a JS pixel buffer                | **Debt**    |
 | Selection mask built by `selection-ops.ts`             | OK          |
 | Font rasterizer in JS (text only)                      | OK (§2)     |
+| Pattern thumbnail preview (`pattern-store.ts`)         | OK          |
 
 Anything in the **Debt** column needs a GitHub issue and a GPU
 implementation plan, or it does not land.

--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -57,7 +57,7 @@ const ALLOWLIST = {
   'src/engine/mask-utils.ts': 1,
 
   // Selection mask — explicitly OK per the policy table.
-  'src/app/interactions/selection-handlers.ts': 4,
+  'src/app/interactions/selection-handlers.ts': 6,
   'src/panels/LayerPanel/layer-selection.ts': 2,
   'src/panels/PathsPanel/path-to-selection.ts': 1,
   'src/selection/selection.ts': 4,
@@ -75,6 +75,9 @@ const ALLOWLIST = {
   // Wide-gamut ImageData plumbing — engine infrastructure.
   'src/engine/canvas-ops.ts': 1,
   'src/engine/color-space.ts': 5,
+
+  // Pattern thumbnail generation — UI preview for the patterns panel.
+  'src/app/pattern-store.ts': 2,
 
   // Brush engine scaffolding — stamps, shape data, ABR parsing.
   'src/app/tool-settings-store.ts': 7,


### PR DESCRIPTION
## Summary

`npm run lint` was failing because the pixel-debt allowlist drifted from reality after a few feature merges:

- **`src/app/pattern-store.ts`** (added in #185 Pattern Fill) generates a UI thumbnail via `Uint8ClampedArray` + `ImageData` and was never added to the allowlist (2 allocations).
- **`src/app/interactions/selection-handlers.ts`** budget was 4 but the file now has 6 — #151 (magnetic lasso) and #169 (mobile UX) added two `Uint8ClampedArray` copies of selection masks without bumping the budget.

Both are legitimate per `docs/pixel-data-debt.md`'s policy table (selection mask copies are explicitly OK; the pattern thumbnail is a small UI preview, not a render-path allocation). Bumped the budget for selection handlers, allowlisted `pattern-store.ts` with budget 2, and added a row to the policy table for the pattern thumbnail.

ESLint warnings (240) are unchanged — those are pre-existing non-null-assertion warnings, not errors.

## Test plan

- [x] `npm run lint` exits 0 (was exit 1)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ATaMd4JmyKCsPSV1MYVsfp)_