### PR TITLE
fix: group layer ordering and boundary reparenting

### DIFF
--- a/src/app/store/actions/move-layer.test.ts
+++ b/src/app/store/actions/move-layer.test.ts
@@ -3,6 +3,7 @@ import '../../../test/canvas-mock';
 import { describe, it, expect } from 'vitest';
 import { computeMoveLayer } from './move-layer';
 import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
+import { isGroupLayer, getDescendantIds } from '../../../layers/group-utils';
 import type { DocumentState, Layer } from '../../../types';
 
 function makeDoc(): DocumentState {
@@ -29,8 +30,37 @@ function namesByOrder(doc: DocumentState): string[] {
 }
 
 /**
+ * Verify that every group's members (the group + all descendants) form a
+ * contiguous block in layerOrder with no non-members interleaved.
+ */
+function assertGroupBlocksContiguous(doc: DocumentState): void {
+  const { layers, layerOrder } = doc;
+  for (const layer of layers) {
+    if (!isGroupLayer(layer)) continue;
+    const memberIds = new Set([layer.id, ...getDescendantIds(layers, layer.id)]);
+    const indices = layerOrder
+      .map((id, i) => (memberIds.has(id) ? i : -1))
+      .filter((i) => i !== -1);
+    if (indices.length === 0) continue;
+    const min = indices[0]!;
+    const max = indices[indices.length - 1]!;
+    for (let i = min; i <= max; i++) {
+      const id = layerOrder[i]!;
+      if (!memberIds.has(id)) {
+        const intruder = layers.find((l) => l.id === id);
+        const intruderName = intruder?.name ?? id;
+        throw new Error(
+          `Group "${layer.name}" block is not contiguous: ` +
+          `"${intruderName}" at index ${i} is not a member but sits between members`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Build a document with a group structure:
- *   layerOrder (bottom→top): [BG, L1, L2, L3, L4, G1, Root]
+ *   layerOrder (bottom->top): [BG, L1, L2, L3, L4, G1, Root]
  *   Root.children = [BG, L1, G1]
  *   G1.children = [L2, L3, L4]
  */
@@ -43,6 +73,37 @@ function makeGroupDoc(): DocumentState {
   const g1 = createGroupLayer({ name: 'G1', children: [l2.id, l3.id, l4.id] });
   const rootGroup = createGroupLayer({ name: 'Root', children: [bg.id, l1.id, g1.id] });
   const layers: Layer[] = [bg, l1, l2, l3, l4, g1, rootGroup];
+  return {
+    id: 'doc-1',
+    name: 'Test',
+    width: 50,
+    height: 50,
+    layers,
+    layerOrder: layers.map((l) => l.id),
+    activeLayerId: bg.id,
+    backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+    rootGroupId: rootGroup.id,
+  };
+}
+
+/**
+ * Build a document with two sibling groups:
+ *   layerOrder: [BG, L2, L3, G1, L4, L5, G2, L1, Root]
+ *   Root.children = [BG, G1, G2, L1]
+ *   G1.children = [L2, L3]
+ *   G2.children = [L4, L5]
+ */
+function makeTwoGroupDoc(): DocumentState {
+  const bg = createRasterLayer({ name: 'BG', width: 50, height: 50 });
+  const l1 = createRasterLayer({ name: 'L1', width: 50, height: 50 });
+  const l2 = createRasterLayer({ name: 'L2', width: 50, height: 50 });
+  const l3 = createRasterLayer({ name: 'L3', width: 50, height: 50 });
+  const l4 = createRasterLayer({ name: 'L4', width: 50, height: 50 });
+  const l5 = createRasterLayer({ name: 'L5', width: 50, height: 50 });
+  const g1 = createGroupLayer({ name: 'G1', children: [l2.id, l3.id] });
+  const g2 = createGroupLayer({ name: 'G2', children: [l4.id, l5.id] });
+  const rootGroup = createGroupLayer({ name: 'Root', children: [bg.id, g1.id, g2.id, l1.id] });
+  const layers: Layer[] = [bg, l2, l3, g1, l4, l5, g2, l1, rootGroup];
   return {
     id: 'doc-1',
     name: 'Test',
@@ -80,8 +141,6 @@ describe('computeMoveLayer', () => {
 describe('computeMoveLayer — group block moves', () => {
   it('moves a group and all its children as a block downward', () => {
     const doc = makeGroupDoc();
-    // layerOrder: [BG, L1, L2, L3, L4, G1, Root]
-    // Move G1 (index 5) to index 1 → block lands before L1
     const result = computeMoveLayer(doc, 0, 5, 1)!;
     expect(namesByOrder(result.document!)).toEqual([
       'BG', 'L2', 'L3', 'L4', 'G1', 'L1', 'Root',
@@ -97,13 +156,11 @@ describe('computeMoveLayer — group block moves', () => {
     const l4 = doc.layers[4]!;
     const g1 = doc.layers[5]!;
     const root = doc.layers[6]!;
-    // Start: [BG, L2, L3, L4, G1, L1, Root]  (group below L1)
     const reordered: DocumentState = {
       ...doc,
       layers: [bg, l2, l3, l4, g1, l1, root],
       layerOrder: [bg.id, l2.id, l3.id, l4.id, g1.id, l1.id, root.id],
     };
-    // Move G1 (index 4) to index 5 → block moves above L1
     const result = computeMoveLayer(reordered, 0, 4, 5)!;
     expect(namesByOrder(result.document!)).toEqual([
       'BG', 'L1', 'L2', 'L3', 'L4', 'G1', 'Root',
@@ -112,7 +169,6 @@ describe('computeMoveLayer — group block moves', () => {
 
   it('group block move to same position is a no-op', () => {
     const doc = makeGroupDoc();
-    // G1 at index 5, target within the block → no change
     const result = computeMoveLayer(doc, 0, 5, 4)!;
     expect(namesByOrder(result.document!)).toEqual([
       'BG', 'L1', 'L2', 'L3', 'L4', 'G1', 'Root',
@@ -144,5 +200,78 @@ describe('computeMoveLayer — group block moves', () => {
     const result = computeMoveLayer(doc, 0, 1, 0)!;
     const { layers, layerOrder } = result.document!;
     expect(layers.map((l) => l.id)).toEqual(layerOrder);
+  });
+});
+
+describe('group block contiguity invariant', () => {
+  it('holds for every possible toIndex when moving a non-group layer', () => {
+    const doc = makeGroupDoc();
+    // L1 is at index 1 (outside G1). Try moving it to every valid position.
+    // layerOrder: [BG(0), L1(1), L2(2), L3(3), L4(4), G1(5), Root(6)]
+    for (let to = 0; to < doc.layerOrder.length; to++) {
+      if (to === 1) continue; // same position → no-op in caller
+      const result = computeMoveLayer(doc, 0, 1, to);
+      if (!result) continue;
+      assertGroupBlocksContiguous(result.document!);
+    }
+  });
+
+  it('holds for every possible toIndex when moving a group', () => {
+    const doc = makeGroupDoc();
+    // G1 is at index 5. Try moving it to every valid position.
+    for (let to = 0; to < doc.layerOrder.length; to++) {
+      if (to === 5) continue;
+      const result = computeMoveLayer(doc, 0, 5, to);
+      if (!result) continue;
+      assertGroupBlocksContiguous(result.document!);
+    }
+  });
+
+  it('holds with two sibling groups — moving layer to every position', () => {
+    const doc = makeTwoGroupDoc();
+    // L1 is at index 7 (outside both groups).
+    // layerOrder: [BG(0), L2(1), L3(2), G1(3), L4(4), L5(5), G2(6), L1(7), Root(8)]
+    for (let to = 0; to < doc.layerOrder.length; to++) {
+      if (to === 7) continue;
+      const result = computeMoveLayer(doc, 0, 7, to);
+      if (!result) continue;
+      assertGroupBlocksContiguous(result.document!);
+    }
+  });
+
+  it('holds with two sibling groups — moving G1 to every position', () => {
+    const doc = makeTwoGroupDoc();
+    for (let to = 0; to < doc.layerOrder.length; to++) {
+      if (to === 3) continue;
+      const result = computeMoveLayer(doc, 0, 3, to);
+      if (!result) continue;
+      assertGroupBlocksContiguous(result.document!);
+    }
+  });
+
+  it('holds with two sibling groups — moving G2 to every position', () => {
+    const doc = makeTwoGroupDoc();
+    for (let to = 0; to < doc.layerOrder.length; to++) {
+      if (to === 6) continue;
+      const result = computeMoveLayer(doc, 0, 6, to);
+      if (!result) continue;
+      assertGroupBlocksContiguous(result.document!);
+    }
+  });
+
+  it('holds after successive moves', () => {
+    let doc = makeGroupDoc();
+    // Move L1 into G1, then move it back out, then move BG around
+    const r1 = computeMoveLayer(doc, 0, 1, 3)!;
+    doc = r1.document!;
+    assertGroupBlocksContiguous(doc);
+
+    const r2 = computeMoveLayer(doc, 0, 3, 0)!;
+    doc = r2.document!;
+    assertGroupBlocksContiguous(doc);
+
+    const r3 = computeMoveLayer(doc, 0, 0, 4)!;
+    doc = r3.document!;
+    assertGroupBlocksContiguous(doc);
   });
 });

--- a/src/app/store/actions/move-layer.test.ts
+++ b/src/app/store/actions/move-layer.test.ts
@@ -2,8 +2,8 @@
 import '../../../test/canvas-mock';
 import { describe, it, expect } from 'vitest';
 import { computeMoveLayer } from './move-layer';
-import { createRasterLayer } from '../../../layers/layer-model';
-import type { DocumentState } from '../../../types';
+import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
+import type { DocumentState, Layer } from '../../../types';
 
 function makeDoc(): DocumentState {
   const layers = [
@@ -20,6 +20,39 @@ function makeDoc(): DocumentState {
     layerOrder: layers.map((l) => l.id),
     activeLayerId: layers[0]!.id,
     backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+  };
+}
+
+function namesByOrder(doc: DocumentState): string[] {
+  const map = new Map(doc.layers.map((l) => [l.id, l]));
+  return doc.layerOrder.map((id) => map.get(id)!.name);
+}
+
+/**
+ * Build a document with a group structure:
+ *   layerOrder (bottom→top): [BG, L1, L2, L3, L4, G1, Root]
+ *   Root.children = [BG, L1, G1]
+ *   G1.children = [L2, L3, L4]
+ */
+function makeGroupDoc(): DocumentState {
+  const bg = createRasterLayer({ name: 'BG', width: 50, height: 50 });
+  const l1 = createRasterLayer({ name: 'L1', width: 50, height: 50 });
+  const l2 = createRasterLayer({ name: 'L2', width: 50, height: 50 });
+  const l3 = createRasterLayer({ name: 'L3', width: 50, height: 50 });
+  const l4 = createRasterLayer({ name: 'L4', width: 50, height: 50 });
+  const g1 = createGroupLayer({ name: 'G1', children: [l2.id, l3.id, l4.id] });
+  const rootGroup = createGroupLayer({ name: 'Root', children: [bg.id, l1.id, g1.id] });
+  const layers: Layer[] = [bg, l1, l2, l3, l4, g1, rootGroup];
+  return {
+    id: 'doc-1',
+    name: 'Test',
+    width: 50,
+    height: 50,
+    layers,
+    layerOrder: layers.map((l) => l.id),
+    activeLayerId: bg.id,
+    backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+    rootGroupId: rootGroup.id,
   };
 }
 
@@ -41,5 +74,75 @@ describe('computeMoveLayer', () => {
     const doc = makeDoc();
     const result = computeMoveLayer(doc, 5, 0, 1)!;
     expect(result.renderVersion).toBe(6);
+  });
+});
+
+describe('computeMoveLayer — group block moves', () => {
+  it('moves a group and all its children as a block downward', () => {
+    const doc = makeGroupDoc();
+    // layerOrder: [BG, L1, L2, L3, L4, G1, Root]
+    // Move G1 (index 5) to index 1 → block lands before L1
+    const result = computeMoveLayer(doc, 0, 5, 1)!;
+    expect(namesByOrder(result.document!)).toEqual([
+      'BG', 'L2', 'L3', 'L4', 'G1', 'L1', 'Root',
+    ]);
+  });
+
+  it('moves a group and all its children as a block upward', () => {
+    const doc = makeGroupDoc();
+    const bg = doc.layers[0]!;
+    const l1 = doc.layers[1]!;
+    const l2 = doc.layers[2]!;
+    const l3 = doc.layers[3]!;
+    const l4 = doc.layers[4]!;
+    const g1 = doc.layers[5]!;
+    const root = doc.layers[6]!;
+    // Start: [BG, L2, L3, L4, G1, L1, Root]  (group below L1)
+    const reordered: DocumentState = {
+      ...doc,
+      layers: [bg, l2, l3, l4, g1, l1, root],
+      layerOrder: [bg.id, l2.id, l3.id, l4.id, g1.id, l1.id, root.id],
+    };
+    // Move G1 (index 4) to index 5 → block moves above L1
+    const result = computeMoveLayer(reordered, 0, 4, 5)!;
+    expect(namesByOrder(result.document!)).toEqual([
+      'BG', 'L1', 'L2', 'L3', 'L4', 'G1', 'Root',
+    ]);
+  });
+
+  it('group block move to same position is a no-op', () => {
+    const doc = makeGroupDoc();
+    // G1 at index 5, target within the block → no change
+    const result = computeMoveLayer(doc, 0, 5, 4)!;
+    expect(namesByOrder(result.document!)).toEqual([
+      'BG', 'L1', 'L2', 'L3', 'L4', 'G1', 'Root',
+    ]);
+  });
+
+  it('preserves children order within the group block', () => {
+    const doc = makeGroupDoc();
+    const result = computeMoveLayer(doc, 0, 5, 0)!;
+    const order = namesByOrder(result.document!);
+    const g1Idx = order.indexOf('G1');
+    const l2Idx = order.indexOf('L2');
+    const l3Idx = order.indexOf('L3');
+    const l4Idx = order.indexOf('L4');
+    expect(l2Idx).toBeLessThan(l3Idx);
+    expect(l3Idx).toBeLessThan(l4Idx);
+    expect(l4Idx).toBeLessThan(g1Idx);
+  });
+
+  it('keeps layers array in sync with layerOrder after group move', () => {
+    const doc = makeGroupDoc();
+    const result = computeMoveLayer(doc, 0, 5, 1)!;
+    const { layers, layerOrder } = result.document!;
+    expect(layers.map((l) => l.id)).toEqual(layerOrder);
+  });
+
+  it('keeps layers array in sync with layerOrder after single move', () => {
+    const doc = makeGroupDoc();
+    const result = computeMoveLayer(doc, 0, 1, 0)!;
+    const { layers, layerOrder } = result.document!;
+    expect(layers.map((l) => l.id)).toEqual(layerOrder);
   });
 });

--- a/src/app/store/actions/move-layer.ts
+++ b/src/app/store/actions/move-layer.ts
@@ -44,6 +44,21 @@ export function computeMoveLayer(
       insertAt = restEntries.length;
     }
 
+    // Ensure we don't insert inside a sibling group's block.
+    // Find the moved group's parent, then check if both neighbors at the
+    // insertion point belong to the same sibling group — if so, skip past it.
+    if (insertAt > 0 && insertAt < restEntries.length) {
+      const movedParentId = findParentGroup(doc.layers, movedId)?.id;
+      const prevSibling = findContainingSiblingGroup(doc.layers, restEntries[insertAt - 1]!, movedParentId);
+      const nextSibling = findContainingSiblingGroup(doc.layers, restEntries[insertAt]!, movedParentId);
+      if (prevSibling && nextSibling && prevSibling === nextSibling) {
+        const foreignIds = new Set([prevSibling, ...getDescendantIds(doc.layers, prevSibling)]);
+        while (insertAt < restEntries.length && foreignIds.has(restEntries[insertAt]!)) {
+          insertAt++;
+        }
+      }
+    }
+
     restEntries.splice(insertAt, 0, ...blockEntries);
     const newLayers = restEntries.map((id) => layerMap.get(id)!);
 
@@ -79,4 +94,28 @@ export function computeMoveLayer(
     document: { ...doc, layers: newLayers, layerOrder: order },
     renderVersion: renderVersion + 1,
   };
+}
+
+import type { Layer } from '../../../types/layers';
+
+/**
+ * Walk up from layerId to find which sibling group (a group that is a direct
+ * child of parentGroupId) contains it. Returns the sibling group's ID, or
+ * null if layerId is a direct non-group child of parentGroupId.
+ */
+function findContainingSiblingGroup(
+  layers: readonly Layer[],
+  layerId: string,
+  parentGroupId: string | undefined,
+): string | null {
+  let current = layerId;
+  for (;;) {
+    const parent = findParentGroup(layers, current);
+    if (!parent) return null;
+    if (parent.id === parentGroupId) {
+      const layer = layers.find((l) => l.id === current);
+      return layer && isGroupLayer(layer) ? current : null;
+    }
+    current = parent.id;
+  }
 }

--- a/src/app/store/actions/move-layer.ts
+++ b/src/app/store/actions/move-layer.ts
@@ -1,6 +1,6 @@
 import type { DocumentState } from '../../../types';
 import type { ActionResult } from '../types';
-import { findParentGroup, removeFromParentGroup, addToGroup, isGroupLayer } from '../../../layers/group-utils';
+import { findParentGroup, removeFromParentGroup, addToGroup, isGroupLayer, getDescendantIds } from '../../../layers/group-utils';
 
 export function computeMoveLayer(
   doc: DocumentState,
@@ -8,21 +8,63 @@ export function computeMoveLayer(
   fromIndex: number,
   toIndex: number,
 ): ActionResult | undefined {
-  let layers = [...doc.layers];
   const order = [...doc.layerOrder];
-  const [movedLayer] = layers.splice(fromIndex, 1);
-  const [movedOrder] = order.splice(fromIndex, 1);
-  if (movedLayer === undefined || movedOrder === undefined) return undefined;
-  layers.splice(toIndex, 0, movedLayer);
-  order.splice(toIndex, 0, movedOrder);
+  const movedId = order[fromIndex];
+  if (!movedId) return undefined;
+
+  const layerMap = new Map(doc.layers.map((l) => [l.id, l]));
+  const movedLayer = layerMap.get(movedId);
+  if (!movedLayer) return undefined;
+
+  if (isGroupLayer(movedLayer)) {
+    const descendantIds = new Set(getDescendantIds(doc.layers, movedId));
+    const blockIds = new Set([movedId, ...descendantIds]);
+
+    const blockEntries: string[] = [];
+    const restEntries: string[] = [];
+    for (const id of order) {
+      (blockIds.has(id) ? blockEntries : restEntries).push(id);
+    }
+
+    const orderWithoutMoved = order.filter((id) => id !== movedId);
+    let anchorId: string | undefined;
+    for (let i = toIndex; i < orderWithoutMoved.length; i++) {
+      const candidate = orderWithoutMoved[i];
+      if (candidate !== undefined && !blockIds.has(candidate)) {
+        anchorId = candidate;
+        break;
+      }
+    }
+
+    let insertAt: number;
+    if (anchorId) {
+      const idx = restEntries.indexOf(anchorId);
+      insertAt = idx !== -1 ? idx : restEntries.length;
+    } else {
+      insertAt = restEntries.length;
+    }
+
+    restEntries.splice(insertAt, 0, ...blockEntries);
+    const newLayers = restEntries.map((id) => layerMap.get(id)!);
+
+    return {
+      document: { ...doc, layers: newLayers, layerOrder: restEntries },
+      renderVersion: renderVersion + 1,
+    };
+  }
+
+  // Single item move
+  order.splice(fromIndex, 1);
+  order.splice(toIndex, 0, movedId);
 
   // After the flat reorder, check if the layer's neighbor has a different
   // parent group. If so, re-parent the moved layer to match its new neighbor.
-  const movedId = movedLayer.id;
+  let layers = [...doc.layers];
   const currentParent = findParentGroup(layers, movedId);
   const neighborIdx = toIndex > 0 ? toIndex - 1 : toIndex + 1;
-  const neighbor = layers[neighborIdx];
-  if (neighbor && !isGroupLayer(movedLayer)) {
+  const neighborId = order[neighborIdx];
+  const neighbor = neighborId ? layerMap.get(neighborId) : undefined;
+  if (neighbor) {
     const neighborParent = findParentGroup(layers, neighbor.id);
     if (neighborParent && currentParent && neighborParent.id !== currentParent.id) {
       layers = removeFromParentGroup(layers, movedId);
@@ -30,8 +72,11 @@ export function computeMoveLayer(
     }
   }
 
+  const updatedMap = new Map(layers.map((l) => [l.id, l]));
+  const newLayers = order.map((id) => updatedMap.get(id)!);
+
   return {
-    document: { ...doc, layers, layerOrder: order },
+    document: { ...doc, layers: newLayers, layerOrder: order },
     renderVersion: renderVersion + 1,
   };
 }

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -2,7 +2,7 @@ import type { BlendMode, LayerEffects, Layer, Rect } from '../../types';
 import type { AlignEdge } from '../../tools/move/move';
 import { createRasterLayer, createGroupLayer } from '../../layers/layer-model';
 import { createImageData } from '../../engine/color-space';
-import { moveLayerToGroup as moveLayerToGroupUtil, getInsertionGroupId, getInsertionOrderIndex, addToGroup as addToGroupUtil } from '../../layers/group-utils';
+import { moveLayerToGroup as moveLayerToGroupUtil, getInsertionGroupId, getInsertionOrderIndex, addToGroup as addToGroupUtil, getDescendantIds as getDescendantIdsUtil } from '../../layers/group-utils';
 import { sparseToImageData } from '../../engine/canvas-ops';
 import { readLayerAsImageData } from '../../engine-wasm/gpu-pixel-access';
 import { getEngine, clearEngine } from '../../engine-wasm/engine-state';
@@ -293,14 +293,24 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
   moveLayerToGroup: (layerId, targetGroupId, insertIndex) => {
     const doc = get().document;
     const newLayers = moveLayerToGroupUtil(doc.layers, layerId, targetGroupId, insertIndex);
-    // Reposition in layerOrder: place just before the target group
-    // so the layer renders within the group's range
-    const newOrder = doc.layerOrder.filter((id) => id !== layerId);
+
+    // Collect all IDs to reposition (the layer + descendants if it's a group)
+    const movedLayer = doc.layers.find((l) => l.id === layerId);
+    const idsToMove = new Set([layerId]);
+    if (movedLayer && movedLayer.type === 'group') {
+      for (const id of getDescendantIdsUtil(doc.layers, layerId)) {
+        idsToMove.add(id);
+      }
+    }
+
+    // Preserve relative order of moved entries
+    const movedEntries = doc.layerOrder.filter((id) => idsToMove.has(id));
+    const newOrder = doc.layerOrder.filter((id) => !idsToMove.has(id));
     const groupIdx = newOrder.indexOf(targetGroupId);
     if (groupIdx !== -1) {
-      newOrder.splice(groupIdx, 0, layerId);
+      newOrder.splice(groupIdx, 0, ...movedEntries);
     } else {
-      newOrder.push(layerId);
+      newOrder.push(...movedEntries);
     }
     set({ document: { ...doc, layers: newLayers, layerOrder: newOrder } });
   },

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -137,8 +137,10 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
       const { from, gap } = drag;
       if (gap === from || gap === from + 1) return;
 
-      // Determine the target parent group from the gap position.
-      const neighborIdx = gap > 0 ? gap - 1 : 0;
+      // Use the item BELOW the gap to determine which group the drop
+      // position belongs to. This prevents layers from being pulled into
+      // a group when dropped at its lower boundary.
+      const neighborIdx = gap < displayList.length ? gap : gap - 1;
       const neighbor = displayList[neighborIdx];
       const draggedParent = findParentGroup(layers, draggedLayer.id);
 


### PR DESCRIPTION
## Summary

- **Group block moves**: Moving a group now moves all its descendants as a unit. Previously only the group entry moved in `layerOrder`, orphaning children at their old positions (the "layer falls out of group" bug).
- **Boundary reparenting**: Dropping a layer at a group's lower boundary no longer pulls it into the group. The gap-based drop handler now checks the item *below* the gap to determine group membership, instead of above.
- **Array sync**: `computeMoveLayer` now uses `layerOrder` for index operations and rebuilds `layers` to match, fixing a latent bug where the two arrays could diverge in ordering after `computeAddLayer`.
- `moveLayerToGroup` in the store also handles group descendants when reparenting a group into another group.

## Test plan

- [x] Unit tests: 6 new tests for group block moves (downward, upward, no-op, child order preservation, layers/layerOrder sync)
- [ ] Manual: new doc → create group → add layer outside group → add 3 layers to group → drag group below outside layer → verify all children move with the group
- [ ] Manual: drag a layer near a group boundary → verify it doesn't get pulled into the group unexpectedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)