### PR TITLE
fix(ui): header-only drag + transparent overlay on preview

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -229,11 +229,10 @@ export function App() {
               ref={effectsDrawerRef}
               data-testid="effects-drawer"
               style={{ transform: `translate(${drawerOffset.x}px, ${drawerOffset.y}px)` }}
-              {...drawerDragProps}
             >
               {activeLayerId && layers.find((l) => l.id === activeLayerId)?.type === 'group'
-                ? <AdjustmentsPanel showHeader />
-                : <LayerEffectsPanel />
+                ? <AdjustmentsPanel showHeader dragProps={drawerDragProps} />
+                : <LayerEffectsPanel dragProps={drawerDragProps} />
               }
             </div>
           )}

--- a/src/app/hooks/useDraggablePanel.ts
+++ b/src/app/hooks/useDraggablePanel.ts
@@ -2,6 +2,12 @@ import { useCallback, useRef, useState } from 'react';
 
 const INTERACTIVE_SELECTORS = 'input, button, select, textarea, [role="slider"], [role="option"], label';
 
+export type DragProps = {
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: () => void;
+};
+
 export function useDraggablePanel() {
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const dragState = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(null);

--- a/src/components/FilterDialog/FilterDialog.module.css
+++ b/src/components/FilterDialog/FilterDialog.module.css
@@ -8,6 +8,15 @@
   z-index: var(--z-modal);
 }
 
+.overlayTransparent {
+  background: transparent;
+  pointer-events: none;
+}
+
+.overlayTransparent .modal {
+  pointer-events: auto;
+}
+
 .modal {
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
@@ -23,6 +32,7 @@
 .header {
   padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
+  cursor: grab;
 }
 
 .header h2 {

--- a/src/components/FilterDialog/FilterDialog.tsx
+++ b/src/components/FilterDialog/FilterDialog.tsx
@@ -94,16 +94,15 @@ export function FilterDialog({ title, params, onApply, onCancel, onPreviewChange
   const { offset, dragProps } = useDraggablePanel();
 
   return (
-    <div className={styles.overlay} role="presentation">
+    <div className={`${styles.overlay} ${preview ? styles.overlayTransparent : ''}`} role="presentation">
       <div
         className={styles.modal}
         role="dialog"
         aria-label={title}
         onKeyDown={handleKeyDown}
         style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
-        {...dragProps}
       >
-        <div className={styles.header}>
+        <div className={styles.header} {...dragProps}>
           <h2>{title}</h2>
         </div>
         <div className={styles.body}>

--- a/src/components/FilterDialog/NoiseDialog.module.css
+++ b/src/components/FilterDialog/NoiseDialog.module.css
@@ -23,6 +23,7 @@
 .header {
   padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
+  cursor: grab;
 }
 
 .header h2 {

--- a/src/components/FilterDialog/NoiseDialog.tsx
+++ b/src/components/FilterDialog/NoiseDialog.tsx
@@ -45,9 +45,8 @@ export function NoiseDialog({ title, onApply, onCancel }: NoiseDialogProps) {
         aria-label={title}
         onKeyDown={handleKeyDown}
         style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
-        {...dragProps}
       >
-        <div className={styles.header}>
+        <div className={styles.header} {...dragProps}>
           <h2>{title}</h2>
         </div>
         <div className={styles.body}>
@@ -131,9 +130,8 @@ export function FillNoiseDialog({ title, onApply, onCancel }: FillNoiseDialogPro
         aria-label={title}
         onKeyDown={handleKeyDown}
         style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
-        {...dragProps}
       >
-        <div className={styles.header}>
+        <div className={styles.header} {...dragProps}>
           <h2>{title}</h2>
         </div>
         <div className={styles.body}>

--- a/src/components/PatternFillDialog/PatternFillDialog.module.css
+++ b/src/components/PatternFillDialog/PatternFillDialog.module.css
@@ -8,6 +8,15 @@
   z-index: var(--z-modal);
 }
 
+.overlayTransparent {
+  background: transparent;
+  pointer-events: none;
+}
+
+.overlayTransparent .modal {
+  pointer-events: auto;
+}
+
 .modal {
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
@@ -23,6 +32,7 @@
 .header {
   padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
+  cursor: grab;
 }
 
 .header h2 {

--- a/src/components/PatternFillDialog/PatternFillDialog.tsx
+++ b/src/components/PatternFillDialog/PatternFillDialog.tsx
@@ -88,16 +88,15 @@ export function PatternFillDialog({ onApply, onCancel, onPreviewChange, onPrevie
   const selectedPattern: PatternDefinition | undefined = patterns.find((p) => p.id === selectedId);
 
   return (
-    <div className={styles.overlay} role="presentation">
+    <div className={`${styles.overlay} ${preview ? styles.overlayTransparent : ''}`} role="presentation">
       <div
         className={styles.modal}
         role="dialog"
         aria-label="Pattern Fill"
         onKeyDown={handleKeyDown}
         style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
-        {...dragProps}
       >
-        <div className={styles.header}>
+        <div className={styles.header} {...dragProps}>
           <h2>Pattern Fill</h2>
         </div>
         <div className={styles.body}>

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.module.css
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.module.css
@@ -12,6 +12,7 @@
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
+  cursor: grab;
 }
 
 .headerTitle {

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Eye, EyeOff, X } from 'lucide-react';
 import { Slider } from '../../components/Slider/Slider';
 import { IconButton } from '../../components/IconButton/IconButton';
+import type { DragProps } from '../../app/hooks/useDraggablePanel';
 import { CurveEditor } from '../../components/CurveEditor/CurveEditor';
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
@@ -81,9 +82,10 @@ function useActiveGroup(): GroupLayer | null {
 
 interface AdjustmentsPanelProps {
   showHeader?: boolean;
+  dragProps?: DragProps;
 }
 
-export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
+export function AdjustmentsPanel({ showHeader, dragProps }: AdjustmentsPanelProps = {}) {
   const group = useActiveGroup();
   const setGroupAdjustments = useEditorStore((s) => s.setGroupAdjustments);
   const setGroupAdjustmentsEnabled = useEditorStore((s) => s.setGroupAdjustmentsEnabled);
@@ -130,7 +132,7 @@ export function AdjustmentsPanel({ showHeader }: AdjustmentsPanelProps = {}) {
   return (
     <div className={styles.panel}>
       {showHeader && (
-        <div className={styles.header}>
+        <div className={styles.header} {...dragProps}>
           <span className={styles.headerTitle}>{group.name}</span>
           <IconButton
             icon={<X size={14} />}

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.module.css
@@ -14,6 +14,7 @@
   padding: 0 var(--space-2);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
+  cursor: grab;
 }
 
 .drawerTitle {

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
 import { IconButton } from '../../components/IconButton/IconButton';
+import type { DragProps } from '../../app/hooks/useDraggablePanel';
 import type { BlendMode, LayerEffects } from '../../types';
 import { BLEND_MODE_TO_DISPLAY } from '../../types/blend-mode-tables';
 import { DropShadowForm } from './DropShadowForm';
@@ -33,7 +34,11 @@ const EFFECT_LIST: { key: EffectKey; label: string }[] = [
   { key: 'colorOverlay', label: 'Color Overlay' },
 ];
 
-export function LayerEffectsPanel() {
+interface LayerEffectsPanelProps {
+  dragProps?: DragProps;
+}
+
+export function LayerEffectsPanel({ dragProps }: LayerEffectsPanelProps) {
   const activeLayerId = useEditorStore((s) => s.document.activeLayerId);
   const layers = useEditorStore((s) => s.document.layers);
   const updateLayerEffects = useEditorStore((s) => s.updateLayerEffects);
@@ -90,7 +95,7 @@ export function LayerEffectsPanel() {
   if (!activeLayer) {
     return (
       <div className={styles.drawer}>
-        <div className={styles.drawerHeader}>
+        <div className={styles.drawerHeader} {...dragProps}>
           <span className={styles.drawerTitle}>Layer Effects</span>
           <IconButton
             icon={<X size={14} />}


### PR DESCRIPTION
## Summary
- Restrict modal/panel dragging to the header bar only (previously the entire surface was draggable), with `cursor: grab` for discoverability
- Remove the dim overlay backdrop when preview is enabled on filter/pattern dialogs so the canvas is fully visible
- Pass `dragProps` into LayerEffectsPanel and AdjustmentsPanel as a prop so the effects drawer header is the drag handle

## Test plan
- [ ] Open a filter dialog (e.g. Gaussian Blur) — verify dragging only works from the title bar, not the body/footer
- [ ] Open Pattern Fill dialog — same header-only drag check
- [ ] Open the Layer Effects panel — verify drag works from the header, not from the effect list or form area
- [ ] Open the Adjustments panel (select a group layer) — same header-only drag check
- [ ] In a filter dialog, toggle Preview on — overlay should disappear, canvas visible behind the modal
- [ ] Toggle Preview off — overlay should reappear
- [ ] With Preview on, verify the modal is still fully interactive (sliders, buttons, drag by header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)