### PR TITLE
perf(wasm): preload WASM module at app startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { useToolSettingsStore } from './app/tool-settings-store';
 import { usePatternStore } from './app/pattern-store';
 import { pixelDataManager } from './engine/pixel-data-manager';
 import { getEngine, getEngineCanvas } from './engine-wasm/engine-state';
-import { render as renderWasm, readLayerPixels, getLayerTextureDimensions } from './engine-wasm/wasm-bridge';
+import { render as renderWasm, readLayerPixels, getLayerTextureDimensions, initWasm } from './engine-wasm/wasm-bridge';
 import {
   syncDocumentSize,
   syncBackgroundColor,
@@ -129,6 +129,10 @@ window.addEventListener('keydown', (e) => {
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/sw.js');
 }
+
+// Kick off WASM fetch + compilation immediately so it's ready by the time
+// the user creates their first document.
+initWasm().catch(() => {});
 
 const root = document.getElementById('root');
 if (!root) {


### PR DESCRIPTION
## Summary

- Calls `initWasm()` as a fire-and-forget in `main.tsx` immediately after the page loads
- The existing singleton cache in `wasm-bridge.ts` ensures the WASM binary is only fetched and compiled once
- When the user creates a document and the canvas mounts, `initEngine()` awaits an already-resolved promise instead of waiting for the full WASM load

## Test plan

- [ ] Open the app and wait ~2 seconds before creating a new document — canvas should appear immediately with no perceptible delay
- [ ] Open the app and create a new document right away — should be at least as fast as before, ideally faster
- [ ] Verify no console errors related to WASM init on startup

---
_Generated by [Claude Code](https://claude.ai/code/session_011x3cwMdC4uBpqQiEU1AJGd)_