### PR TITLE
feat(transform): use cmd for rotation snap and scale constraint

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,6 +47,14 @@
 - Pulls colors along the stroke direction, blending neighbouring pixels.
 - **Shift+click**: smudges along a straight line from the previous stroke endpoint
 
+### Spray
+- **Size**: 1 - 500 px
+- **Density**: 1 - 100 (number of dots emitted per dab)
+- **Opacity**: 1 - 100%
+- **Softness**: 0 - 100% (per-dot hardness falloff)
+- Shortcut: `J`
+- Holding the cursor still keeps emitting dots at ~6 Hz so paint accumulates over time, mimicking an airbrush. Dragging spreads dots along the path with automatic spacing scaled to brush size.
+
 ---
 
 ## Shape & Vector Tools
@@ -93,9 +101,6 @@
 ### Lasso (Freehand)
 - No configurable parameters
 
-### Polygonal Lasso
-- Click-to-place-points polygon selection
-
 ### Magnetic Lasso
 - **Width**: 1 - 40 px (perpendicular search radius from the cursor path)
 - **Contrast**: 1 - 100% (minimum edge strength to snap onto)
@@ -125,6 +130,8 @@
 - **Skew**: X and Y
 - **Corner manipulation**: 4-point distort/perspective
 - **Quick transforms**: flip horizontal, flip vertical, rotate 90 CW, rotate 90 CCW
+- **Shift+drag a rotation handle**: snaps rotation to 15° increments (the same snap kicks in automatically when grid + snap-to-grid are enabled)
+- **Shift+drag a corner handle**: constrains the scale to a uniform aspect ratio
 
 ---
 
@@ -207,6 +214,11 @@ Applied globally or per-group. All default to 0.
   `CurveEditor` (drag points, click to add, double-click or yank to remove).
   Runs as a single 256×1 RGBA LUT texture sampled in the GPU adjustments
   shader; identity curves bypass the lookup.
+- **Levels**: per-channel input/output remap (RGB master + R / G / B) with
+  Input Black, Input White, Gamma (0.01 – 10, log slider), Output Black,
+  and Output White controls. Master is applied first, then per-channel
+  levels. Compiled to a 256×1 LUT and shares the GPU adjustments path with
+  Curves; identity levels bypass the lookup.
 
 ---
 
@@ -308,9 +320,11 @@ Applied globally or per-group. All default to 0.
 - Rename
 - Align (left, center-h, right, top, center-v, bottom)
 - Add/remove/toggle mask
+- **Cmd/Ctrl+click a layer thumbnail**: loads that layer's alpha as a marquee selection (non-transparent pixels become the selection)
 
 ### Clipboard
 - Copy, cut, paste (respects selection)
+- **Cmd+Shift+C**: copy merged (composites all visible layers within the selection bounds before copying, so the clipboard contains a flattened RGBA snapshot rather than just the active layer)
 - Paste external image data
 
 ---

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -14,31 +14,38 @@
 - **Custom brush tips**: grayscale bitmap or procedural circle
 - **ABR import**: Adobe Brush file support
 - **Built-in presets**: Hard Round, Soft Round, Airbrush, Square, Cross Hatch, Diamond, Star, Slash, Chalk, Spray, Leaf
+- **Shift+click**: draws a straight line from the previous stroke endpoint to the click point
+- **Hold-to-smooth**: pause the cursor mid-stroke and the recorded freehand path is auto-smoothed and re-rasterized in place (undo restores the freehand version first, then the pre-stroke state)
 
 ### Pencil
 - **Size**: 1 - 100 px
 - **Symmetry**: horizontal, vertical, or both
 - Pixel-perfect Bresenham lines (no anti-aliasing)
+- **Shift+click**: draws a straight pixel-perfect line from the previous stroke endpoint
 
 ### Eraser
 - **Size**: 1 - 200 px
 - **Opacity**: 1 - 100%
 - **Hardness**: 0 - 100% (internal)
+- **Shift+click**: erases a straight line from the previous stroke endpoint
 
 ### Dodge / Burn
 - **Mode**: dodge or burn
 - **Exposure**: 1 - 100%
 - **Size**: 1 - 200 px
+- **Shift+click**: applies dodge/burn along a straight line from the previous stroke endpoint
 
 ### Clone Stamp
 - **Size**: 1 - 200 px
-- Alt/Cmd+click to set source point
+- **Alt/Cmd+click**: set the source sample point
+- **Shift+click**: stamps along a straight line from the previous stroke endpoint, preserving source offset
 
 ### Smudge
 - **Size**: 1 - 200 px
 - **Strength**: 0 - 100% (how far pixels are pulled along the stroke)
 - Shortcut: `R`
 - Pulls colors along the stroke direction, blending neighbouring pixels.
+- **Shift+click**: smudges along a straight line from the previous stroke endpoint
 
 ---
 
@@ -61,6 +68,7 @@
 - Close path, split segment, convert anchor
 - Stroke path to pixels
 - Convert path to selection
+- **Cmd/Meta+click an anchor**: toggles between corner (no handles) and smooth spline (double-click does the same)
 
 ### Text Tool
 - **Font size**: 1 - 500
@@ -128,6 +136,8 @@
 - Snap to grid
 - Snap to guides
 - **Align**: left, center-h, right, top, center-v, bottom
+- **Alt/Option+drag**: with no active selection, duplicates the active layer before moving; with an active marquee, leaves the original pixels behind and moves a floating copy
+- **Shift+drag (transform handles)**: constrains aspect ratio when scaling, and forces grid/guide snapping during the transform
 
 ### Eyedropper
 - **Sample size**: point, 3x3, 5x5
@@ -140,6 +150,7 @@
 - **Type**: linear, radial
 - **Stops**: multiple color stops with position (0-1)
 - **Reverse**: on/off
+- **Cmd/Meta+drag**: snaps the gradient angle to 15° increments while dragging
 
 ### Crop
 - Interactive drag to define crop rectangle
@@ -318,6 +329,8 @@ Applied globally or per-group. All default to 0.
 - **Zoom**: 0.01x - 64x
 - **Pan**: unlimited
 - **Fit to view**: auto-zoom with padding
+- **Space+drag** or **middle-click drag**: temporarily pan from any tool
+- **Cmd/Ctrl+scroll**: zoom centered on the cursor; plain scroll pans
 
 ### Grid
 - **Show grid**: on/off
@@ -339,19 +352,21 @@ Applied globally or per-group. All default to 0.
 - **Sidebar collapsed**: on/off
 - **Panel visibility**: togglable per panel (color, layers, etc.)
 - **Mask edit mode**: on/off
+- **Draggable modals & panels**: filter dialogs, pattern fill, layer effects, adjustments, and the reference image drawer can be repositioned by dragging the header bar (cursor: grab on hover; content interactions are not hijacked)
+- **Filter / pattern preview overlay**: when live preview is enabled the dim backdrop is removed and pointer-events on the overlay are disabled so the canvas is fully visible while the modal stays interactive
 
 ---
 
-## Reference Image Panel
+## Reference Image Drawer
 
-- Load reference images via file picker or drag-and-drop
-- **Multiple images**: thumbnail strip with add/remove, click to switch
-- **Zoom**: mouse wheel zoom with cursor-centered scaling (0.05x – 20x)
-- **Pan**: click and drag to reposition within the preview
-- **Opacity**: 1 – 100% slider to fade the reference image
-- **Flip horizontal / vertical**: mirror the reference for composition checks
-- **Reset view**: fit image to panel width
-- Collapse state persisted to localStorage
+A floating, draggable, resizable modal (toggled from the toolbar) for keeping reference images alongside the canvas.
+
+- Load reference images via file picker or drag-and-drop onto the drawer
+- **Multiple images**: thumbnail strip with add/remove, click to switch between references
+- **Zoom**: mouse-wheel zoom with cursor-centered scaling (0.05x – 20x)
+- **Pan**: click and drag inside the preview to reposition
+- **Per-image view state**: zoom, pan, opacity, and horizontal/vertical flip are tracked independently for each loaded image
+- **Drag the header bar** to reposition the drawer; **bottom-right resize handle** to resize
 - Images are pure client-side blob URLs — no upload, no backend
 
 ---

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -222,14 +222,14 @@ function handleSelectionTransformDown(
 export function handleTransformMove(
   state: InteractionState,
   canvasPos: Point,
-  shiftKey: boolean,
+  metaKey: boolean,
 ): void {
   if (!state.transformHandle || !state.transformStartState || !state.startPoint) {
     return;
   }
 
   if (state.selectionOnlyTransform) {
-    handleSelectionTransformMove(state, canvasPos, shiftKey);
+    handleSelectionTransformMove(state, canvasPos, metaKey);
     return;
   }
 
@@ -264,7 +264,7 @@ export function handleTransformMove(
       state.startPoint,
       snappedInput,
       startState,
-      shiftKey,
+      metaKey,
     );
     newTransform = {
       ...startState,
@@ -277,7 +277,7 @@ export function handleTransformMove(
     const currentAngle = computeRotation(canvasPos, startState);
     const newRotation = currentAngle - state.transformStartAngle;
     const uiState = useUIStore.getState();
-    const shouldSnap = shiftKey || (uiState.showGrid && uiState.snapToGrid);
+    const shouldSnap = metaKey || (uiState.showGrid && uiState.snapToGrid);
     const snappedRotation = shouldSnap
       ? Math.round(newRotation / (Math.PI / 12)) * (Math.PI / 12)
       : newRotation;
@@ -322,7 +322,7 @@ export function handleTransformMove(
 function handleSelectionTransformMove(
   state: InteractionState,
   canvasPos: Point,
-  shiftKey: boolean,
+  metaKey: boolean,
 ): void {
   const handle = state.transformHandle!;
   const startState = state.transformStartState!;
@@ -333,7 +333,7 @@ function handleSelectionTransformMove(
     ? { x: Math.round(canvasPos.x / uiSnap.gridSize) * uiSnap.gridSize, y: Math.round(canvasPos.y / uiSnap.gridSize) * uiSnap.gridSize }
     : canvasPos;
 
-  const result = computeScale(handle, state.startPoint!, snappedInput, startState, shiftKey);
+  const result = computeScale(handle, state.startPoint!, snappedInput, startState, metaKey);
   const newTransform: TransformState = {
     ...startState,
     scaleX: result.scaleX,

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -330,7 +330,7 @@ export function useCanvasInteraction(
 
       // Transform handle drag (not tool-routed)
       if (state.transformHandle && state.transformStartState && state.startPoint) {
-        handleTransformMove(state, canvasPos, e.shiftKey);
+        handleTransformMove(state, canvasPos, e.metaKey);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Changed rotation snap shortcut from Shift to Cmd (meta) during transform with the move tool
- Changed scale constraint (aspect ratio lock) from Shift to Cmd as well
- Both rotation snapping and proportional scaling now use the same Cmd modifier
- Renamed internal parameter from `shiftKey`/`snapKey` to `metaKey` for clarity