### PR TITLE
fix(shape): reject invalid shape modes; align FEATURES.md with what ships

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -45,7 +45,8 @@
 ## Shape & Vector Tools
 
 ### Shape Tool
-- **Shape types**: rectangle, ellipse, polygon, line, arrow, star
+- **Shape types**: ellipse, polygon. A rectangle/square is drawn as a
+  4-sided polygon (set sides to 4); triangles use sides=3, etc.
 - **Output**: pixels or path
 - **Fill color**: any color or none
 - **Stroke color**: any color or none
@@ -271,7 +272,7 @@ Applied globally or per-group. All default to 0.
 ### Layer Types
 - **Raster**: pixel layer
 - **Text**: live-editable text
-- **Shape**: vector shape (rectangle, ellipse, polygon, line, arrow, star)
+- **Shape**: vector shape (ellipse, polygon — see Shape Tool above)
 - **Group**: folder with optional per-group adjustments
 - **Adjustment**: adjustment layer
 - **Fill**: fill layer

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { useToolSettingsStore } from './tool-settings-store';
+
+describe('setShapeMode — issue #236 (invalid modes render incorrectly)', () => {
+  it('accepts ellipse', () => {
+    useToolSettingsStore.getState().setShapeMode('ellipse');
+    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+  });
+
+  it('accepts polygon', () => {
+    useToolSettingsStore.getState().setShapeMode('polygon');
+    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+  });
+
+  it('ignores invalid values like "rectangle" instead of silently storing them', () => {
+    useToolSettingsStore.getState().setShapeMode('ellipse');
+    // The setter is typed as ShapeMode but JS callers (and TS @ts-ignore
+    // bypasses) can pass anything. The store must reject invalid values
+    // so the GPU dispatch doesn't render a polygon with stale `sides`
+    // when a caller asked for "rectangle".
+    (useToolSettingsStore.getState().setShapeMode as (m: string) => void)('rectangle');
+    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+  });
+
+  it('ignores other invalid values (line, arrow, star)', () => {
+    useToolSettingsStore.getState().setShapeMode('polygon');
+    const setter = useToolSettingsStore.getState().setShapeMode as (m: string) => void;
+    setter('line');
+    setter('arrow');
+    setter('star');
+    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -483,7 +483,14 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setEraserOpacity: (opacity) => set({ eraserOpacity: Math.max(1, Math.min(100, opacity)) }),
   setFillTolerance: (tolerance) => set({ fillTolerance: Math.max(0, Math.min(255, tolerance)) }),
   setFillContiguous: (contiguous) => set({ fillContiguous: contiguous }),
-  setShapeMode: (mode) => set({ shapeMode: mode }),
+  setShapeMode: (mode) => {
+    // Guard against invalid values (e.g. 'rectangle', 'line') sneaking in
+    // via store bypass. The shader treats anything-not-ellipse as polygon
+    // and would render a polygon with whatever sides setting is current,
+    // which doesn't match what a caller passing 'rectangle' expects.
+    if (mode !== 'ellipse' && mode !== 'polygon') return;
+    set({ shapeMode: mode });
+  },
   setShapeOutput: (output) => set({ shapeOutput: output }),
   setShapeFillColor: (color) => set({ shapeFillColor: color }),
   setShapeStrokeColor: (color) => set({ shapeStrokeColor: color }),


### PR DESCRIPTION
## Summary

### #232 — FEATURES.md lists shape modes that don't exist

`FEATURES.md` advertised the Shape Tool as supporting `rectangle, ellipse, polygon, line, arrow, star`, but the only `ShapeMode` values are `ellipse` and `polygon`. Update both the Shape Tool section and the Layer Types entry to match what ships, and note that a rectangle is drawn as a 4-sided polygon.

### #236 — Stroke-only "rectangle" draws unexpected geometry

The bug surfaced when a caller (or test) set `shapeMode` to `'rectangle'` (not a valid value). `shapeModeToU32` returned 1 (polygon) for anything not ellipse, so the shader rendered a polygon using whatever `shapePolygonSides` was active — producing geometry that didn't match what the caller asked for.

Fix: `setShapeMode` now rejects any value other than `'ellipse'` or `'polygon'` so a typoed mode is a no-op rather than silently mapping to a different shape. Combined with the FEATURES.md doc fix, callers who want a rectangle now have a clear path: `setShapeMode('polygon')` + `setShapePolygonSides(4)`.

## Tests

- `src/app/tool-settings-store.test.ts` — 4 tests covering the valid modes, the `'rectangle'` case from the bug report, and other invalid values (`line`, `arrow`, `star`).

Closes #232
Closes #236

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6Xbvb93ZVtVNqXe26c2Ni)_