### PR TITLE
fix(filter, smudge): expand layer to scratch size before scratch-FBO passes

### DIFF
--- a/e2e/filter-bounds-bug.spec.ts
+++ b/e2e/filter-bounds-bug.spec.ts
@@ -1,0 +1,69 @@
+// Regression test for #235: Gaussian Blur (and other filters that read
+// from scratch FBOs) must work correctly on layers smaller than the
+// document. Before the fix, the scratch textures were doc-sized but the
+// viewport was set to the layer size, so pass-2 sampled garbage outside
+// the valid sub-region and destroyed layer content.
+
+import { test, expect } from './fixtures';
+import { createDocument, waitForStore, drawEllipse, applyFilter } from './helpers';
+
+async function getLayerPixelAt(
+  page: import('@playwright/test').Page,
+  x: number,
+  y: number,
+): Promise<{ r: number; g: number; b: number; a: number }> {
+  return page.evaluate(({ x, y }) => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => {
+        document: { activeLayerId: string; layers: { id: string; x: number; y: number }[] };
+        getOrCreateLayerPixelData: (id: string) => ImageData;
+      };
+    };
+    const s = store.getState();
+    const id = s.document.activeLayerId;
+    const layer = s.document.layers.find((l) => l.id === id)!;
+    const data = s.getOrCreateLayerPixelData(id);
+    const lx = x - layer.x;
+    const ly = y - layer.y;
+    if (lx < 0 || ly < 0 || lx >= data.width || ly >= data.height) {
+      return { r: 0, g: 0, b: 0, a: 0 };
+    }
+    const i = (ly * data.width + lx) * 4;
+    return { r: data.data[i]!, g: data.data[i + 1]!, b: data.data[i + 2]!, a: data.data[i + 3]! };
+  }, { x, y });
+}
+
+test.describe('filter bounds (#235)', () => {
+  test('Gaussian Blur on a small ellipse layer preserves the ellipse content', async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 800, 600, false);
+
+    // A small ellipse positioned away from the doc origin — this is the
+    // case that used to break: the layer's content area is much smaller
+    // than the doc-sized scratch texture.
+    const cream = { r: 240, g: 230, b: 210 };
+    await drawEllipse(page, 400, 300, 100, 50, cream);
+
+    // Sample the ellipse center BEFORE the blur to confirm content exists.
+    const before = await getLayerPixelAt(page, 400, 300);
+    expect(before.a).toBeGreaterThan(200);
+    expect(before.r).toBeGreaterThan(200);
+    expect(before.g).toBeGreaterThan(200);
+    expect(before.b).toBeGreaterThan(150);
+
+    // Apply Gaussian Blur radius=2 — should soften the edges, not blank
+    // the ellipse out.
+    await applyFilter(page, 'Gaussian Blur...', { Radius: 2 });
+
+    // After the blur the center pixel should still be near the cream
+    // colour. Before the fix it became near-zero (alpha mostly gone),
+    // because the shader read garbage outside the layer's sub-region of
+    // the scratch texture.
+    const after = await getLayerPixelAt(page, 400, 300);
+    expect(after.a).toBeGreaterThan(200);
+    expect(after.r).toBeGreaterThan(180);
+    expect(after.g).toBeGreaterThan(180);
+    expect(after.b).toBeGreaterThan(140);
+  });
+});

--- a/e2e/smudge-bounds-bug.spec.ts
+++ b/e2e/smudge-bounds-bug.spec.ts
@@ -1,0 +1,75 @@
+// Regression test for #237: Smudge tool produced full-width horizontal
+// streak artifacts because the GPU dispatch wrote to a doc-sized scratch
+// FBO with the viewport set to the (smaller) layer size, then blitted
+// the scratch back into the layer — reading garbage from the scratch's
+// unwritten region in the process. Same root cause as #235.
+
+import { test, expect } from './fixtures';
+import {
+  createDocument,
+  waitForStore,
+  drawRect,
+  selectTool,
+  setToolOption,
+  docToScreen,
+} from './helpers';
+
+async function getLayerPixelAt(
+  page: import('@playwright/test').Page,
+  x: number,
+  y: number,
+): Promise<{ r: number; g: number; b: number; a: number }> {
+  return page.evaluate(({ x, y }) => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => {
+        document: { activeLayerId: string; layers: { id: string; x: number; y: number }[] };
+        getOrCreateLayerPixelData: (id: string) => ImageData;
+      };
+    };
+    const s = store.getState();
+    const id = s.document.activeLayerId;
+    const layer = s.document.layers.find((l) => l.id === id)!;
+    const data = s.getOrCreateLayerPixelData(id);
+    const lx = x - layer.x;
+    const ly = y - layer.y;
+    if (lx < 0 || ly < 0 || lx >= data.width || ly >= data.height) {
+      return { r: 0, g: 0, b: 0, a: 0 };
+    }
+    const i = (ly * data.width + lx) * 4;
+    return { r: data.data[i]!, g: data.data[i + 1]!, b: data.data[i + 2]!, a: data.data[i + 3]! };
+  }, { x, y });
+}
+
+test.describe('smudge bounds (#237)', () => {
+  test('smudge stroke does not leave full-width streaks far from the brush', async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 800, 600, false);
+
+    // A small dark rectangle on a transparent layer.
+    await drawRect(page, 200, 100, 100, 80, { r: 30, g: 30, b: 30 });
+
+    // Smudge across the top edge of the rectangle. The stroke is small
+    // (~30 px) and stays inside the rectangle; pixels far away should
+    // be unaffected.
+    await selectTool(page, 'smudge');
+    await setToolOption(page, 'Size', 20);
+    await setToolOption(page, 'Strength', 50);
+
+    const start = await docToScreen(page, 220, 110);
+    const end = await docToScreen(page, 250, 105);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    // Sample a pixel FAR from the smudge brush — somewhere on the right
+    // half of the canvas at the same Y as the smudge stroke.
+    // Before the fix, scratch-FBO leakage would create a horizontal
+    // streak across the full layer width, so this pixel would pick up
+    // the dark colour. After the fix it should remain transparent.
+    const farPixel = await getLayerPixelAt(page, 600, 110);
+    expect(farPixel.a).toBeLessThan(20);
+  });
+});

--- a/engine-rs/crates/lopsy-wasm/src/api/filter/blur.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/filter/blur.rs
@@ -53,6 +53,10 @@ pub fn filter_unsharp_mask(
     // Step 2: sharpen shader with original + blurred
     if radius == 0 { return; }
 
+    // Match the rest of the filter pipeline: ensure layer/scratch sizes
+    // align so pass-2 sampling doesn't read garbage outside the layer.
+    let _ = engine.inner.ensure_layer_full_size(layer_id);
+
     // First do a gaussian blur pass (layer -> scratch B via scratch A)
     let kernel = lopsy_core::filters::blur::gaussian_kernel(radius);
     let gl = &engine.inner.gl;

--- a/engine-rs/crates/lopsy-wasm/src/filter_gpu.rs
+++ b/engine-rs/crates/lopsy-wasm/src/filter_gpu.rs
@@ -104,6 +104,13 @@ pub fn apply_filter(
     get_shader: impl Fn(&EngineInner) -> &ShaderProgram,
     set_uniforms: impl FnOnce(&WebGl2RenderingContext, &ShaderProgram),
 ) {
+    // Scratch FBOs are sized to the document. If the layer texture is
+    // smaller (e.g. a tiny ellipse on a large canvas), pass-2 sampling
+    // would read garbage from the scratch's unwritten region, destroying
+    // the filter output. Expanding the layer to at least doc size
+    // guarantees the scratch and layer dimensions match.
+    let _ = engine.ensure_layer_full_size(layer_id);
+
     let has_selection = engine.selection_mask_texture.is_some();
 
     // If there's a selection, save the original layer to scratch B first
@@ -181,6 +188,10 @@ pub fn apply_separable_blur(
     get_shader: impl Fn(&EngineInner) -> &ShaderProgram,
     set_common_uniforms: impl Fn(&WebGl2RenderingContext, &ShaderProgram),
 ) {
+    // See note in apply_filter: ensure layer/scratch dimensions match so
+    // pass 2 doesn't sample garbage outside the layer's sub-region.
+    let _ = engine.ensure_layer_full_size(layer_id);
+
     let has_selection = engine.selection_mask_texture.is_some();
 
     let tex_handle = match engine.layer_textures.get(layer_id) {

--- a/engine-rs/crates/lopsy-wasm/src/smudge_gpu.rs
+++ b/engine-rs/crates/lopsy-wasm/src/smudge_gpu.rs
@@ -33,6 +33,13 @@ pub fn apply_smudge_dab_batch(
     if points.len() < 4 {
         return;
     }
+    // The dispatch writes to a doc-sized scratch FBO with the viewport set
+    // to the layer texture size, then blits the scratch back to the layer.
+    // If the layer is smaller than the scratch, the blit reads garbage
+    // from the scratch's unwritten region — the same root cause as the
+    // filter bounds bug, surfacing as full-width streak artifacts.
+    let _ = engine.ensure_layer_full_size(layer_id);
+
     let gl = &engine.gl;
     let tex_handle = match engine.layer_textures.get(layer_id) {
         Some(&h) => h,


### PR DESCRIPTION
## Summary

Two bugs with the same root cause: GPU dispatchers that bind a doc-sized scratch FBO with the viewport set to the (smaller) layer texture size, then sample from the scratch back into the layer.

When the layer is smaller than the doc, pass 1 only writes the top-left layer-sized sub-region of the scratch. Pass 2 (or the blit-back) samples the **full** scratch with `v_uv ∈ [0, 1]`, reading uninitialized / stale data outside the valid sub-region.

- **#235** — Filters (Gaussian Blur, Chromatic Aberration, etc.) blank the layer because pass 2 reads garbage. The dialog path normally masks this via `saveFilterPreview` → `ensure_layer_full_size`, but `saveFilterPreview` only fires when the user toggles the Preview checkbox. Apply-without-preview hits the bug.
- **#237** — Smudge produces full-width horizontal streaks because the blit step reads garbage from the scratch's unwritten region.

## Fix

Call `ensure_layer_full_size(layer_id)` at the top of:
- `filter_gpu::apply_filter`
- `filter_gpu::apply_separable_blur`
- `filter_unsharp_mask` (dispatches to scratch FBOs directly)
- `smudge_gpu::apply_smudge_dab_batch`

`ensure_layer_full_size` is a no-op when the layer texture already covers the doc, so this is safe to call unconditionally.

## Tests

- `e2e/filter-bounds-bug.spec.ts` — exact reproduction from #235 (cream ellipse + Gaussian Blur radius=2). Asserts the centre pixel is still cream after the filter, instead of being blanked.
- `e2e/smudge-bounds-bug.spec.ts` — smudges a small rectangle; asserts pixels far from the brush remain transparent (instead of picking up the streak).

Closes #235
Closes #237