### PR TITLE
fix(e2e): handle group layers and disambiguate Size selector in helpers

### DIFF
--- a/e2e/effects-helper-bugs.spec.ts
+++ b/e2e/effects-helper-bugs.spec.ts
@@ -1,0 +1,79 @@
+// Regression tests for #240 (openEffectsPanel for groups) and #242
+// (configureEffect 'Size' selector colliding with tool-options-bar inputs).
+
+import { test, expect } from './fixtures';
+import {
+  createDocument,
+  waitForStore,
+  setActiveLayer,
+  drawRect,
+  openEffectsPanel,
+  configureEffect,
+  selectTool,
+} from './helpers';
+
+test.describe('e2e helper regressions', () => {
+  test('#240: openEffectsPanel works when the active layer is a group', async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 400, false);
+
+    // Add a group via the layers panel and make it active.
+    const groupId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          addGroup: (name?: string) => void;
+          document: { layers: { id: string; type: string }[] };
+          setActiveLayer: (id: string) => void;
+        };
+      };
+      const s = store.getState();
+      s.addGroup('Test Group');
+      const group = store.getState().document.layers.find((l) => l.type === 'group')!;
+      store.getState().setActiveLayer(group.id);
+      return group.id;
+    });
+    expect(groupId).toBeTruthy();
+
+    // Calling openEffectsPanel must NOT time out for a group layer.
+    // Before the fix it would hang waiting for [aria-labelledby="blend-mode-label"]
+    // which never appears because groups render AdjustmentsPanel.
+    await openEffectsPanel(page);
+
+    // Drawer is visible and contains the adjustments tablist.
+    await expect(page.getByTestId('effects-drawer')).toBeVisible();
+    await expect(page.locator('[role="tablist"][aria-label="Adjustment type"]')).toBeVisible();
+  });
+
+  test('#242: configureEffect picks the drawer Size input even when a tool-options Size exists', async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 400, false);
+
+    // Draw something so we have a raster layer with content to give effects to.
+    await drawRect(page, 50, 50, 100, 100, { r: 200, g: 100, b: 100 });
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return store.getState().document.activeLayerId;
+    });
+    await setActiveLayer(page, layerId);
+
+    // Switch to the brush tool — this exposes a "Size value" input in the
+    // tool options bar, which used to collide with the effects-drawer Size.
+    await selectTool(page, 'brush');
+    await expect(page.getByRole('toolbar', { name: 'Brush options' }).getByLabel('Size value')).toBeVisible();
+
+    // Should not throw a strict-mode violation; the helper now scopes to
+    // the effects drawer.
+    await configureEffect(page, 'Outer Glow', { 'Size': 12 });
+
+    // The drawer's Size value reflects what we set.
+    const drawerSize = await page
+      .getByTestId('effects-drawer')
+      .locator('[aria-label="Size value"]')
+      .inputValue();
+    expect(drawerSize).toBe('12');
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -581,17 +581,26 @@ export async function moveLayerTo(
 // ---------------------------------------------------------------------------
 
 export async function openEffectsPanel(page: Page): Promise<void> {
-  const panel = page.locator('[aria-labelledby="blend-mode-label"]');
-  if (!(await panel.isVisible())) {
-    const activeId = await page.evaluate(() => {
-      const store = (window as unknown as Record<string, unknown>).__editorStore as {
-        getState: () => { document: { activeLayerId: string } };
-      };
-      return store.getState().document.activeLayerId;
-    });
-    const row = page.locator(`[data-layer-id="${activeId}"]`);
-    await row.locator('button[aria-label*="effects"]').click();
-    await panel.waitFor({ state: 'visible', timeout: 5000 });
+  const drawer = page.getByTestId('effects-drawer');
+  if (await drawer.isVisible()) return;
+
+  const { activeId, isGroup } = await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { document: { activeLayerId: string; layers: { id: string; type: string }[] } };
+    };
+    const doc = store.getState().document;
+    const layer = doc.layers.find((l) => l.id === doc.activeLayerId);
+    return { activeId: doc.activeLayerId, isGroup: layer?.type === 'group' };
+  });
+  const row = page.locator(`[data-layer-id="${activeId}"]`);
+  await row.locator('button[aria-label*="effects"]').click();
+  // Group layers render AdjustmentsPanel (no blend-mode header); raster/text
+  // render LayerEffectsPanel which IS keyed by blend-mode-label. Wait for
+  // the appropriate sentinel based on which layer type is active.
+  if (isGroup) {
+    await page.locator('[role="tablist"][aria-label="Adjustment type"]').waitFor({ state: 'visible', timeout: 5000 });
+  } else {
+    await page.locator('[aria-labelledby="blend-mode-label"]').waitFor({ state: 'visible', timeout: 5000 });
   }
 }
 
@@ -621,8 +630,12 @@ export async function configureEffect(
   settings: Record<string, number>,
 ): Promise<void> {
   await enableEffect(page, effectName);
+  // Scope to the effects drawer so labels like "Size" don't collide with
+  // identically-named tool-options-bar inputs (brush/eraser also have a
+  // "Size" slider with the same aria-label).
+  const drawer = page.getByTestId('effects-drawer');
   for (const [label, value] of Object.entries(settings)) {
-    const input = page.locator(`[aria-label="${label} value"]`);
+    const input = drawer.locator(`[aria-label="${label} value"]`);
     await input.waitFor({ state: 'visible', timeout: 3000 });
     await input.fill(String(value));
     await input.press('Enter');


### PR DESCRIPTION
## Summary

Two e2e-helper bugs surfaced by composition tests:

### #240 — `openEffectsPanel` times out for group layers

The helper unconditionally waited for `[aria-labelledby="blend-mode-label"]`. Group layers render `AdjustmentsPanel` instead of `LayerEffectsPanel` and have no blend-mode header, so the wait timed out after 5s.

Fix: detect whether the active layer is a group; for groups wait for the adjustments tablist (`role="tablist"[aria-label="Adjustment type"]`); for raster/text continue waiting for the blend-mode header.

### #242 — `configureEffect` matches the tool-options-bar Size input

`[aria-label="Size value"]` matches both:
- the effects drawer's Size input
- the brush/eraser tool-options-bar Size input

When called while a Size-bearing tool was active, Playwright threw a strict-mode violation.

Fix: scope the locator to `getByTestId('effects-drawer')` so it only sees inputs inside the drawer.

## Tests

`e2e/effects-helper-bugs.spec.ts` — two regression tests:
- openEffectsPanel succeeds for a group layer (would previously hang).
- configureEffect picks the drawer's Size input even with the brush tool active (would previously throw a strict-mode violation).

Closes #240
Closes #242

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6Xbvb93ZVtVNqXe26c2Ni)_