### PR TITLE
fix: remove unused variable breaking TypeScript build

### DIFF
--- a/src/app/store/actions/merge-down.ts
+++ b/src/app/store/actions/merge-down.ts
@@ -21,7 +21,6 @@ export function computeMergeDown(
   const bottomLayer = doc.layers.find((l) => l.id === belowId);
   if (!topLayer || !bottomLayer) return undefined;
 
-  let bottomRasterized = false;
   const engine = getEngine();
   if (engine) {
     if (hasEnabledEffects(topLayer.effects)) {
@@ -67,7 +66,6 @@ export function computeMergeDown(
           effects: {},
           mask: null,
         }));
-        bottomRasterized = true;
       }
     }
 


### PR DESCRIPTION
## Summary

- PR #197 introduced a `bottomRasterized` variable in `src/app/store/actions/merge-down.ts` that is declared and written to but never read, causing `TS6133: 'bottomRasterized' is declared but its value is never read` under strict mode.
- This removes both the declaration (`let bottomRasterized = false;`) and the assignment (`bottomRasterized = true;`) to fix the CI build.

## Test plan

- [x] Verified `npx tsc --noEmit` no longer reports the TS6133 error for `merge-down.ts`
- [x] No functional changes — the variable was write-only and had no effect on behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)