### PR TITLE
docs(features): add Spray tool, Levels, and missing modifier shortcuts

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,6 +47,14 @@
 - Pulls colors along the stroke direction, blending neighbouring pixels.
 - **Shift+click**: smudges along a straight line from the previous stroke endpoint
 
+### Spray
+- **Size**: 1 - 500 px
+- **Density**: 1 - 100 (number of dots emitted per dab)
+- **Opacity**: 1 - 100%
+- **Softness**: 0 - 100% (per-dot hardness falloff)
+- Shortcut: `J`
+- Holding the cursor still keeps emitting dots at ~6 Hz so paint accumulates over time, mimicking an airbrush. Dragging spreads dots along the path with automatic spacing scaled to brush size.
+
 ---
 
 ## Shape & Vector Tools
@@ -93,9 +101,6 @@
 ### Lasso (Freehand)
 - No configurable parameters
 
-### Polygonal Lasso
-- Click-to-place-points polygon selection
-
 ### Magnetic Lasso
 - **Width**: 1 - 40 px (perpendicular search radius from the cursor path)
 - **Contrast**: 1 - 100% (minimum edge strength to snap onto)
@@ -125,6 +130,8 @@
 - **Skew**: X and Y
 - **Corner manipulation**: 4-point distort/perspective
 - **Quick transforms**: flip horizontal, flip vertical, rotate 90 CW, rotate 90 CCW
+- **Shift+drag a rotation handle**: snaps rotation to 15° increments (the same snap kicks in automatically when grid + snap-to-grid are enabled)
+- **Shift+drag a corner handle**: constrains the scale to a uniform aspect ratio
 
 ---
 
@@ -207,6 +214,11 @@ Applied globally or per-group. All default to 0.
   `CurveEditor` (drag points, click to add, double-click or yank to remove).
   Runs as a single 256×1 RGBA LUT texture sampled in the GPU adjustments
   shader; identity curves bypass the lookup.
+- **Levels**: per-channel input/output remap (RGB master + R / G / B) with
+  Input Black, Input White, Gamma (0.01 – 10, log slider), Output Black,
+  and Output White controls. Master is applied first, then per-channel
+  levels. Compiled to a 256×1 LUT and shares the GPU adjustments path with
+  Curves; identity levels bypass the lookup.
 
 ---
 
@@ -308,9 +320,11 @@ Applied globally or per-group. All default to 0.
 - Rename
 - Align (left, center-h, right, top, center-v, bottom)
 - Add/remove/toggle mask
+- **Cmd/Ctrl+click a layer thumbnail**: loads that layer's alpha as a marquee selection (non-transparent pixels become the selection)
 
 ### Clipboard
 - Copy, cut, paste (respects selection)
+- **Cmd+Shift+C**: copy merged (composites all visible layers within the selection bounds before copying, so the clipboard contains a flattened RGBA snapshot rather than just the active layer)
 - Paste external image data
 
 ---


### PR DESCRIPTION
## Summary
Audit pass over FEATURES.md against the current toolset to make capability docs exhaustive.

- **Spray tool** — entirely missing from FEATURES.md. Documents size (1–500), density, opacity, softness, the `J` shortcut, and the time-based airbrush behavior.
- **Levels adjustment** — non-destructive levels (RGB master + R/G/B with Input Black/White, Gamma, Output Black/White) is shipped in the Adjustments panel but wasn't documented. Now sits alongside Curves.
- **Cmd/Ctrl+click on a layer thumbnail** — loads the layer's alpha as a marquee. Existing behavior, undocumented.
- **Cmd+Shift+C** — copy merged. Was wired up in the edit shortcuts but not surfaced in the feature list.
- **Transform** — spell out that Shift+drag a rotation handle snaps to 15° increments and Shift+drag a corner handle constrains aspect ratio (the existing entry only covered grid/guide snapping).
- **Polygonal Lasso** — removed. The only lasso tools in the registry are `lasso` (freehand) and `lasso-magnetic`; the polygonal entry was stale.

No code changes — docs only.

## Test plan
- [ ] Skim FEATURES.md to confirm Spray section reads cleanly and tool ranges match `tool-settings-store.ts`.
- [ ] Confirm Levels description matches `LevelsEditor.tsx` controls.
- [ ] Verify Cmd+click thumbnail and Cmd+Shift+C in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)