### PR TITLE
fix(text): commit text editing on Tab

### DIFF
--- a/e2e/bug-repro-262-text-tab-commit.spec.ts
+++ b/e2e/bug-repro-262-text-tab-commit.spec.ts
@@ -1,0 +1,98 @@
+// Regression test for issue #262 — pressing Tab to commit a text layer left
+// the editor stuck in textEditing mode, so the next single-key tool shortcut
+// (e.g. `t`, `b`, `v`) was inserted as a literal character into the text
+// buffer instead of switching tools. The "HELLO" + Tab + `t` repro from the
+// issue ended up reading as "HELLOt" with the commit/cancel chips still
+// visible.
+//
+// Fix: useKeyboardShortcuts.ts now treats Tab during textEditing the same way
+// it treats Shift+Enter — preventDefault + commitTextEditing — so the next
+// keystroke goes back through the global shortcut handler.
+import { test, expect } from '@playwright/test';
+import {
+  createDocument,
+  setForegroundColor,
+  selectTool,
+  docToScreen,
+  waitForStore,
+} from './helpers';
+
+test('issue #262 — Tab commits text and the next shortcut switches tools', async ({ page }) => {
+  await page.goto('/');
+  await waitForStore(page);
+  await createDocument(page, 800, 600, true);
+
+  // Add a fresh layer for the text and pick a visible color.
+  await page.locator('[aria-label="Add Layer"]').click();
+  await page.waitForTimeout(50);
+  await setForegroundColor(page, 255, 255, 255);
+
+  await selectTool(page, 'text');
+  const click = await docToScreen(page, 400, 300);
+  await page.mouse.click(click.x, click.y);
+  await page.waitForTimeout(200);
+
+  // Type the literal "HELLO" — note that processTextKey treats single-key
+  // keystrokes as printable, so this exercises the same path as a real user.
+  await page.keyboard.type('HELLO');
+  await page.waitForTimeout(150);
+
+  // Snapshot the in-progress editing buffer so we know the type-typed
+  // characters reached the editor before we press Tab.
+  const editingTextBeforeTab = await page.evaluate(() => {
+    const ui = (window as unknown as { __uiStore: { getState: () => { textEditing: { text: string } | null } } }).__uiStore;
+    return ui.getState().textEditing?.text ?? null;
+  });
+  expect(editingTextBeforeTab).toBe('HELLO');
+
+  // Tab — this should commit the text (clearing textEditing) and NOT leak
+  // into the buffer.
+  await page.keyboard.press('Tab');
+  await page.waitForTimeout(200);
+
+  // After Tab, the editor should be out of edit mode and the committed
+  // layer's text should be exactly "HELLO" with no trailing characters.
+  const afterTab = await page.evaluate(() => {
+    const ui = (window as unknown as { __uiStore: { getState: () => { textEditing: { text: string } | null } } }).__uiStore;
+    const editor = (window as unknown as { __editorStore: { getState: () => { document: { layers: Array<{ id: string; type: string; text?: string }> } } } }).__editorStore;
+    const lastTextLayer = [...editor.getState().document.layers]
+      .reverse()
+      .find((l) => typeof l.text === 'string');
+    return {
+      textEditing: ui.getState().textEditing,
+      committedText: lastTextLayer?.text ?? null,
+    };
+  });
+  expect(afterTab.textEditing).toBeNull();
+  expect(afterTab.committedText).toBe('HELLO');
+
+  // Press `t` — the single-key tool shortcut for the Text tool. With the
+  // editor out of edit mode, this should switch tools, NOT append "t" to
+  // the just-committed layer.
+  await page.keyboard.press('t');
+  await page.waitForTimeout(80);
+
+  const afterToolKey = await page.evaluate(() => {
+    const ui = (window as unknown as { __uiStore: { getState: () => { activeTool: string; textEditing: unknown } } }).__uiStore;
+    const editor = (window as unknown as { __editorStore: { getState: () => { document: { layers: Array<{ type: string; text?: string }> } } } }).__editorStore;
+    const lastTextLayer = [...editor.getState().document.layers]
+      .reverse()
+      .find((l) => typeof l.text === 'string');
+    return {
+      activeTool: ui.getState().activeTool,
+      committedText: lastTextLayer?.text ?? null,
+      textEditing: ui.getState().textEditing,
+    };
+  });
+  expect(afterToolKey.activeTool).toBe('text');
+  expect(afterToolKey.committedText).toBe('HELLO');
+  expect(afterToolKey.textEditing).toBeNull();
+
+  // Visual confirmation: the commit/cancel chips must NOT be visible after
+  // Tab. The TextActionButtons component renders only when textEditing is
+  // truthy, so an absent chip is the user-visible signal that Tab worked.
+  await expect(page.locator('button[aria-label="Commit text"]')).toHaveCount(0);
+  await expect(page.locator('button[aria-label="Cancel text"]')).toHaveCount(0);
+
+  await page.screenshot({ path: 'e2e/screenshots/bug-262-tab-commits-text.png' });
+});

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -88,8 +88,11 @@ export function useKeyboardShortcuts({
           return;
         }
 
-        // Shift+Enter commits text
-        if (e.key === 'Enter' && e.shiftKey) {
+        // Shift+Enter or Tab commits text. Tab also has to swallow the browser
+        // default (focus change) so the next single-key shortcut isn't captured
+        // by a newly-focused element, and so the textEditing state doesn't
+        // outlive the commit and route subsequent letters into the text buffer.
+        if ((e.key === 'Enter' && e.shiftKey) || e.key === 'Tab') {
           e.preventDefault();
           commitTextEditing();
           return;

--- a/src/tools/text/text-input.test.ts
+++ b/src/tools/text/text-input.test.ts
@@ -153,6 +153,14 @@ describe('processTextKey', () => {
     expect(processTextKey(state, 'Control', false)).toBeNull();
   });
 
+  it('returns null for Tab so the caller can treat it as a commit', () => {
+    // Issue #262: Tab is the user-facing "commit text" shortcut. The
+    // handler in useKeyboardShortcuts.ts intercepts Tab during text
+    // editing and calls commitTextEditing(); for that to be safe,
+    // processTextKey must NOT also try to insert "Tab" into the buffer.
+    expect(processTextKey(state, 'Tab', false)).toBeNull();
+  });
+
   it('ignores printable chars with meta key', () => {
     // Cmd+C should not insert 'c'
     expect(processTextKey(state, 'c', true)).toBeNull();


### PR DESCRIPTION
## Summary

- Pressing Tab to commit a text layer left the editor stuck in `textEditing` mode — the commit/cancel chips remained visible and the next single-key tool shortcut (`t`, `b`, `v`, `e`, …) was consumed by `processTextKey` and inserted into the text buffer. So `HELLO` + Tab + `t` ended up reading as `HELLOt` instead of switching to the Text tool.
- The keyboard handler in `useKeyboardShortcuts.ts` already treats Shift+Enter as a commit; this extends the same path to Tab so the commit fires (and `preventDefault` runs) before the next keystroke arrives.
- New e2e test (`e2e/bug-repro-262-text-tab-commit.spec.ts`) reproduces the scenario end-to-end (type → Tab → next-shortcut) and asserts the committed text equals `HELLO`, the next `t` switches tools, and the commit/cancel chips disappear.
- A unit test on `processTextKey` pins the contract that Tab returns null so the caller is free to interpret it as a commit without risk of double-processing.

## Test plan

- [x] `npx vitest run src/tools/text/text-input.test.ts` — 28/28 pass
- [x] e2e spec written to assert: editing buffer holds `HELLO` before Tab; `textEditing` clears and committed layer text equals `HELLO` after Tab; pressing `t` afterwards switches the tool to text without appending to the layer; `Commit text` / `Cancel text` buttons are not in the DOM after Tab
- [x] No new typecheck or lint errors introduced

Fixes #262

https://claude.ai/code/session_0156S1e5hvicrizQfyrSug5j

---
_Generated by [Claude Code](https://claude.ai/code/session_0156S1e5hvicrizQfyrSug5j)_