### PR TITLE
fix(tool-settings): document opacity setters as percent and warn on normalised inputs

### DIFF
--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useToolSettingsStore } from './tool-settings-store';
 
 describe('setShapeMode — issue #236 (invalid modes render incorrectly)', () => {
@@ -30,5 +30,75 @@ describe('setShapeMode — issue #236 (invalid modes render incorrectly)', () =>
     setter('arrow');
     setter('star');
     expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+  });
+});
+
+describe('opacity setters — issue #250 (percent vs normalised footgun)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    // The warn-once dedupe lives in module state, so re-import a fresh copy
+    // for each test to make the warning behaviour deterministic.
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('clamps brush opacity to the documented 1–100 percent range', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setBrushOpacity(50);
+    expect(store.getState().brushOpacity).toBe(50);
+    store.getState().setBrushOpacity(200);
+    expect(store.getState().brushOpacity).toBe(100);
+    store.getState().setBrushOpacity(-5);
+    expect(store.getState().brushOpacity).toBe(1);
+  });
+
+  it('warns when setBrushOpacity receives a fractional value (likely 0–1 normalised)', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setBrushOpacity(0.5);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain('setBrushOpacity');
+    expect(message).toContain('percent');
+    expect(message).toContain('50');
+    // The value still gets clamped into the percent range (no silent
+    // 1%-stroke), so callers don't get the original footgun.
+    expect(store.getState().brushOpacity).toBe(1);
+  });
+
+  it('does not warn for the integer sentinel 0', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setBrushOpacity(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for legitimate percent values, including 1', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setBrushOpacity(1);
+    store.getState().setBrushOpacity(50);
+    store.getState().setBrushOpacity(100);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns at most once per setter even with repeated bad calls', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setBrushOpacity(0.5);
+    store.getState().setBrushOpacity(0.2);
+    store.getState().setBrushOpacity(0.99);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('also warns from setEraserOpacity and setSprayOpacity (same footgun)', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setEraserOpacity(0.5);
+    store.getState().setSprayOpacity(0.3);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    const messages = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ''));
+    expect(messages.some((m: string) => m.includes('setEraserOpacity'))).toBe(true);
+    expect(messages.some((m: string) => m.includes('setSprayOpacity'))).toBe(true);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -8,6 +8,22 @@ import { colorEquals } from '../utils/color';
 
 const MAX_RECENT_COLORS = 20;
 
+// Opacity setters in this store take **percent** (1–100), not normalised
+// 0–1. Callers reaching for normalised opacity (which is what colours and
+// layer alpha use elsewhere) will silently end up with ~1% strokes. Warn
+// once per setter when the input looks normalised — fractional and not
+// the legitimate sentinel 0.
+const warnedNormalisedOpacity = new Set<string>();
+function warnIfNormalisedOpacity(setter: string, value: number): void {
+  if (value > 0 && value < 1 && !warnedNormalisedOpacity.has(setter)) {
+    warnedNormalisedOpacity.add(setter);
+    console.warn(
+      `[tool-settings] ${setter}(${value}) looks like a normalised 0–1 opacity. ` +
+      `This setter expects percent (1–100). Did you mean ${Math.round(value * 100)}?`,
+    );
+  }
+}
+
 let nextId = 1;
 function uid(): string {
   return `brush-${nextId++}`;
@@ -345,6 +361,7 @@ interface ToolSettings {
 
   setSpraySize: (size: number) => void;
   setSprayDensity: (density: number) => void;
+  /** Spray opacity in **percent**, range `1–100` (not normalised `0–1`). */
   setSprayOpacity: (opacity: number) => void;
   setSprayHardness: (hardness: number) => void;
   setBrushSize: (size: number) => void;
@@ -370,10 +387,12 @@ interface ToolSettings {
   setTextFontWeight: (weight: number) => void;
   setTextFontStyle: (style: FontStyle) => void;
   setTextAlign: (align: TextAlign) => void;
+  /** Brush opacity in **percent**, range `1–100` (not normalised `0–1`). */
   setBrushOpacity: (opacity: number) => void;
   setBrushHardness: (hardness: number) => void;
   setPencilSize: (size: number) => void;
   setEraserSize: (size: number) => void;
+  /** Eraser opacity in **percent**, range `1–100` (not normalised `0–1`). */
   setEraserOpacity: (opacity: number) => void;
   setFillTolerance: (tolerance: number) => void;
   setFillContiguous: (contiguous: boolean) => void;
@@ -468,7 +487,10 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
 
   setSpraySize: (size) => set({ spraySize: Math.max(1, Math.min(500, size)) }),
   setSprayDensity: (density) => set({ sprayDensity: Math.max(1, Math.min(100, density)) }),
-  setSprayOpacity: (opacity) => set({ sprayOpacity: Math.max(1, Math.min(100, opacity)) }),
+  setSprayOpacity: (opacity) => {
+    warnIfNormalisedOpacity('setSprayOpacity', opacity);
+    set({ sprayOpacity: Math.max(1, Math.min(100, opacity)) });
+  },
   setSprayHardness: (hardness) => set({ sprayHardness: Math.max(0, Math.min(100, hardness)) }),
   setBrushSize: (size) => set({ brushSize: Math.max(1, Math.min(2000, size)) }),
   setBrushFade: (fade) => set({ brushFade: Math.max(0, Math.min(2000, fade)) }),
@@ -476,11 +498,17 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setBrushScatter: (scatter) => set({ brushScatter: Math.max(0, Math.min(100, scatter)) }),
   setBrushAngle: (angle) => set({ brushAngle: ((angle % 360) + 360) % 360 }),
   setActiveBrushTip: (tip) => set({ activeBrushTip: tip }),
-  setBrushOpacity: (opacity) => set({ brushOpacity: Math.max(1, Math.min(100, opacity)) }),
+  setBrushOpacity: (opacity) => {
+    warnIfNormalisedOpacity('setBrushOpacity', opacity);
+    set({ brushOpacity: Math.max(1, Math.min(100, opacity)) });
+  },
   setBrushHardness: (hardness) => set({ brushHardness: Math.max(0, Math.min(100, hardness)) }),
   setPencilSize: (size) => set({ pencilSize: Math.max(1, Math.min(100, size)) }),
   setEraserSize: (size) => set({ eraserSize: Math.max(1, Math.min(200, size)) }),
-  setEraserOpacity: (opacity) => set({ eraserOpacity: Math.max(1, Math.min(100, opacity)) }),
+  setEraserOpacity: (opacity) => {
+    warnIfNormalisedOpacity('setEraserOpacity', opacity);
+    set({ eraserOpacity: Math.max(1, Math.min(100, opacity)) });
+  },
   setFillTolerance: (tolerance) => set({ fillTolerance: Math.max(0, Math.min(255, tolerance)) }),
   setFillContiguous: (contiguous) => set({ fillContiguous: contiguous }),
   setShapeMode: (mode) => {


### PR DESCRIPTION
## Summary

Closes #250.

`setBrushOpacity`, `setEraserOpacity` and `setSprayOpacity` clamp to `[1, 100]` percent, but their names line up with colour/alpha APIs elsewhere in the codebase that use normalised `[0, 1]`. Calling `setBrushOpacity(1)` thinking it means "fully opaque" silently produced ~1% strokes — easy to mis-diagnose as the brush not painting on the active layer.

This is the "less churn" path from the issue (Option A): keep the percent contract, but make the contract loud.

- **JSDoc each opacity setter as percent** on the `ToolSettings` interface, so hovering at any call site surfaces the range.
- **Runtime warning** (once per setter) when the input is fractional and non-zero — the unambiguous signal that a caller passed a normalised opacity. The warning is dev-friendly: it includes the offending value and suggests the percent equivalent.
  - Legitimate percent values (including `1`) don't warn. The integer sentinel `0` doesn't warn.
  - The clamp still produces a bounded output, so the symptom (~1% strokes) doesn't disappear silently — but the warning surfaces *why*.

## Why not change the API to `0–1`

Option B (normalise to 0–1) would touch `BrushModal`, `BrushOptions`, presets, and the brush dab path, plus shift the meaning of `brushOpacity: 100` in stored presets. The JSDoc + warn approach matches the suggestion in the issue and avoids a breaking change for stored brush presets.

## #224 (sequential cuts)

Re-investigated this round and reached the same wall as the prior three passes: the JS-side `cut()` flow looks contractually correct, and the bug needs a browser-level WASM-side log of `selection_mask_texture.is_some()` / `has_mask` uniform at cut #2 to localise. Left a comment on #224 and kept it open rather than ship a speculative fix.

## Test plan

- [x] `npx vitest run src/app/tool-settings-store.test.ts` — 10 passed (5 new for #250).
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors only).
- [x] Manual: hover `setBrushOpacity` at a call site — JSDoc shows "Brush opacity in percent, range 1–100".
- [ ] Manual smoke in the dev server: paint with `setBrushOpacity(0.5)` from the console; verify the warning fires once and `brushOpacity` clamps to `1`.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8j5xB4h1NQ5gUKM7SuYFG)_