### PR TITLE
fix(gradient): commit active transform before dispatching to other tools

### DIFF
--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -10,6 +10,7 @@ import {
   applyBrushDabBatch as gpuBrushDabBatch,
   uploadLayerPixels,
   getLayerTextureDimensions,
+  setSelectionMask,
 } from '../engine-wasm/wasm-bridge';
 import { flushLayerSync, resetTrackedState, syncDocumentSize, syncSelection } from '../engine-wasm/engine-sync';
 import { uploadCompressed } from '../engine-wasm/gpu-pixel-access';
@@ -27,6 +28,7 @@ import type {
 } from './interactions/interaction-types';
 import { handleTransformDown } from './interactions/transform-handlers';
 import { handleNudgeMove } from './interactions/move-handlers';
+import { selectLayerAlpha } from '../panels/LayerPanel/layer-selection';
 import { createTransformState } from '../tools/transform/transform';
 import { toolHandlers, handleTransformMove } from './interactions/tool-router';
 // PAINT_TOOLS / GPU_TOOLS are derived from the tool registry, so adding a
@@ -261,6 +263,21 @@ export function useCanvasInteraction(
       if (transformResult) {
         stateRef.current = transformResult;
         return;
+      }
+
+      // Commit any active GPU float (from transform or move) before dispatching
+      // to other tools. Without this, tools like gradient read the stale
+      // pre-transform selection mask from the GPU.
+      // Move handles this itself in handleMoveDown.
+      if (activeTool !== 'move' && engine && hasFloat(engine)) {
+        persistentTransformRef.current = null;
+        floatingSelectionRef.current = null;
+        selectLayerAlpha(activeLayerId);
+        const selAfter = useEditorStore.getState().selection;
+        if (selAfter.active && selAfter.mask) {
+          const maskBytes = new Uint8Array(selAfter.mask.buffer, selAfter.mask.byteOffset, selAfter.mask.byteLength);
+          setSelectionMask(engine, maskBytes, selAfter.maskWidth, selAfter.maskHeight);
+        }
       }
 
       const handler = toolHandlers[activeTool];


### PR DESCRIPTION
## Summary
- When a selection was rotated (e.g. marquee around an oval, rotate 45° with move tool) and then the user switched to gradient, the gradient filled the old pre-rotation bounding box instead of the rotated selection shape
- The GPU float from the rotation was never committed when switching tools, so the selection mask on the GPU remained stale
- Now in `handleToolDown`, any active GPU float is committed (drop float → rebuild selection mask from pixel alpha → sync mask to GPU) before dispatching to the new tool

## Test plan
- [ ] New doc → shape tool draw 16:9 oval → marquee around oval → move tool → rotate 45° → gradient tool → gradient across oval → verify gradient fills the rotated selection shape, not the old axis-aligned rectangle
- [ ] Same flow but with a simple move (translate, no rotation) before switching to gradient — verify gradient respects the moved selection
- [ ] Rotate selection → switch to brush → paint — verify brush is constrained to the rotated selection shape
- [ ] Rotate selection → switch back to move tool → drag — verify move still works correctly (move handles commit itself)


🤖 Generated with [Claude Code](https://claude.com/claude-code)