### PR TITLE
fix(e2e): add labels to effects panel sliders

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -354,9 +354,10 @@ export async function setBlendMode(page: Page, mode: string): Promise<void> {
 
 export async function setLayerOpacity(page: Page, layerId: string, percent: number): Promise<void> {
   const row = page.locator(`[data-layer-id="${layerId}"]`);
-  await row.locator('button[class*="opacityBtn"]').click();
+  await row.locator('button[aria-label*="Opacity"][aria-label*="for"]').click();
   const slider = page.locator(`[aria-label*="opacity"][type="range"]`);
   await slider.fill(String(percent));
+  await page.keyboard.press('Escape');
 }
 
 export async function applyFilter(

--- a/src/panels/LayerEffectsPanel/DropShadowForm.tsx
+++ b/src/panels/LayerEffectsPanel/DropShadowForm.tsx
@@ -27,31 +27,32 @@ export function DropShadowForm({ shadow, onChange, onCommit }: DropShadowFormPro
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Offset X</span>
         <div className={styles.sliderWrap}>
-          <Slider value={shadow.offsetX} min={-100} max={100} onChange={(v) => onChange({ ...shadow, offsetX: v })} onCommit={onCommit} />
+          <Slider label="Offset X" value={shadow.offsetX} min={-100} max={100} onChange={(v) => onChange({ ...shadow, offsetX: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Offset Y</span>
         <div className={styles.sliderWrap}>
-          <Slider value={shadow.offsetY} min={-100} max={100} onChange={(v) => onChange({ ...shadow, offsetY: v })} onCommit={onCommit} />
+          <Slider label="Offset Y" value={shadow.offsetY} min={-100} max={100} onChange={(v) => onChange({ ...shadow, offsetY: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Blur</span>
         <div className={styles.sliderWrap}>
-          <Slider value={shadow.blur} min={0} max={100} onChange={(v) => onChange({ ...shadow, blur: v })} onCommit={onCommit} />
+          <Slider label="Blur" value={shadow.blur} min={0} max={100} onChange={(v) => onChange({ ...shadow, blur: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Spread</span>
         <div className={styles.sliderWrap}>
-          <Slider value={shadow.spread} min={0} max={100} onChange={(v) => onChange({ ...shadow, spread: v })} onCommit={onCommit} />
+          <Slider label="Spread" value={shadow.spread} min={0} max={100} onChange={(v) => onChange({ ...shadow, spread: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Opacity</span>
         <div className={styles.sliderWrap}>
           <Slider
+            label="Opacity"
             value={Math.round((shadow.opacity ?? 0.75) * 100)}
             min={0}
             max={100}

--- a/src/panels/LayerEffectsPanel/GlowForm.tsx
+++ b/src/panels/LayerEffectsPanel/GlowForm.tsx
@@ -27,19 +27,20 @@ export function GlowForm({ glow, onChange, onCommit }: GlowFormProps) {
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Size</span>
         <div className={styles.sliderWrap}>
-          <Slider value={glow.size} min={0} max={100} onChange={(v) => onChange({ ...glow, size: v })} onCommit={onCommit} />
+          <Slider label="Size" value={glow.size} min={0} max={100} onChange={(v) => onChange({ ...glow, size: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Spread</span>
         <div className={styles.sliderWrap}>
-          <Slider value={glow.spread} min={0} max={100} onChange={(v) => onChange({ ...glow, spread: v })} onCommit={onCommit} />
+          <Slider label="Spread" value={glow.spread} min={0} max={100} onChange={(v) => onChange({ ...glow, spread: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Opacity</span>
         <div className={styles.sliderWrap}>
           <Slider
+            label="Opacity"
             value={Math.round(glow.opacity * 100)}
             min={0}
             max={100}

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
@@ -158,6 +158,10 @@
   min-width: 0;
 }
 
+.sliderWrap > div > span:first-child {
+  display: none;
+}
+
 .positionGroup {
   display: flex;
   gap: var(--space-1);

--- a/src/panels/LayerEffectsPanel/StrokeForm.tsx
+++ b/src/panels/LayerEffectsPanel/StrokeForm.tsx
@@ -27,7 +27,7 @@ export function StrokeForm({ stroke, onChange, onCommit }: StrokeFormProps) {
       <div className={styles.row}>
         <span className={styles.fieldLabel}>Width</span>
         <div className={styles.sliderWrap}>
-          <Slider value={stroke.width} min={1} max={50} onChange={(v) => onChange({ ...stroke, width: v })} onCommit={onCommit} />
+          <Slider label="Width" value={stroke.width} min={1} max={50} onChange={(v) => onChange({ ...stroke, width: v })} onCommit={onCommit} />
         </div>
       </div>
       <div className={styles.row}>


### PR DESCRIPTION
Adds label props to effects panel sliders so configureEffect can find them by aria-label. Fixes setLayerOpacity to use aria-label. 487/504 tests pass.