### PR TITLE
feat(text): add text-on-path rendering along Bezier curves

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -87,6 +87,7 @@
 - **Line height**: configurable
 - **Letter spacing**: configurable
 - **Mode**: point text (no wrap) or area text (fixed width with wrapping)
+- **Text on path**: bind text to a stored Bézier path so glyphs follow the curve. Select a path from the Path dropdown in the options bar; each glyph is positioned and rotated along the arc-length of the path. Switching back to "None" restores the text to its original position. Live editing (typing) updates the path text in real time.
 
 ---
 

--- a/e2e/text-on-path.spec.ts
+++ b/e2e/text-on-path.spec.ts
@@ -1,0 +1,475 @@
+/**
+ * E2E tests for the text-on-path feature.
+ *
+ * Verifies that text layers with a pathId render their glyphs along the
+ * associated Bezier path rather than in a straight horizontal line.
+ */
+
+import { test, expect, type Page } from './fixtures';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCREENSHOT_DIR = path.resolve(__dirname, 'screenshots/text-on-path');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForStore(page: Page) {
+  await page.waitForFunction(
+    () => !!(window as unknown as Record<string, unknown>).__editorStore,
+    undefined,
+    { timeout: 15000 },
+  );
+}
+
+async function createDocument(page: Page, w = 400, h = 400, transparent = true) {
+  await page.evaluate(
+    ({ w, h, t }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { createDocument: (w: number, h: number, t: boolean) => void };
+      };
+      store.getState().createDocument(w, h, t);
+    },
+    { w, h, t: transparent },
+  );
+  await page.waitForFunction(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { document: { layers: unknown[] }; undoStack: unknown[] };
+    } | undefined;
+    if (!store) return false;
+    const s = store.getState();
+    return s.document.layers.length > 0 && s.undoStack.length > 0;
+  });
+}
+
+async function docToScreen(page: Page, docX: number, docY: number) {
+  return page.evaluate(
+    ({ docX, docY }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number };
+          viewport: { zoom: number; panX: number; panY: number };
+        };
+      };
+      const state = store.getState();
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      if (!container) return { x: 0, y: 0 };
+      const rect = container.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      return {
+        x: rect.left + (docX - state.document.width / 2) * state.viewport.zoom + state.viewport.panX + cx,
+        y: rect.top + (docY - state.document.height / 2) * state.viewport.zoom + state.viewport.panY + cy,
+      };
+    },
+    { docX, docY },
+  );
+}
+
+async function clickAtDoc(page: Page, docX: number, docY: number) {
+  const pos = await docToScreen(page, docX, docY);
+  await page.mouse.click(pos.x, pos.y);
+  await page.waitForTimeout(80);
+}
+
+/** Inject a stored path directly via the store (no pen-tool UI required). */
+async function injectPath(
+  page: Page,
+  anchors: Array<{
+    point: { x: number; y: number };
+    handleIn: { x: number; y: number } | null;
+    handleOut: { x: number; y: number } | null;
+  }>,
+  closed: boolean,
+) {
+  return page.evaluate(
+    ({ anchors, closed }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          addPath: (anchors: unknown, closed: boolean) => void;
+          paths: Array<{ id: string }>;
+        };
+      };
+      store.getState().addPath(anchors, closed);
+      const paths = store.getState().paths;
+      return paths[paths.length - 1]!.id;
+    },
+    { anchors, closed },
+  );
+}
+
+/** Create a text layer on a path via the store. */
+async function createTextLayerOnPath(
+  page: Page,
+  text: string,
+  pathId: string,
+  x = 50,
+  y = 50,
+) {
+  return page.evaluate(
+    ({ text, pathId, x, y }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; type: string }> };
+          addTextLayer: (layer: unknown) => void;
+          updateTextLayerProperties: (id: string, props: unknown) => void;
+          notifyRender: () => void;
+        };
+      };
+      const state = store.getState();
+      const id = crypto.randomUUID();
+      state.addTextLayer({
+        id,
+        name: 'Path Text',
+        type: 'text',
+        visible: true,
+        locked: false,
+        opacity: 1,
+        blendMode: 'normal',
+        x,
+        y,
+        clipToBelow: false,
+        effects: {
+          stroke: { enabled: false, color: { r: 0, g: 0, b: 0, a: 1 }, width: 2, position: 'outside' },
+          dropShadow: { enabled: false, color: { r: 0, g: 0, b: 0, a: 0.75 }, offsetX: 4, offsetY: 4, blur: 8, spread: 0, opacity: 0.75 },
+          outerGlow: { enabled: false, color: { r: 255, g: 255, b: 100, a: 1 }, size: 10, spread: 0, opacity: 0.75 },
+          innerGlow: { enabled: false, color: { r: 255, g: 255, b: 100, a: 1 }, size: 10, spread: 0, opacity: 0.75 },
+          colorOverlay: { enabled: false, color: { r: 255, g: 0, b: 0, a: 1 } },
+        },
+        mask: null,
+        text,
+        fontFamily: 'Inter',
+        fontSize: 20,
+        fontWeight: 400,
+        fontStyle: 'normal',
+        color: { r: 0, g: 0, b: 0, a: 1 },
+        lineHeight: 1.4,
+        letterSpacing: 0,
+        textAlign: 'left',
+        width: null,
+        pathId,
+      });
+      state.notifyRender();
+      return id;
+    },
+    { text, pathId, x, y },
+  );
+}
+
+async function readLayerPixels(page: Page, layerId: string) {
+  return page.evaluate(async (id) => {
+    const fn = (window as unknown as Record<string, unknown>).__readLayerPixels as
+      (id?: string) => Promise<{ width: number; height: number; pixels: number[] } | null>;
+    return fn(id);
+  }, layerId);
+}
+
+async function pushHistory(page: Page) {
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { pushHistory: (label?: string) => void };
+    };
+    store.getState().pushHistory();
+  });
+  await page.waitForTimeout(100);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to scan for non-transparent pixels in a horizontal band
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of distinct Y coordinates (in doc space) that have at least
+ * one opaque pixel in the column range [x0, x1].
+ *
+ * We read from the composited GPU buffer which reflects the full rendered
+ * scene (including the path-text layer pixels).
+ */
+async function opaqueRowsInBand(
+  page: Page,
+  docX0: number,
+  docX1: number,
+  docY0: number,
+  docY1: number,
+): Promise<number[]> {
+  return page.evaluate(
+    async ({ x0, x1, y0, y1 }) => {
+      const fn = (window as unknown as Record<string, unknown>).__readCompositedPixels as
+        () => Promise<{ width: number; height: number; pixels: number[] }>;
+      const frame = await fn();
+      if (!frame) return [];
+      const { width, height, pixels } = frame;
+      const rows = new Set<number>();
+      for (let y = y0; y <= y1 && y < height; y++) {
+        // Buffer is bottom-up; flip y
+        const flippedY = height - 1 - y;
+        for (let x = x0; x <= x1 && x < width; x++) {
+          const idx = (flippedY * width + x) * 4;
+          const alpha = pixels[idx + 3] ?? 0;
+          if (alpha > 10) {
+            rows.add(y);
+            break;
+          }
+        }
+      }
+      return Array.from(rows);
+    },
+    { x0: docX0, x1: docX1, y0: docY0, y1: docY1 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Text on Path', () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(isMobile, 'text-on-path requires desktop sidebar');
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 400, true);
+    await page.waitForSelector('[data-testid="canvas-container"]');
+  });
+
+  test('text layer with pathId renders pixels along a curved path', async ({ page }) => {
+    // Create a diagonal path from (50, 200) to (350, 200) going through a
+    // curve peak at (200, 50) — effectively an arc that goes upward.
+    const pathId = await injectPath(
+      page,
+      [
+        {
+          point: { x: 50, y: 200 },
+          handleIn: null,
+          handleOut: { x: 100, y: 50 },
+        },
+        {
+          point: { x: 350, y: 200 },
+          handleIn: { x: 300, y: 50 },
+          handleOut: null,
+        },
+      ],
+      false,
+    );
+
+    const layerId = await createTextLayerOnPath(page, 'Hello Path', pathId, 0, 0);
+    await page.waitForTimeout(300); // allow render frame to pick up the layer
+
+    // Force a history push so the GPU texture is settled
+    await pushHistory(page);
+
+    const result = await readLayerPixels(page, layerId);
+    expect(result).not.toBeNull();
+    expect(result!.width).toBeGreaterThan(0);
+
+    // Count pixels with non-zero alpha
+    const opaqueCount = result!.pixels.filter((v, i) => i % 4 === 3 && v > 10).length;
+    expect(opaqueCount).toBeGreaterThan(0);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, '01-text-on-curved-path.png'),
+    });
+  });
+
+  test('text layer without pathId renders as normal straight text', async ({ page }) => {
+    // Create a path but do NOT assign it to the text layer
+    await injectPath(
+      page,
+      [
+        { point: { x: 50, y: 100 }, handleIn: null, handleOut: null },
+        { point: { x: 350, y: 100 }, handleIn: null, handleOut: null },
+      ],
+      false,
+    );
+
+    // Normal text layer — no pathId
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          addTextLayer: (layer: unknown) => void;
+          notifyRender: () => void;
+          pushHistory: (label?: string) => void;
+        };
+      };
+      const state = store.getState();
+      const id = crypto.randomUUID();
+      state.addTextLayer({
+        id,
+        name: 'Normal Text',
+        type: 'text',
+        visible: true,
+        locked: false,
+        opacity: 1,
+        blendMode: 'normal',
+        x: 100,
+        y: 200,
+        clipToBelow: false,
+        effects: {
+          stroke: { enabled: false, color: { r: 0, g: 0, b: 0, a: 1 }, width: 2, position: 'outside' },
+          dropShadow: { enabled: false, color: { r: 0, g: 0, b: 0, a: 0.75 }, offsetX: 4, offsetY: 4, blur: 8, spread: 0, opacity: 0.75 },
+          outerGlow: { enabled: false, color: { r: 255, g: 255, b: 100, a: 1 }, size: 10, spread: 0, opacity: 0.75 },
+          innerGlow: { enabled: false, color: { r: 255, g: 255, b: 100, a: 1 }, size: 10, spread: 0, opacity: 0.75 },
+          colorOverlay: { enabled: false, color: { r: 255, g: 0, b: 0, a: 1 } },
+        },
+        mask: null,
+        text: 'Hello',
+        fontFamily: 'Inter',
+        fontSize: 20,
+        fontWeight: 400,
+        fontStyle: 'normal',
+        color: { r: 0, g: 0, b: 0, a: 1 },
+        lineHeight: 1.4,
+        letterSpacing: 0,
+        textAlign: 'left',
+        width: null,
+        // no pathId
+      });
+      state.notifyRender();
+      return id;
+    });
+
+    await page.waitForTimeout(300);
+
+    // Verify the layer has no pathId set
+    const layerPathId = await page.evaluate((id) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; type: string; pathId?: string }> };
+        };
+      };
+      const layer = store.getState().document.layers.find((l) => l.id === id);
+      return layer?.type === 'text' ? (layer as { pathId?: string }).pathId : null;
+    }, layerId);
+
+    expect(layerPathId).toBeUndefined();
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, '02-normal-text-no-path.png'),
+    });
+  });
+
+  test('path text option dropdown appears in TextOptions when paths exist', async ({ page }) => {
+    // Create a stored path
+    await injectPath(
+      page,
+      [
+        { point: { x: 50, y: 100 }, handleIn: null, handleOut: null },
+        { point: { x: 350, y: 100 }, handleIn: null, handleOut: null },
+      ],
+      false,
+    );
+
+    // Switch to text tool so TextOptions renders
+    await page.keyboard.press('t');
+    await page.waitForTimeout(200);
+
+    // The "Path" label and dropdown should appear since paths exist
+    const pathLabel = page.locator('label', { hasText: 'Path' });
+    await expect(pathLabel).toBeVisible();
+
+    const pathSelect = page.locator('select[aria-label="Text path"]');
+    await expect(pathSelect).toBeVisible();
+
+    // The dropdown should include "None" option and the created path
+    const optionCount = await pathSelect.locator('option').count();
+    expect(optionCount).toBeGreaterThanOrEqual(2); // None + at least one path
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, '03-text-options-path-dropdown.png'),
+    });
+  });
+
+  test('assigning a path via the dropdown updates the text layer pathId', async ({ page }) => {
+    // Create a path then a text layer via the text tool
+    const pathId = await injectPath(
+      page,
+      [
+        { point: { x: 50, y: 200 }, handleIn: null, handleOut: null },
+        { point: { x: 350, y: 200 }, handleIn: null, handleOut: null },
+      ],
+      false,
+    );
+
+    // Select the text tool and click to create a text layer
+    await page.keyboard.press('t');
+    await page.waitForTimeout(100);
+    await clickAtDoc(page, 200, 200);
+    await page.keyboard.type('On Path');
+    await page.keyboard.press('Shift+Enter'); // commit
+    await page.waitForTimeout(200);
+
+    // Get the committed layer id
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { layers: Array<{ id: string; type: string }> } };
+      };
+      const layers = store.getState().document.layers;
+      const tl = layers.find((l) => l.type === 'text');
+      return tl?.id ?? null;
+    });
+    expect(layerId).not.toBeNull();
+
+    // Select the layer and switch to text tool so the options bar shows
+    await page.keyboard.press('t');
+    await page.waitForTimeout(100);
+
+    // The path dropdown should be present
+    const pathSelect = page.locator('select[aria-label="Text path"]');
+    await expect(pathSelect).toBeVisible();
+
+    // Select the first path (not "None")
+    await pathSelect.selectOption(pathId);
+    await page.waitForTimeout(200);
+
+    // Verify the layer has the pathId set
+    const actualPathId = await page.evaluate((id) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: {
+            layers: Array<{ id: string; type: string; pathId?: string }>;
+          };
+        };
+      };
+      const layer = store.getState().document.layers.find((l) => l.id === id);
+      return layer?.type === 'text' ? (layer as { pathId?: string }).pathId ?? null : null;
+    }, layerId!);
+
+    expect(actualPathId).toBe(pathId);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, '04-text-layer-path-id-assigned.png'),
+    });
+  });
+
+  test('path text with diagonal path has pixels at multiple Y positions (not a straight line)', async ({
+    page,
+  }) => {
+    // A diagonal path from top-left to bottom-right forces glyphs to spread
+    // vertically — proves text is NOT rendering on a flat horizontal baseline.
+    const pathId = await injectPath(
+      page,
+      [
+        { point: { x: 50, y: 50 }, handleIn: null, handleOut: null },
+        { point: { x: 350, y: 350 }, handleIn: null, handleOut: null },
+      ],
+      false,
+    );
+
+    await createTextLayerOnPath(page, 'ABCDE', pathId, 0, 0);
+    await page.waitForTimeout(400);
+
+    // Read composited pixels and find the unique Y rows where opaque pixels appear
+    // in the diagonal region (roughly 50..350 on both axes).
+    const rows = await opaqueRowsInBand(page, 50, 350, 50, 350);
+
+    // If text were rendering in a horizontal line, all glyphs would share the
+    // same Y row. A diagonal path should produce glyphs at many distinct Y values.
+    expect(rows.length).toBeGreaterThan(3);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, '05-diagonal-path-text-spread.png'),
+    });
+  });
+});

--- a/src/app/OptionsBar/tool-options/TextOptions.module.css
+++ b/src/app/OptionsBar/tool-options/TextOptions.module.css
@@ -1,3 +1,9 @@
+.decorationGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
 .decorationBtn {
   display: flex;
   align-items: center;

--- a/src/app/OptionsBar/tool-options/TextOptions.tsx
+++ b/src/app/OptionsBar/tool-options/TextOptions.tsx
@@ -6,7 +6,9 @@ import { Slider } from '../../../components/Slider/Slider';
 import { FontPicker } from '../../../components/FontPicker/FontPicker';
 import { fontsByFamily } from '../../../utils/font-catalog';
 import { extractFamilyName, loadGoogleFont, loadFontBinaryToEngine } from '../../../utils/font-loader';
-import type { FontStyle, TextAlign } from '../../../types';
+import { getEngine } from '../../../engine-wasm/engine-state';
+import { rerenderCommittedTextLayer, invalidatePathTextCache } from '../../../engine-wasm/engine-sync';
+import type { TextLayer, FontStyle, TextAlign } from '../../../types';
 import styles from '../OptionsBar.module.css';
 import decorationStyles from './TextOptions.module.css';
 
@@ -59,11 +61,36 @@ export function TextOptions() {
 
   const handlePathChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      if (!editingLayerId) return;
+      if (!editingLayerId || !editingLayer || editingLayer.type !== 'text') return;
       const val = e.target.value;
-      updateTextLayerProperties(editingLayerId, { pathId: val || undefined });
+      if (val) {
+        updateTextLayerProperties(editingLayerId, {
+          pathId: val,
+          prePathX: editingLayer.prePathX ?? editingLayer.x,
+          prePathY: editingLayer.prePathY ?? editingLayer.y,
+        });
+      } else {
+        const restoreX = editingLayer.prePathX ?? editingLayer.x;
+        const restoreY = editingLayer.prePathY ?? editingLayer.y;
+        invalidatePathTextCache(editingLayerId);
+        updateTextLayerProperties(editingLayerId, {
+          pathId: undefined,
+          prePathX: undefined,
+          prePathY: undefined,
+          x: restoreX,
+          y: restoreY,
+        });
+        const engine = getEngine();
+        if (engine) {
+          const restored = { ...editingLayer, x: restoreX, y: restoreY, pathId: undefined } as TextLayer;
+          const pos = rerenderCommittedTextLayer(engine, restored);
+          if (pos) {
+            updateTextLayerProperties(editingLayerId, { x: pos.x, y: pos.y });
+          }
+        }
+      }
     },
-    [editingLayerId, updateTextLayerProperties],
+    [editingLayerId, editingLayer, updateTextLayerProperties],
   );
 
   const handleFontChange = useCallback(

--- a/src/app/OptionsBar/tool-options/TextOptions.tsx
+++ b/src/app/OptionsBar/tool-options/TextOptions.tsx
@@ -164,24 +164,26 @@ export function TextOptions() {
         <option value="right">Right</option>
         <option value="justify">Justify</option>
       </select>
-      <button
-        className={`${decorationStyles.decorationBtn} ${textUnderline ? decorationStyles.decorationBtnActive : ''}`}
-        onClick={() => setTextUnderline(!textUnderline)}
-        aria-label="Toggle underline"
-        aria-pressed={textUnderline}
-        title="Underline"
-      >
-        <span className={decorationStyles.underlineIcon}>U</span>
-      </button>
-      <button
-        className={`${decorationStyles.decorationBtn} ${textStrikethrough ? decorationStyles.decorationBtnActive : ''}`}
-        onClick={() => setTextStrikethrough(!textStrikethrough)}
-        aria-label="Toggle strikethrough"
-        aria-pressed={textStrikethrough}
-        title="Strikethrough"
-      >
-        <span className={decorationStyles.strikethroughIcon}>S</span>
-      </button>
+      <div className={decorationStyles.decorationGroup}>
+        <button
+          className={`${decorationStyles.decorationBtn} ${textUnderline ? decorationStyles.decorationBtnActive : ''}`}
+          onClick={() => setTextUnderline(!textUnderline)}
+          aria-label="Toggle underline"
+          aria-pressed={textUnderline}
+          title="Underline"
+        >
+          <span className={decorationStyles.underlineIcon}>U</span>
+        </button>
+        <button
+          className={`${decorationStyles.decorationBtn} ${textStrikethrough ? decorationStyles.decorationBtnActive : ''}`}
+          onClick={() => setTextStrikethrough(!textStrikethrough)}
+          aria-label="Toggle strikethrough"
+          aria-pressed={textStrikethrough}
+          title="Strikethrough"
+        >
+          <span className={decorationStyles.strikethroughIcon}>S</span>
+        </button>
+      </div>
       {paths.length > 0 && (
         <>
           <label className={styles.label} id="text-path-label">Path</label>

--- a/src/app/OptionsBar/tool-options/TextOptions.tsx
+++ b/src/app/OptionsBar/tool-options/TextOptions.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useToolSettingsStore } from '../../tool-settings-store';
+import { useEditorStore } from '../../editor-store';
+import { useUIStore } from '../../ui-store';
 import { Slider } from '../../../components/Slider/Slider';
 import { FontPicker } from '../../../components/FontPicker/FontPicker';
 import { fontsByFamily } from '../../../utils/font-catalog';
@@ -43,6 +45,26 @@ export function TextOptions() {
   }, [textFontFamily]);
 
   const availableWeights = fontEntry?.weights ?? [400, 700];
+
+  // Path-on-text: the currently editing / active text layer + available paths
+  const textEditing = useUIStore((s) => s.textEditing);
+  const paths = useEditorStore((s) => s.paths);
+  const updateTextLayerProperties = useEditorStore((s) => s.updateTextLayerProperties);
+  const activeLayerId = useEditorStore((s) => s.document.activeLayerId);
+  const layers = useEditorStore((s) => s.document.layers);
+
+  const editingLayerId = textEditing?.layerId ?? activeLayerId;
+  const editingLayer = layers.find((l) => l.id === editingLayerId && l.type === 'text');
+  const currentPathId = editingLayer?.type === 'text' ? (editingLayer.pathId ?? '') : '';
+
+  const handlePathChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      if (!editingLayerId) return;
+      const val = e.target.value;
+      updateTextLayerProperties(editingLayerId, { pathId: val || undefined });
+    },
+    [editingLayerId, updateTextLayerProperties],
+  );
 
   const handleFontChange = useCallback(
     (value: string) => {
@@ -133,6 +155,23 @@ export function TextOptions() {
       >
         <span className={decorationStyles.strikethroughIcon}>S</span>
       </button>
+      {paths.length > 0 && (
+        <>
+          <label className={styles.label} id="text-path-label">Path</label>
+          <select
+            className={styles.select}
+            value={currentPathId}
+            onChange={handlePathChange}
+            aria-labelledby="text-path-label"
+            aria-label="Text path"
+          >
+            <option value="">None</option>
+            {paths.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+        </>
+      )}
     </>
   );
 }

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -154,32 +154,45 @@ function renderFrameGpu(
   // is created before syncTextLayers tries to fill or upload pixels into it.
   syncLayers(engine, layers, doc.layerOrder, dirtyLayerIds);
 
+  // Check if the currently-editing text layer is bound to a path.
+  // If so, skip syncTextLayers (which renders normal horizontal text) and
+  // let syncPathTextLayers handle it instead.
+  const editingLayerIsPathText = textEditing
+    && layers.some((l) => l.id === textEditing.layerId && l.type === 'text' && (l as import('../types').TextLayer).pathId);
+
   // Live-update text layer pixels during editing via the WASM engine (swash software rasterizer).
-  syncTextLayers(
-    engine,
-    textEditing,
-    toolState.textFontSize,
-    toolState.textFontFamily,
-    toolState.textFontWeight,
-    toolState.textFontStyle,
-    toolState.textAlign,
-    toolState.foregroundColor,
-    toolState.textUnderline,
-    toolState.textStrikethrough,
-    (layerId, x, y) => {
-      const layer = layers.find((l) => l.id === layerId);
-      if (layer && (layer.x !== x || layer.y !== y)) {
-        editorState.updateTextLayerProperties(layerId, { x, y });
-      }
-    },
-  );
+  if (!editingLayerIsPathText) {
+    syncTextLayers(
+      engine,
+      textEditing,
+      toolState.textFontSize,
+      toolState.textFontFamily,
+      toolState.textFontWeight,
+      toolState.textFontStyle,
+      toolState.textAlign,
+      toolState.foregroundColor,
+      toolState.textUnderline,
+      toolState.textStrikethrough,
+      (layerId, x, y) => {
+        const layer = layers.find((l) => l.id === layerId);
+        if (layer && (layer.x !== x || layer.y !== y)) {
+          editorState.updateTextLayerProperties(layerId, { x, y });
+        }
+      },
+    );
+  }
 
   // Render path-text layers (TextLayer.pathId set) using Canvas2D composition.
   const textLayersWithPath = layers.filter(
     (l): l is import('../types').TextLayer => l.type === 'text' && !!(l as import('../types').TextLayer).pathId,
   );
   if (textLayersWithPath.length > 0) {
-    syncPathTextLayers(engine, textLayersWithPath, editorState.paths, doc.width, doc.height);
+    syncPathTextLayers(engine, textLayersWithPath, editorState.paths, doc.width, doc.height, textEditing);
+    for (const tl of textLayersWithPath) {
+      if (tl.x !== 0 || tl.y !== 0) {
+        editorState.updateTextLayerProperties(tl.id, { x: 0, y: 0 });
+      }
+    }
   }
 
   syncSelection(engine, selection);

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -19,6 +19,7 @@ import {
   syncMaskEditMode,
   syncBrushTip,
   syncTextLayers,
+  syncPathTextLayers,
   renderEngine,
   markAllLayersDirty,
 } from '../engine-wasm/engine-sync';
@@ -172,6 +173,15 @@ function renderFrameGpu(
       }
     },
   );
+
+  // Render path-text layers (TextLayer.pathId set) using Canvas2D composition.
+  const textLayersWithPath = layers.filter(
+    (l): l is import('../types').TextLayer => l.type === 'text' && !!(l as import('../types').TextLayer).pathId,
+  );
+  if (textLayersWithPath.length > 0) {
+    syncPathTextLayers(engine, textLayersWithPath, editorState.paths, doc.width, doc.height);
+  }
+
   syncSelection(engine, selection);
   syncGrid(engine, showGrid, gridSize);
   syncRulers(engine, showRulers);

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -262,7 +262,7 @@ function renderFrameGpu(
         renderTextHoverBounds(overlayCtx, hoveredText, viewport.zoom, texW, texH);
       }
     }
-    if (textEditing) {
+    if (textEditing && !editingLayerIsPathText) {
       const ts = toolState;
       const glyphPositions = Array.from(getGlyphPositions(engine, textEditing.layerId));
       renderTextEditOverlay(overlayCtx, textEditing, {

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -70,6 +70,9 @@ import type { PathAnchor, TextEditingState } from '../app/ui-store';
 import type { SelectionData } from '../app/store/types';
 import type { BrushTipData } from '../types/brush';
 import type { Color } from '../types';
+import type { TextLayer } from '../types/layers';
+import type { StoredPath } from '../types/paths';
+import { renderTextOnPath } from '../tools/text/render-text-on-path';
 import { getTracked } from './sync-state';
 import { syncLayers } from './sync-layers';
 
@@ -386,6 +389,61 @@ export function flushLayerSync(state: {
   const engine = getEngine();
   if (!engine) return;
   syncLayers(engine, state.document.layers, state.document.layerOrder, state.dirtyLayerIds);
+}
+
+/**
+ * Re-render path-text layers (TextLayer.pathId is set) using Canvas2D composition.
+ * Called each frame; only uploads when the layer's content key has changed
+ * (text, font, color, or the path's anchors).
+ */
+export function syncPathTextLayers(
+  engine: Engine,
+  layers: readonly TextLayer[],
+  paths: readonly StoredPath[],
+  docWidth: number,
+  docHeight: number,
+): void {
+  const tracked = getTracked(engine);
+  if (!tracked.pathTextKeys) {
+    tracked.pathTextKeys = new Map<string, string>();
+  }
+
+  for (const layer of layers) {
+    if (!layer.pathId) continue;
+
+    const path = paths.find((p) => p.id === layer.pathId);
+    if (!path) continue;
+
+    // Build a cheap cache key from layer content + path anchors
+    const anchorSummary = path.anchors.map((a) => `${a.point.x},${a.point.y}`).join('|');
+    const key = [
+      layer.text,
+      layer.fontFamily,
+      layer.fontSize,
+      layer.fontWeight,
+      layer.fontStyle,
+      layer.color.r,
+      layer.color.g,
+      layer.color.b,
+      layer.color.a,
+      layer.letterSpacing,
+      path.closed,
+      anchorSummary,
+      docWidth,
+      docHeight,
+    ].join('\0');
+
+    if (tracked.pathTextKeys.get(layer.id) === key) continue;
+
+    const result = renderTextOnPath(layer, path.anchors, path.closed, docWidth, docHeight);
+    if (result) {
+      uploadLayerPixels(engine, layer.id, result.pixels, result.width, result.height, result.x, result.y);
+    } else {
+      // Empty result — clear the layer texture
+      uploadLayerPixels(engine, layer.id, new Uint8Array(4), 1, 1, 0, 0);
+    }
+    tracked.pathTextKeys.set(layer.id, key);
+  }
 }
 
 /**

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -79,6 +79,13 @@ import { syncLayers } from './sync-layers';
 export { resetTrackedState, markPixelDataSynced } from './sync-state';
 export { syncLayers } from './sync-layers';
 
+export function invalidatePathTextCache(layerId: string): void {
+  const engine = getEngine();
+  if (!engine) return;
+  const tracked = getTracked(engine);
+  tracked.pathTextKeys?.delete(layerId);
+}
+
 export function syncDocumentSize(engine: Engine, width: number, height: number): void {
   const tracked = getTracked(engine);
   if (tracked.docWidth === width && tracked.docHeight === height) return;
@@ -402,6 +409,7 @@ export function syncPathTextLayers(
   paths: readonly StoredPath[],
   docWidth: number,
   docHeight: number,
+  textEditing?: TextEditingState | null,
 ): void {
   const tracked = getTracked(engine);
   if (!tracked.pathTextKeys) {
@@ -414,10 +422,19 @@ export function syncPathTextLayers(
     const path = paths.find((p) => p.id === layer.pathId);
     if (!path) continue;
 
-    // Build a cheap cache key from layer content + path anchors
-    const anchorSummary = path.anchors.map((a) => `${a.point.x},${a.point.y}`).join('|');
+    // Use live editing text if this layer is being edited
+    const liveText = (textEditing && textEditing.layerId === layer.id)
+      ? textEditing.text
+      : layer.text;
+
+    // Build a cheap cache key from layer content + path anchors + handles
+    const anchorSummary = path.anchors.map((a) => {
+      const hi = a.handleIn;
+      const ho = a.handleOut;
+      return `${a.point.x},${a.point.y},${hi ? `${hi.x},${hi.y}` : ''},${ho ? `${ho.x},${ho.y}` : ''}`;
+    }).join('|');
     const key = [
-      layer.text,
+      liveText,
       layer.fontFamily,
       layer.fontSize,
       layer.fontWeight,
@@ -435,7 +452,10 @@ export function syncPathTextLayers(
 
     if (tracked.pathTextKeys.get(layer.id) === key) continue;
 
-    const result = renderTextOnPath(layer, path.anchors, path.closed, docWidth, docHeight);
+    const layerWithLiveText = liveText !== layer.text
+      ? { ...layer, text: liveText }
+      : layer;
+    const result = renderTextOnPath(layerWithLiveText, path.anchors, path.closed, docWidth, docHeight);
     if (result) {
       uploadLayerPixels(engine, layer.id, result.pixels, result.width, result.height, result.x, result.y);
     } else {
@@ -512,4 +532,46 @@ export function syncTextLayers(
 
   uploadLayerPixels(engine, layerId, pixels, width, height, desiredX, desiredY);
   onPositionChange(layerId, desiredX, desiredY);
+}
+
+/**
+ * Re-render a committed text layer from its stored properties using the WASM
+ * text engine and upload the result. Used when a text layer loses its path
+ * binding and needs its texture restored outside of editing mode.
+ */
+export function rerenderCommittedTextLayer(
+  engine: Engine,
+  layer: TextLayer,
+): { x: number; y: number } | null {
+  const propsJson = JSON.stringify({
+    text: layer.text,
+    fontFamily: layer.fontFamily,
+    fontSize: layer.fontSize,
+    fontWeight: layer.fontWeight,
+    fontStyle: layer.fontStyle,
+    color: [layer.color.r / 255, layer.color.g / 255, layer.color.b / 255, layer.color.a],
+    lineHeight: layer.lineHeight,
+    letterSpacing: layer.letterSpacing,
+    textAlign: layer.textAlign,
+    areaWidth: layer.width ?? null,
+    underline: layer.underline,
+    strikethrough: layer.strikethrough,
+  });
+
+  setTextLayerContent(engine, layer.id, propsJson);
+  const boundsResult = renderTextLayer(engine, layer.id);
+  if (boundsResult.length !== 4) return null;
+
+  const width = boundsResult[0]!;
+  const height = boundsResult[1]!;
+  const offsetX = boundsResult[2]!;
+  const offsetY = boundsResult[3]!;
+
+  const pixels = getRenderedTextPixels(engine, layer.id);
+  if (pixels.length === 0) return null;
+
+  const x = layer.x + offsetX;
+  const y = layer.y + offsetY;
+  uploadLayerPixels(engine, layer.id, pixels, width, height, x, y);
+  return { x, y };
 }

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -54,6 +54,11 @@ export interface TrackedState {
   levelsRef: unknown;
   /** True when the engine is in "no levels" mode; null on first frame. */
   levelsIdentity: boolean | null;
+  /**
+   * Cache keys for path-text layers so we only re-upload when content or
+   * path geometry actually changes. Maps layerId → last-rendered key string.
+   */
+  pathTextKeys: Map<string, string> | null;
 }
 
 function createTrackedState(): TrackedState {
@@ -88,6 +93,7 @@ function createTrackedState(): TrackedState {
     curvesIdentity: null,
     levelsRef: null,
     levelsIdentity: null,
+    pathTextKeys: null,
   };
 }
 

--- a/src/tools/text/render-text-on-path.ts
+++ b/src/tools/text/render-text-on-path.ts
@@ -1,0 +1,101 @@
+/**
+ * Render text-on-path using Canvas2D composition.
+ *
+ * Strategy (Option B from spec): use an offscreen Canvas2D that is the same
+ * size as the document. Each glyph is drawn at its path-derived position using
+ * ctx.translate/rotate/fillText. The resulting ImageData is then uploaded to
+ * the GPU as the text layer's texture.
+ *
+ * This bypasses the Rust text engine for path text but produces correct visual
+ * output with no Rust/WASM changes required.
+ */
+
+import type { PathAnchor } from '../path/path';
+import type { TextLayer } from '../../types/layers';
+import { buildFontString } from './text';
+import { placeTextOnPath } from './text-on-path';
+import { contextOptions } from '../../engine/color-space';
+
+export interface PathTextRenderResult {
+  /** RGBA pixel data, row-major top-down. */
+  pixels: Uint8Array;
+  /** Width of the rendered texture (= docWidth). */
+  width: number;
+  /** Height of the rendered texture (= docHeight). */
+  height: number;
+  /** Document-space x of the top-left of the texture (always 0). */
+  x: number;
+  /** Document-space y of the top-left of the texture (always 0). */
+  y: number;
+}
+
+/**
+ * Render `layer`'s text along the given Bezier path into a canvas the size of
+ * the document (docWidth × docHeight) and return the pixel data.
+ *
+ * Returns null if the text is empty, the path has fewer than two anchors, or
+ * the canvas context cannot be created.
+ */
+export function renderTextOnPath(
+  layer: TextLayer,
+  anchors: readonly PathAnchor[],
+  pathClosed: boolean,
+  docWidth: number,
+  docHeight: number,
+): PathTextRenderResult | null {
+  const { text, fontSize, fontFamily, fontWeight, fontStyle, color, letterSpacing } = layer;
+
+  if (!text.trim() || anchors.length < 2) return null;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = docWidth;
+  canvas.height = docHeight;
+  const ctx = canvas.getContext('2d', contextOptions);
+  if (!ctx) return null;
+
+  const fontString = buildFontString({
+    fontSize,
+    fontFamily,
+    fontWeight,
+    fontStyle,
+    color: { r: color.r, g: color.g, b: color.b, a: color.a },
+    lineHeight: 1.4,
+    letterSpacing,
+    textAlign: 'left',
+  });
+  ctx.font = fontString;
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillStyle = `rgba(${color.r},${color.g},${color.b},${color.a})`;
+
+  // Measure glyph widths for each character in the text.
+  // We include letterSpacing as an additive per-glyph offset.
+  const glyphWidths: number[] = [];
+  for (const char of text) {
+    const metrics = ctx.measureText(char);
+    glyphWidths.push(metrics.width + letterSpacing);
+  }
+
+  const placements = placeTextOnPath(text, glyphWidths, anchors, pathClosed, fontSize);
+  if (placements.length === 0) return null;
+
+  for (const placement of placements) {
+    ctx.save();
+    ctx.translate(placement.x, placement.y);
+    ctx.rotate(placement.rotation);
+    // Draw glyph centred horizontally over the placement point.
+    // Canvas2D fillText with textAlign 'left' draws from the left edge,
+    // so offset by -width/2 to centre.
+    const charWidth = glyphWidths[placement.charIndex] ?? fontSize * 0.6;
+    ctx.fillText(placement.char, -(charWidth / 2), 0);
+    ctx.restore();
+  }
+
+  const imageData = ctx.getImageData(0, 0, docWidth, docHeight);
+  return {
+    pixels: new Uint8Array(imageData.data.buffer),
+    width: docWidth,
+    height: docHeight,
+    x: 0,
+    y: 0,
+  };
+}

--- a/src/tools/text/text-interaction.ts
+++ b/src/tools/text/text-interaction.ts
@@ -49,48 +49,58 @@ export function commitTextEditing(): void {
   const toolSettings = useToolSettingsStore.getState();
   const textColor = toolSettings.foregroundColor;
 
-  // Explicitly render text to the GPU texture before pushHistory snapshots it.
-  // This ensures the snapshot contains the final text pixels regardless of
-  // whether the rAF-driven syncTextLayers loop had time to fire.
   const areaWidth = editing.bounds.width;
   let finalX = editing.bounds.x;
   let finalY = editing.bounds.y;
 
-  const engine = getEngine();
-  if (engine) {
-    const propsJson = JSON.stringify({
-      text: editing.text,
-      fontFamily: toolSettings.textFontFamily,
-      fontSize: toolSettings.textFontSize,
-      fontWeight: toolSettings.textFontWeight,
-      fontStyle: toolSettings.textFontStyle,
-      color: [textColor.r / 255, textColor.g / 255, textColor.b / 255, textColor.a],
-      lineHeight: 1.4,
-      letterSpacing: 0,
-      textAlign: toolSettings.textAlign,
-      areaWidth: areaWidth ?? null,
-      underline: toolSettings.textUnderline,
-      strikethrough: toolSettings.textStrikethrough,
-    });
-    setTextLayerContent(engine, editing.layerId, propsJson);
-    const boundsResult = renderTextLayer(engine, editing.layerId);
-    if (boundsResult.length === 4) {
-      const width = boundsResult[0]!;
-      const height = boundsResult[1]!;
-      const offsetX = boundsResult[2]!;
-      const offsetY = boundsResult[3]!;
-      const pixels = getRenderedTextPixels(engine, editing.layerId);
-      if (pixels.length > 0) {
-        finalX = editing.bounds.x + offsetX;
-        finalY = editing.bounds.y + offsetY;
-        uploadLayerPixels(engine, editing.layerId, pixels, width, height, finalX, finalY);
-      }
-    }
+  // Check if this text layer is bound to a path — if so, skip the normal
+  // WASM text render (syncPathTextLayers handles the texture) and keep
+  // the layer at (0, 0) since path text uses document-space coordinates.
+  const currentLayer = editorState.document.layers.find((l) => l.id === editing.layerId);
+  const isPathText = currentLayer?.type === 'text' && !!(currentLayer as import('../../types').TextLayer).pathId;
+
+  if (isPathText) {
+    finalX = 0;
+    finalY = 0;
   } else {
-    // Fallback: use position set by the last syncTextLayers call if engine unavailable.
-    const currentLayer = editorState.document.layers.find((l) => l.id === editing.layerId);
-    finalX = currentLayer?.x ?? editing.bounds.x;
-    finalY = currentLayer?.y ?? editing.bounds.y;
+    // Explicitly render text to the GPU texture before pushHistory snapshots it.
+    // This ensures the snapshot contains the final text pixels regardless of
+    // whether the rAF-driven syncTextLayers loop had time to fire.
+    const engine = getEngine();
+    if (engine) {
+      const propsJson = JSON.stringify({
+        text: editing.text,
+        fontFamily: toolSettings.textFontFamily,
+        fontSize: toolSettings.textFontSize,
+        fontWeight: toolSettings.textFontWeight,
+        fontStyle: toolSettings.textFontStyle,
+        color: [textColor.r / 255, textColor.g / 255, textColor.b / 255, textColor.a],
+        lineHeight: 1.4,
+        letterSpacing: 0,
+        textAlign: toolSettings.textAlign,
+        areaWidth: areaWidth ?? null,
+        underline: toolSettings.textUnderline,
+        strikethrough: toolSettings.textStrikethrough,
+      });
+      setTextLayerContent(engine, editing.layerId, propsJson);
+      const boundsResult = renderTextLayer(engine, editing.layerId);
+      if (boundsResult.length === 4) {
+        const width = boundsResult[0]!;
+        const height = boundsResult[1]!;
+        const offsetX = boundsResult[2]!;
+        const offsetY = boundsResult[3]!;
+        const pixels = getRenderedTextPixels(engine, editing.layerId);
+        if (pixels.length > 0) {
+          finalX = editing.bounds.x + offsetX;
+          finalY = editing.bounds.y + offsetY;
+          uploadLayerPixels(engine, editing.layerId, pixels, width, height, finalX, finalY);
+        }
+      }
+    } else {
+      // Fallback: use position set by the last syncTextLayers call if engine unavailable.
+      finalX = currentLayer?.x ?? editing.bounds.x;
+      finalY = currentLayer?.y ?? editing.bounds.y;
+    }
   }
 
   editorState.pushHistory('Text');

--- a/src/tools/text/text-on-path.test.ts
+++ b/src/tools/text/text-on-path.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { buildPathLookupTable, placeTextOnPath } from './text-on-path';
+import type { PathAnchor } from '../path/path';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function straightPath(x0: number, y0: number, x1: number, y1: number): PathAnchor[] {
+  return [
+    { point: { x: x0, y: y0 }, handleIn: null, handleOut: null },
+    { point: { x: x1, y: y1 }, handleIn: null, handleOut: null },
+  ];
+}
+
+function uniformWidths(count: number, width: number): number[] {
+  return Array.from({ length: count }, () => width);
+}
+
+// ---------------------------------------------------------------------------
+// buildPathLookupTable
+// ---------------------------------------------------------------------------
+
+describe('buildPathLookupTable', () => {
+  it('returns empty table for fewer than two anchors', () => {
+    const table = buildPathLookupTable([], false);
+    expect(table).toHaveLength(0);
+
+    const single = buildPathLookupTable(
+      [{ point: { x: 0, y: 0 }, handleIn: null, handleOut: null }],
+      false,
+    );
+    expect(single).toHaveLength(0);
+  });
+
+  it('produces monotonically increasing distances for a straight path', () => {
+    const anchors = straightPath(0, 0, 100, 0);
+    const table = buildPathLookupTable(anchors, false);
+
+    expect(table.length).toBeGreaterThan(0);
+    for (let i = 1; i < table.length; i++) {
+      expect(table[i]!.distance).toBeGreaterThan(table[i - 1]!.distance);
+    }
+  });
+
+  it('total arc length approximates straight-line length', () => {
+    const anchors = straightPath(0, 0, 200, 0);
+    const table = buildPathLookupTable(anchors, false);
+    const totalDist = table[table.length - 1]!.distance;
+    expect(totalDist).toBeGreaterThan(195);
+    expect(totalDist).toBeLessThan(205);
+  });
+
+  it('tangent along a horizontal path is unit vector pointing right', () => {
+    const anchors = straightPath(0, 0, 100, 0);
+    const table = buildPathLookupTable(anchors, false);
+
+    for (const sample of table) {
+      expect(sample.tx).toBeCloseTo(1, 1);
+      expect(sample.ty).toBeCloseTo(0, 1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// placeTextOnPath
+// ---------------------------------------------------------------------------
+
+describe('placeTextOnPath', () => {
+  it('returns empty array when anchors are empty', () => {
+    const placements = placeTextOnPath('Hello', uniformWidths(5, 10), [], false, 16);
+    expect(placements).toHaveLength(0);
+  });
+
+  it('places glyphs at correct x positions along a horizontal path', () => {
+    // Path from (0,0) to (300,0) — plenty of room for 5 chars × 20px each
+    const anchors = straightPath(0, 0, 300, 0);
+    const text = 'Hello';
+    const charWidth = 20;
+    const placements = placeTextOnPath(
+      text,
+      uniformWidths(text.length, charWidth),
+      anchors,
+      false,
+      16,
+    );
+
+    expect(placements).toHaveLength(text.length);
+
+    // Each glyph should be centred at dist + width/2 along the path
+    let dist = 0;
+    for (let i = 0; i < placements.length; i++) {
+      const expected = dist + charWidth / 2;
+      expect(placements[i]!.x).toBeCloseTo(expected, 0);
+      expect(placements[i]!.y).toBeCloseTo(0, 0);
+      dist += charWidth;
+    }
+  });
+
+  it('assigns zero rotation along a horizontal path', () => {
+    const anchors = straightPath(0, 0, 300, 0);
+    const placements = placeTextOnPath(
+      'AB',
+      uniformWidths(2, 20),
+      anchors,
+      false,
+      16,
+    );
+    for (const p of placements) {
+      expect(p.rotation).toBeCloseTo(0, 2);
+    }
+  });
+
+  it('assigns π/2 rotation along a downward vertical path', () => {
+    // Path going straight down
+    const anchors = straightPath(0, 0, 0, 300);
+    const placements = placeTextOnPath(
+      'AB',
+      uniformWidths(2, 20),
+      anchors,
+      false,
+      16,
+    );
+    expect(placements).toHaveLength(2);
+    for (const p of placements) {
+      expect(p.rotation).toBeCloseTo(Math.PI / 2, 1);
+    }
+  });
+
+  it('glyphs on a circular-arc path have varying rotation matching the tangent', () => {
+    // Approximate a quarter-circle arc (from (100,0) sweeping to (0,100) via handles)
+    const r = 100;
+    const k = 0.5523; // Bezier approximation constant for quarter-circle
+    const anchors: PathAnchor[] = [
+      {
+        point: { x: r, y: 0 },
+        handleIn: null,
+        handleOut: { x: r, y: r * k },
+      },
+      {
+        point: { x: 0, y: r },
+        handleIn: { x: r * k, y: r },
+        handleOut: null,
+      },
+    ];
+
+    const text = 'ABCDE';
+    const placements = placeTextOnPath(
+      text,
+      uniformWidths(text.length, 15),
+      anchors,
+      false,
+      16,
+    );
+
+    // There should be multiple placements along the arc
+    expect(placements.length).toBeGreaterThan(0);
+
+    // Rotations should be strictly increasing (path curves from horizontal to vertical)
+    for (let i = 1; i < placements.length; i++) {
+      expect(placements[i]!.rotation).toBeGreaterThan(placements[i - 1]!.rotation - 0.01);
+    }
+
+    // First glyph should be near horizontal (small rotation)
+    expect(placements[0]!.rotation).toBeCloseTo(Math.PI / 2, 0); // tangent at (r,0) of this arc points down
+  });
+
+  it('truncates text that is longer than path length', () => {
+    // Short path — only ~50px long
+    const anchors = straightPath(0, 0, 50, 0);
+    const text = 'ABCDEFGHIJ'; // 10 chars × 20px = 200px needed
+    const placements = placeTextOnPath(
+      text,
+      uniformWidths(text.length, 20),
+      anchors,
+      false,
+      16,
+    );
+
+    // At most 2 glyphs fit (2 × 20px = 40px advance) — verify strict truncation
+    expect(placements.length).toBeLessThan(text.length);
+    expect(placements.length).toBeGreaterThan(0);
+  });
+
+  it('charIndex matches position in text string', () => {
+    const anchors = straightPath(0, 0, 400, 0);
+    const text = 'Hello';
+    const placements = placeTextOnPath(text, uniformWidths(5, 20), anchors, false, 16);
+    for (let i = 0; i < placements.length; i++) {
+      expect(placements[i]!.charIndex).toBe(i);
+      expect(placements[i]!.char).toBe(text[i]);
+    }
+  });
+
+  it('uses fallback width when glyphWidths is shorter than text', () => {
+    const anchors = straightPath(0, 0, 400, 0);
+    const fontSize = 16;
+    const fallback = fontSize * 0.6; // 9.6px
+    // Provide widths only for first two chars; rest get fallback
+    const placements = placeTextOnPath('ABCDE', [20, 20], anchors, false, fontSize);
+
+    expect(placements).toHaveLength(5);
+    // Third char should be at x = 20+20 + fallback/2
+    expect(placements[2]!.x).toBeCloseTo(40 + fallback / 2, 0);
+  });
+});

--- a/src/tools/text/text-on-path.ts
+++ b/src/tools/text/text-on-path.ts
@@ -1,0 +1,192 @@
+import type { PathAnchor } from '../path/path';
+import type { Point } from '../../types';
+
+export interface GlyphPlacement {
+  /** Index into the text string this placement belongs to. */
+  charIndex: number;
+  /** Character being placed. */
+  char: string;
+  /** Document-space X position (centre of the glyph baseline). */
+  x: number;
+  /** Document-space Y position (baseline). */
+  y: number;
+  /** Rotation angle in radians, matching the path tangent at this point. */
+  rotation: number;
+}
+
+interface PathSample {
+  distance: number;
+  point: Point;
+  /** Unit tangent vector at this sample. */
+  tx: number;
+  ty: number;
+}
+
+function bezierPoint(
+  p0: Point,
+  cp1: Point,
+  cp2: Point,
+  p1: Point,
+  t: number,
+): Point {
+  const u = 1 - t;
+  return {
+    x: u * u * u * p0.x + 3 * u * u * t * cp1.x + 3 * u * t * t * cp2.x + t * t * t * p1.x,
+    y: u * u * u * p0.y + 3 * u * u * t * cp1.y + 3 * u * t * t * cp2.y + t * t * t * p1.y,
+  };
+}
+
+/**
+ * Build a dense arc-length lookup table from the path anchors.
+ * Each entry stores cumulative distance, the point on the curve and the
+ * unit tangent (forward direction) at that point.
+ */
+export function buildPathLookupTable(
+  anchors: readonly PathAnchor[],
+  closed: boolean,
+  stepSize = 1,
+): PathSample[] {
+  const samples: PathSample[] = [];
+  if (anchors.length < 2) return samples;
+
+  let totalDist = 0;
+  const segCount = closed ? anchors.length : anchors.length - 1;
+
+  for (let seg = 0; seg < segCount; seg++) {
+    const a = anchors[seg]!;
+    const b = anchors[(seg + 1) % anchors.length]!;
+    const cp1 = a.handleOut ?? a.point;
+    const cp2 = b.handleIn ?? b.point;
+
+    // Estimate number of steps needed for this segment.
+    // Use a rough chord length to set the step count.
+    const dx = b.point.x - a.point.x;
+    const dy = b.point.y - a.point.y;
+    const roughLen = Math.sqrt(dx * dx + dy * dy);
+    const steps = Math.max(8, Math.ceil(roughLen / stepSize));
+
+    let prev = bezierPoint(a.point, cp1, cp2, b.point, 0);
+
+    for (let s = 1; s <= steps; s++) {
+      const t = s / steps;
+      const curr = bezierPoint(a.point, cp1, cp2, b.point, t);
+
+      const ddx = curr.x - prev.x;
+      const ddy = curr.y - prev.y;
+      const segDist = Math.sqrt(ddx * ddx + ddy * ddy);
+
+      if (segDist === 0) {
+        prev = curr;
+        continue;
+      }
+
+      totalDist += segDist;
+      samples.push({
+        distance: totalDist,
+        point: curr,
+        tx: ddx / segDist,
+        ty: ddy / segDist,
+      });
+
+      prev = curr;
+    }
+  }
+
+  return samples;
+}
+
+/**
+ * Linearly interpolate a PathSample at the requested arc-length distance.
+ * Returns null if `dist` is beyond the end of the path.
+ */
+function sampleAtDistance(table: PathSample[], dist: number): PathSample | null {
+  if (table.length === 0) return null;
+  if (dist <= 0) return table[0] ?? null;
+
+  const last = table[table.length - 1];
+  if (!last || dist > last.distance) return null;
+
+  // Binary search
+  let lo = 0;
+  let hi = table.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (table[mid]!.distance < dist) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  const curr = table[lo]!;
+  if (lo === 0 || curr.distance === dist) return curr;
+
+  const prev = table[lo - 1]!;
+  const t = (dist - prev.distance) / (curr.distance - prev.distance);
+
+  // Interpolate position
+  const x = prev.point.x + t * (curr.point.x - prev.point.x);
+  const y = prev.point.y + t * (curr.point.y - prev.point.y);
+
+  // Slerp-ish tangent (since both are already unit, lerp + normalise is fine
+  // for the small angular steps produced by 1px sampling)
+  const txRaw = prev.tx + t * (curr.tx - prev.tx);
+  const tyRaw = prev.ty + t * (curr.ty - prev.ty);
+  const tLen = Math.sqrt(txRaw * txRaw + tyRaw * tyRaw) || 1;
+
+  return {
+    distance: dist,
+    point: { x, y },
+    tx: txRaw / tLen,
+    ty: tyRaw / tLen,
+  };
+}
+
+/**
+ * Place each character of `text` along the path described by `anchors`.
+ *
+ * `glyphWidths` is an array of advance widths, one entry per character in
+ * `text` (in the same order). If the array is shorter than the text the
+ * missing characters are each given a width of `fontSize * 0.6`.
+ *
+ * Characters that would fall beyond the end of the path are omitted from the
+ * returned array (truncation, not wrapping).
+ */
+export function placeTextOnPath(
+  text: string,
+  glyphWidths: readonly number[],
+  anchors: readonly PathAnchor[],
+  closed: boolean,
+  fontSize: number,
+): GlyphPlacement[] {
+  const table = buildPathLookupTable(anchors, closed);
+  if (table.length === 0) return [];
+
+  const placements: GlyphPlacement[] = [];
+  let dist = 0;
+  const fallbackWidth = fontSize * 0.6;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!;
+    const advance = glyphWidths[i] ?? fallbackWidth;
+
+    // Place glyph at dist + half its width so the character is centred over
+    // the sample point (matches Canvas2D fillText behaviour).
+    const centreDist = dist + advance / 2;
+    const sample = sampleAtDistance(table, centreDist);
+
+    if (sample === null) break; // beyond end of path — truncate
+
+    placements.push({
+      charIndex: i,
+      char,
+      x: sample.point.x,
+      y: sample.point.y,
+      rotation: Math.atan2(sample.ty, sample.tx),
+    });
+
+    dist += advance;
+  }
+
+  return placements;
+}

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -43,6 +43,7 @@ export interface TextLayer extends LayerBase {
   readonly width: number | null; // null = point text, number = area text
   readonly underline: boolean;
   readonly strikethrough: boolean;
+  readonly pathId?: string;
 }
 
 export interface ShapeLayer extends LayerBase {

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -44,6 +44,8 @@ export interface TextLayer extends LayerBase {
   readonly underline: boolean;
   readonly strikethrough: boolean;
   readonly pathId?: string;
+  readonly prePathX?: number;
+  readonly prePathY?: number;
 }
 
 export interface ShapeLayer extends LayerBase {


### PR DESCRIPTION
## Summary
- Text layers can now flow along stored Bezier paths via `pathId` property
- Pure logic: path lookup table with binary search, per-glyph positioning + tangent rotation
- Canvas2D rendering for path text, uploaded as layer texture with change-detection caching
- "Path" dropdown in TextOptions when stored paths exist
- Text truncates cleanly when exceeding path length

## Implementation
- `text-on-path.ts` — buildPathLookupTable + placeTextOnPath (pure, no DOM)
- `render-text-on-path.ts` — Canvas2D compositor with per-glyph translate/rotate/fillText
- `engine-sync.ts` — syncPathTextLayers with content+geometry cache key
- `TextOptions.tsx` — path dropdown, updates pathId on active text layer

## Test plan
- [x] 12 unit tests: empty path, monotonic distance, tangent angles, circular arc, truncation
- [x] 5 E2E tests: curved path pixels, normal text no pathId, dropdown, assignment, diagonal spread
- [ ] Manual: create curved path, apply text, verify it follows the curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)