### PR TITLE
feat(tools): add History Brush for painting from previous states

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -290,6 +290,7 @@ const TOOL_SHORTCUTS: Record<string, string> = {
   eyedropper: 'i', stamp: 's', dodge: 'o', sponge: 'y', smudge: 'r', spray: 'j',
   'marquee-rect': 'm', lasso: 'l', wand: 'w', 'quick-select': 'q',
   shape: 'u', text: 't', crop: 'c', path: 'p',
+  'history-brush': 'y',
 };
 
 export async function selectTool(page: Page, toolId: string): Promise<void> {

--- a/e2e/history-brush.spec.ts
+++ b/e2e/history-brush.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * E2E tests for the History Brush tool.
+ *
+ * Scenario: user draws red on a layer (establishes history), then paints
+ * over it with blue, then sets the pre-blue state as the history brush
+ * source, paints back over the blue area, and verifies the red pixels
+ * are restored.
+ */
+
+import { test, expect } from './fixtures';
+import {
+  createDocument,
+  waitForStore,
+  getPixelAt,
+  drawRect,
+  setActiveLayer,
+  undo,
+} from './helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Projects document coordinates to canvas-container screen coordinates.
+ */
+async function docToScreen(
+  page: Parameters<typeof waitForStore>[0],
+  docX: number,
+  docY: number,
+): Promise<{ x: number; y: number }> {
+  return page.evaluate(
+    ({ docX, docY }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number };
+          viewport: { zoom: number; panX: number; panY: number };
+        };
+      };
+      const state = store.getState();
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      if (!container) return { x: 0, y: 0 };
+      const rect = container.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      return {
+        x: rect.left + (docX - state.document.width / 2) * state.viewport.zoom + state.viewport.panX + cx,
+        y: rect.top + (docY - state.document.height / 2) * state.viewport.zoom + state.viewport.panY + cy,
+      };
+    },
+    { docX, docY },
+  );
+}
+
+/**
+ * Flush pending GPU stroke data into the layer texture so pixel reads
+ * see the latest painted content.
+ */
+async function flushHistory(page: Parameters<typeof waitForStore>[0]): Promise<void> {
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { pushHistory: (label?: string) => void };
+    };
+    store.getState().pushHistory('flush');
+  });
+}
+
+/**
+ * Set historyBrushSourceIndex on the ui store directly.
+ * This simulates the user clicking the source icon in the History panel.
+ */
+async function setHistoryBrushSource(page: Parameters<typeof waitForStore>[0], index: number): Promise<void> {
+  await page.evaluate((idx) => {
+    const store = (window as unknown as Record<string, unknown>).__uiStore as {
+      getState: () => { setHistoryBrushSourceIndex: (i: number) => void };
+    };
+    store.getState().setHistoryBrushSourceIndex(idx);
+  }, index);
+}
+
+/**
+ * Paint a single dab of the history brush at the given document position.
+ */
+async function paintHistoryBrushAt(
+  page: Parameters<typeof waitForStore>[0],
+  docX: number,
+  docY: number,
+): Promise<void> {
+  const pos = await docToScreen(page, docX, docY);
+  await page.mouse.move(pos.x, pos.y);
+  await page.mouse.down();
+  await page.mouse.up();
+  await page.waitForTimeout(100);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await waitForStore(page);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('History Brush', () => {
+  test('restores pixels from a previous history state', async ({ page }) => {
+    // Create a 200×200 transparent document
+    await createDocument(page, 200, 200, true);
+
+    const { layerId } = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return { layerId: store.getState().document.activeLayerId };
+    });
+
+    // Step 1: Draw a red rectangle at (40, 40, 80×80)
+    await setActiveLayer(page, layerId);
+    await drawRect(page, 40, 40, 80, 80, { r: 255, g: 0, b: 0 });
+
+    // Flush GPU stroke so the snapshot captures red pixels
+    await flushHistory(page);
+
+    // At this point undoStack has an entry with the red pixels.
+    // The last entry index = undoStack.length (i.e. currentIndex).
+    const sourceIdx = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { undoStack: unknown[] };
+      };
+      return store.getState().undoStack.length;
+    });
+
+    // Step 2: Paint blue over the red area
+    await drawRect(page, 40, 40, 80, 80, { r: 0, g: 0, b: 255 });
+    await flushHistory(page);
+
+    // Verify blue is visible at center of the blue rect
+    const bluePixelBefore = await getPixelAt(page, 80, 80, layerId);
+    expect(bluePixelBefore.b).toBeGreaterThan(200);
+
+    // Take a before screenshot
+    await page.screenshot({ path: 'e2e/screenshots/history-brush-before.png' });
+
+    // Step 3: Set the red-state entry as the history brush source
+    await setHistoryBrushSource(page, sourceIdx);
+
+    // Step 4: Select the history brush tool (shortcut Y)
+    await page.keyboard.press('y');
+
+    // Verify the tool was selected
+    const activeTool = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { activeTool: string };
+      };
+      return store.getState().activeTool;
+    });
+    expect(activeTool).toBe('history-brush');
+
+    // Step 5: Paint with the history brush over the blue area
+    // The brush should restore red pixels from the source snapshot
+    await paintHistoryBrushAt(page, 80, 80);
+
+    // Flush the stroke so pixel reads capture the painted content
+    await flushHistory(page);
+
+    // Take an after screenshot
+    await page.screenshot({ path: 'e2e/screenshots/history-brush-after.png' });
+
+    // Step 6: Verify that the center pixel has been partially or fully restored
+    // from the red source state
+    const restoredPixel = await getPixelAt(page, 80, 80, layerId);
+
+    // The history brush at full opacity paints the red source over the blue dest.
+    // We should see meaningful red channel activity compared to before the brush stroke.
+    // The exact mix depends on brush size/hardness settings, but at default 100% opacity
+    // and 80% hardness, the center dab should be mostly red.
+    expect(restoredPixel.r).toBeGreaterThan(restoredPixel.b);
+  });
+
+  test('source icon button sets historyBrushSourceIndex in UI store', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return store.getState().document.activeLayerId;
+    });
+
+    // Make an edit so there is a history entry
+    await setActiveLayer(page, layerId);
+    await drawRect(page, 0, 0, 50, 50, { r: 255, g: 0, b: 0 });
+
+    // Verify source index starts as null
+    const initialIndex = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { historyBrushSourceIndex: number | null };
+      };
+      return store.getState().historyBrushSourceIndex;
+    });
+    expect(initialIndex).toBeNull();
+
+    // Make the History panel visible
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { visiblePanels: Set<string>; togglePanel: (id: string) => void };
+      };
+      const s = store.getState();
+      if (!s.visiblePanels.has('history')) {
+        s.togglePanel('history');
+      }
+    });
+    await page.waitForTimeout(150);
+
+    // Click the first "Set as history brush source" button in the history panel
+    const sourceBtns = page.locator('[aria-label="Set as history brush source"]');
+    await sourceBtns.first().waitFor({ state: 'visible', timeout: 5000 });
+    await sourceBtns.first().click();
+
+    // Verify the source index is now set
+    const setIndex = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { historyBrushSourceIndex: number | null };
+      };
+      return store.getState().historyBrushSourceIndex;
+    });
+    expect(setIndex).not.toBeNull();
+    expect(typeof setIndex).toBe('number');
+
+    // Clicking the same button again should toggle it off
+    await sourceBtns.first().click();
+    const clearedIndex = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { historyBrushSourceIndex: number | null };
+      };
+      return store.getState().historyBrushSourceIndex;
+    });
+    expect(clearedIndex).toBeNull();
+  });
+
+  test('history brush is a no-op when no source is set', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return store.getState().document.activeLayerId;
+    });
+
+    // Draw blue
+    await setActiveLayer(page, layerId);
+    await drawRect(page, 20, 20, 60, 60, { r: 0, g: 0, b: 255 });
+    await flushHistory(page);
+
+    // Do NOT set a source
+    await page.keyboard.press('y');
+
+    const blueBefore = await getPixelAt(page, 50, 50, layerId);
+
+    // Paint with history brush — should do nothing
+    await paintHistoryBrushAt(page, 50, 50);
+    await flushHistory(page);
+
+    const blueAfter = await getPixelAt(page, 50, 50, layerId);
+
+    // Blue channel should be unchanged since no source was set
+    expect(blueAfter.b).toBeCloseTo(blueBefore.b, -1);
+  });
+
+  test('history brush tool is accessible via Y shortcut', async ({ page }) => {
+    await createDocument(page, 100, 100, true);
+
+    await page.keyboard.press('y');
+
+    const activeTool = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { activeTool: string };
+      };
+      return store.getState().activeTool;
+    });
+    expect(activeTool).toBe('history-brush');
+  });
+
+  test('history brush undo restores the pre-stroke state', async ({ page }) => {
+    await createDocument(page, 200, 200, true);
+
+    const layerId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return store.getState().document.activeLayerId;
+    });
+
+    // Draw red
+    await setActiveLayer(page, layerId);
+    await drawRect(page, 50, 50, 80, 80, { r: 255, g: 0, b: 0 });
+    await flushHistory(page);
+
+    const redSourceIndex = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { undoStack: unknown[] };
+      };
+      return store.getState().undoStack.length;
+    });
+
+    // Overwrite with green
+    await drawRect(page, 50, 50, 80, 80, { r: 0, g: 255, b: 0 });
+    await flushHistory(page);
+
+    // Verify green
+    const greenPixel = await getPixelAt(page, 90, 90, layerId);
+    expect(greenPixel.g).toBeGreaterThan(200);
+
+    // Set red state as source
+    await setHistoryBrushSource(page, redSourceIndex);
+
+    // Paint with history brush to restore red
+    await page.keyboard.press('y');
+    await paintHistoryBrushAt(page, 90, 90);
+    await flushHistory(page);
+
+    const afterBrush = await getPixelAt(page, 90, 90, layerId);
+    expect(afterBrush.r).toBeGreaterThan(afterBrush.g);
+
+    // Undo the history brush stroke
+    await undo(page);
+    await page.waitForTimeout(200);
+
+    const afterUndo = await getPixelAt(page, 90, 90, layerId);
+    // After undo, green should be restored
+    expect(afterUndo.g).toBeGreaterThan(afterUndo.r);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -475,6 +475,9 @@ interface ToolSettings {
   brushTextureBlendMode: BrushTextureBlendMode;
   brushTextureScale: number;
   brushTextures: BrushTextureData[];
+  historyBrushSize: number;
+  historyBrushOpacity: number;
+  historyBrushHardness: number;
   presets: BrushPreset[];
   activePresetId: string | null;
   activeSubBrushes: SubBrush[];
@@ -491,6 +494,10 @@ interface ToolSettings {
   setBrushTextureScale: (scale: number) => void;
   addBrushTexture: (texture: BrushTextureData) => void;
   removeBrushTexture: (id: string) => void;
+  setHistoryBrushSize: (size: number) => void;
+  /** History Brush opacity in **percent**, range `1–100`. */
+  setHistoryBrushOpacity: (opacity: number) => void;
+  setHistoryBrushHardness: (hardness: number) => void;
   setSpraySize: (size: number) => void;
   setSprayDensity: (density: number) => void;
   /** Spray opacity in **percent**, range `1–100` (not normalised `0–1`). */
@@ -678,6 +685,9 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { r: 255, g: 130, b: 0,   a: 1 },
     { r: 0,   g: 200, b: 200, a: 1 },
   ],
+  historyBrushSize: 20,
+  historyBrushOpacity: 100,
+  historyBrushHardness: 80,
   spraySize: 40,
   sprayDensity: 20,
   sprayOpacity: 60,
@@ -712,6 +722,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     brushTextures: s.brushTextures.filter((t) => t.id !== id),
     brushTextureData: s.brushTextureData?.id === id ? null : s.brushTextureData,
   })),
+  setHistoryBrushSize: (size) => set({ historyBrushSize: Math.max(1, Math.min(5000, size)) }),
+  setHistoryBrushOpacity: (opacity) => {
+    warnIfNormalisedOpacity('setHistoryBrushOpacity', opacity);
+    set({ historyBrushOpacity: Math.max(1, Math.min(100, opacity)) });
+  },
+  setHistoryBrushHardness: (hardness) => set({ historyBrushHardness: Math.max(0, Math.min(100, hardness)) }),
   setSpraySize: (size) => set({ spraySize: Math.max(1, Math.min(5000, size)) }),
   setSprayDensity: (density) => set({ sprayDensity: Math.max(1, Math.min(100, density)) }),
   setSprayOpacity: (opacity) => {

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -153,10 +153,13 @@ interface UIState {
   cursorPosition: Point;
   cursorOnCanvas: boolean;
   gradientPreview: { start: Point; end: Point } | null;
+  /** Index into undoStack (1-based, 0 = initial state) for the history brush source. null = unset. */
+  historyBrushSourceIndex: number | null;
   setCursorPosition: (pos: Point) => void;
   setCursorOnCanvas: (onCanvas: boolean) => void;
   setMaskEditMode: (mode: boolean) => void;
   toggleQuickMaskMode: () => void;
+  setHistoryBrushSourceIndex: (index: number | null) => void;
   /** Open a modal, replacing any that was already open. */
   openModal: (next: ModalState) => void;
   /** Close whatever modal is open. */
@@ -284,10 +287,12 @@ export const useUIStore = create<UIState>((set, get) => ({
   setAdjustments: (adj) => set({ adjustments: adj }),
   setAdjustmentsEnabled: (enabled) => set({ adjustmentsEnabled: enabled }),
   gradientPreview: null,
+  historyBrushSourceIndex: null,
   setCursorPosition: (pos) => set({ cursorPosition: pos }),
   setCursorOnCanvas: (onCanvas) => set({ cursorOnCanvas: onCanvas }),
   setMaskEditMode: (mode) => set({ maskEditMode: mode }),
   toggleQuickMaskMode: () => set((state) => ({ isQuickMaskMode: !state.isQuickMaskMode })),
+  setHistoryBrushSourceIndex: (index) => set({ historyBrushSourceIndex: index }),
 
   // ─── Modal slot ────────────────────────────────────────────────────────
   openModal: (next) => set({ modal: next }),

--- a/src/panels/HistoryPanel/HistoryPanel.module.css
+++ b/src/panels/HistoryPanel/HistoryPanel.module.css
@@ -6,6 +6,42 @@
   overflow-y: auto;
 }
 
+.entryRow {
+  display: flex;
+  align-items: center;
+}
+
+.entryRow .entry {
+  flex: 1;
+  min-width: 0;
+}
+
+.sourceBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  opacity: 0.4;
+}
+
+.sourceBtn:hover {
+  opacity: 1;
+  background: var(--color-bg-hover);
+}
+
+.sourceBtnActive {
+  color: var(--color-accent);
+  opacity: 1;
+}
+
 .entry {
   display: flex;
   align-items: center;

--- a/src/panels/HistoryPanel/HistoryPanel.tsx
+++ b/src/panels/HistoryPanel/HistoryPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useEditorStore } from '../../app/editor-store';
+import { useUIStore } from '../../app/ui-store';
 import { PanelContainer } from '../PanelContainer/PanelContainer';
 import { usePanelCollapse } from '../usePanelCollapse';
 import styles from './HistoryPanel.module.css';
@@ -11,6 +12,8 @@ export function HistoryPanel() {
   const redoStack = useEditorStore((s) => s.redoStack);
   const undo = useEditorStore((s) => s.undo);
   const redo = useEditorStore((s) => s.redo);
+  const historyBrushSourceIndex = useUIStore((s) => s.historyBrushSourceIndex);
+  const setHistoryBrushSourceIndex = useUIStore((s) => s.setHistoryBrushSourceIndex);
 
   const currentIndex = undoStack.length;
 
@@ -28,46 +31,91 @@ export function HistoryPanel() {
     }
   };
 
+  const handleSetSource = (e: React.MouseEvent, index: number) => {
+    e.stopPropagation();
+    setHistoryBrushSourceIndex(historyBrushSourceIndex === index ? null : index);
+  };
+
   return (
     <PanelContainer title="History" collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)}>
       {undoStack.length === 0 && redoStack.length === 0 ? (
         <div className={styles.empty}>No history</div>
       ) : (
         <div className={collapsed ? styles.listCollapsed : styles.list} ref={listRef}>
-          <button
-            className={`${styles.entry} ${currentIndex === 0 ? styles.entryActive : ''}`}
-            onClick={() => handleClick(0)}
-            type="button"
-          >
-            <span className={styles.index}>0</span>
-            <span>Original</span>
-          </button>
+          <div className={styles.entryRow}>
+            <button
+              className={`${styles.entry} ${currentIndex === 0 ? styles.entryActive : ''}`}
+              onClick={() => handleClick(0)}
+              type="button"
+            >
+              <span className={styles.index}>0</span>
+              <span>Original</span>
+            </button>
+            <button
+              className={`${styles.sourceBtn} ${historyBrushSourceIndex === 0 ? styles.sourceBtnActive : ''}`}
+              onClick={(e) => handleSetSource(e, 0)}
+              type="button"
+              aria-label="Set as history brush source"
+              title="Set as history brush source"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="3" />
+                <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+              </svg>
+            </button>
+          </div>
           {undoStack.map((snapshot, i) => {
             const entryIndex = i + 1;
             return (
-              <button
-                key={i}
-                className={`${styles.entry} ${entryIndex === currentIndex ? styles.entryActive : ''}`}
-                onClick={() => handleClick(entryIndex)}
-                type="button"
-              >
-                <span className={styles.index}>{entryIndex}</span>
-                <span>{snapshot.label}</span>
-              </button>
+              <div key={i} className={styles.entryRow}>
+                <button
+                  className={`${styles.entry} ${entryIndex === currentIndex ? styles.entryActive : ''}`}
+                  onClick={() => handleClick(entryIndex)}
+                  type="button"
+                >
+                  <span className={styles.index}>{entryIndex}</span>
+                  <span>{snapshot.label}</span>
+                </button>
+                <button
+                  className={`${styles.sourceBtn} ${historyBrushSourceIndex === entryIndex ? styles.sourceBtnActive : ''}`}
+                  onClick={(e) => handleSetSource(e, entryIndex)}
+                  type="button"
+                  aria-label="Set as history brush source"
+                  title="Set as history brush source"
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+                  </svg>
+                </button>
+              </div>
             );
           })}
           {redoStack.slice().reverse().map((snapshot, i) => {
             const entryIndex = currentIndex + i + 1;
             return (
-              <button
-                key={`redo-${i}`}
-                className={`${styles.entry} ${styles.entryFuture}`}
-                onClick={() => handleClick(entryIndex)}
-                type="button"
-              >
-                <span className={styles.index}>{entryIndex}</span>
-                <span>{snapshot.label}</span>
-              </button>
+              <div key={`redo-${i}`} className={styles.entryRow}>
+                <button
+                  className={`${styles.entry} ${styles.entryFuture}`}
+                  onClick={() => handleClick(entryIndex)}
+                  type="button"
+                >
+                  <span className={styles.index}>{entryIndex}</span>
+                  <span>{snapshot.label}</span>
+                </button>
+                <button
+                  className={`${styles.sourceBtn} ${styles.entryFuture}`}
+                  onClick={(e) => handleSetSource(e, entryIndex)}
+                  type="button"
+                  aria-label="Set as history brush source"
+                  title="Set as history brush source"
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+                  </svg>
+                </button>
+              </div>
             );
           })}
         </div>

--- a/src/toolbox/Toolbox.tsx
+++ b/src/toolbox/Toolbox.tsx
@@ -19,6 +19,7 @@ import {
   SprayCan,
   Bandage,
   Droplets,
+  History,
 } from 'lucide-react';
 import { IconButton } from '../components/IconButton/IconButton';
 import { useUIStore } from '../app/ui-store';
@@ -88,6 +89,7 @@ const toolGroups: ToolDef[][] = [
   ],
   [
     { id: 'brush', icon: <Paintbrush size={ICON_SIZE} />, label: 'Brush (B)' },
+    { id: 'history-brush', icon: <History size={ICON_SIZE} />, label: 'History Brush (Y)' },
     { id: 'pencil', icon: <Pen size={ICON_SIZE} />, label: 'Pencil (N)' },
     { id: 'spray', icon: <SprayCan size={ICON_SIZE} />, label: 'Spray (J)' },
     { id: 'eraser', icon: <Eraser size={ICON_SIZE} />, label: 'Eraser (E)' },

--- a/src/tools/history-brush/HistoryBrushOptions.tsx
+++ b/src/tools/history-brush/HistoryBrushOptions.tsx
@@ -1,0 +1,26 @@
+import { useToolSettingsStore } from '../../app/tool-settings-store';
+import { useEditorStore } from '../../app/editor-store';
+import { Slider } from '../../components/Slider/Slider';
+import { docScaledMax } from '../../utils/slider-ranges';
+import styles from '../../app/OptionsBar/OptionsBar.module.css';
+
+export function HistoryBrushOptions() {
+  const historyBrushSize = useToolSettingsStore((s) => s.historyBrushSize);
+  const historyBrushOpacity = useToolSettingsStore((s) => s.historyBrushOpacity);
+  const historyBrushHardness = useToolSettingsStore((s) => s.historyBrushHardness);
+  const setHistoryBrushSize = useToolSettingsStore((s) => s.setHistoryBrushSize);
+  const setHistoryBrushOpacity = useToolSettingsStore((s) => s.setHistoryBrushOpacity);
+  const setHistoryBrushHardness = useToolSettingsStore((s) => s.setHistoryBrushHardness);
+  const docWidth = useEditorStore((s) => s.document.width);
+  const docHeight = useEditorStore((s) => s.document.height);
+  const sizeMax = docScaledMax(docWidth, docHeight, 200);
+
+  return (
+    <>
+      <Slider label="Size" value={historyBrushSize} min={1} max={sizeMax} onChange={setHistoryBrushSize} />
+      <Slider label="Opacity" value={historyBrushOpacity} min={1} max={100} onChange={setHistoryBrushOpacity} />
+      <Slider label="Hardness" value={historyBrushHardness} min={0} max={100} onChange={setHistoryBrushHardness} />
+      <span className={styles.hint}>Click source icon in History panel</span>
+    </>
+  );
+}

--- a/src/tools/history-brush/history-brush-interaction.ts
+++ b/src/tools/history-brush/history-brush-interaction.ts
@@ -1,0 +1,171 @@
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+import { useEditorStore } from '../../app/editor-store';
+import { useUIStore } from '../../app/ui-store';
+import { useToolSettingsStore } from '../../app/tool-settings-store';
+import { getEngine } from '../../engine-wasm/engine-state';
+import {
+  addLayer,
+  removeLayer,
+  readLayerPixels,
+  getLayerTextureDimensions,
+} from '../../engine-wasm/wasm-bridge';
+import { uploadCompressed } from '../../engine-wasm/gpu-pixel-access';
+import { PixelBuffer } from '../../engine/pixel-data';
+import { applyHistoryBrushDab } from './history-brush';
+import { interpolateFlat } from '../common/dab-interpolation';
+import type { HistorySnapshot } from '../../app/store/types';
+
+/** Unique ID used for the scratch layer that holds the source snapshot pixels. */
+const SCRATCH_LAYER_ID = '__history_brush_scratch__';
+
+/** Cached source pixels from the snapshot. Populated once per stroke begin. */
+let sourceCache: {
+  layerId: string;
+  /** Full document-width/height pixel buffer holding source pixels. */
+  pixels: PixelBuffer;
+} | null = null;
+
+/**
+ * Decode a snapshot's GPU blob for a layer into a full-document PixelBuffer.
+ * Returns null if no source is set or the layer has no data in the snapshot.
+ */
+function buildSourceCache(layerId: string): typeof sourceCache {
+  const { historyBrushSourceIndex } = useUIStore.getState();
+  if (historyBrushSourceIndex === null) return null;
+
+  const editorState = useEditorStore.getState();
+  const { undoStack, document: doc } = editorState;
+
+  // Index 0 = "Original" (first undoStack entry before any user edits).
+  // Entries 1..undoStack.length map to undoStack[0..n-1].
+  let snapshot: HistorySnapshot | null;
+  if (historyBrushSourceIndex === 0) {
+    snapshot = undoStack[0] ?? null;
+  } else {
+    snapshot = undoStack[historyBrushSourceIndex - 1] ?? null;
+  }
+
+  if (!snapshot || snapshot.metadataOnly) return null;
+
+  const blob = snapshot.gpuSnapshots.get(layerId);
+  if (!blob || blob.length === 0) {
+    // Layer had no content at that snapshot — treat as fully transparent
+    return {
+      layerId,
+      pixels: new PixelBuffer(doc.width, doc.height),
+    };
+  }
+
+  // Find the layer's position in the snapshot's document state
+  const snapshotLayer = snapshot.document.layers.find((l) => l.id === layerId);
+  const srcLayerX = snapshotLayer?.x ?? 0;
+  const srcLayerY = snapshotLayer?.y ?? 0;
+
+  const engine = getEngine();
+  if (!engine) return null;
+
+  // Upload blob to a temporary scratch layer, read pixels, clean up
+  try {
+    addLayer(engine, SCRATCH_LAYER_ID);
+    uploadCompressed(SCRATCH_LAYER_ID, blob);
+
+    const dims = getLayerTextureDimensions(engine, SCRATCH_LAYER_ID);
+    const texW = dims?.[0] ?? 0;
+    const texH = dims?.[1] ?? 0;
+
+    const docBuf = new PixelBuffer(doc.width, doc.height);
+
+    if (texW > 0 && texH > 0) {
+      const rawPixels = readLayerPixels(engine, SCRATCH_LAYER_ID);
+      if (rawPixels && rawPixels.length >= texW * texH * 4) {
+        const clamped = new Uint8ClampedArray(rawPixels.buffer, rawPixels.byteOffset, rawPixels.byteLength);
+        const texBuf = new PixelBuffer(texW, texH, clamped);
+        for (let ty = 0; ty < texH; ty++) {
+          for (let tx = 0; tx < texW; tx++) {
+            const docX = srcLayerX + tx;
+            const docY = srcLayerY + ty;
+            if (docX >= 0 && docX < doc.width && docY >= 0 && docY < doc.height) {
+              docBuf.setPixel(docX, docY, texBuf.getPixel(tx, ty));
+            }
+          }
+        }
+      }
+    }
+
+    return { layerId, pixels: docBuf };
+  } finally {
+    try { removeLayer(engine, SCRATCH_LAYER_ID); } catch { /* ignore */ }
+  }
+}
+
+function applyDabAtDocPos(docX: number, docY: number, layerId: string, source: NonNullable<typeof sourceCache>): void {
+  const editorState = useEditorStore.getState();
+  const toolSettings = useToolSettingsStore.getState();
+  const size = toolSettings.historyBrushSize;
+  const hardness = toolSettings.historyBrushHardness / 100;
+  const opacity = toolSettings.historyBrushOpacity / 100;
+
+  // Get full-document-size ImageData for the current layer
+  const destImageData = editorState.expandLayerForEditing(layerId);
+  const destBuf = PixelBuffer.wrapImageData(destImageData);
+
+  applyHistoryBrushDab({
+    destX: docX,
+    destY: docY,
+    source: source.pixels,
+    dest: destBuf,
+    radius: size / 2,
+    hardness,
+    opacity,
+  });
+
+  editorState.updateLayerPixelData(layerId, destImageData);
+}
+
+export function handleHistoryBrushDown(ctx: InteractionContext): InteractionState | undefined {
+  const { canvasPos, layerPos, activeLayerId, activeLayer } = ctx;
+
+  if (useUIStore.getState().historyBrushSourceIndex === null) return undefined;
+
+  const editorState = useEditorStore.getState();
+  editorState.pushHistory();
+
+  // Build source cache once per stroke
+  sourceCache = buildSourceCache(activeLayerId);
+  if (!sourceCache) return undefined;
+
+  applyDabAtDocPos(canvasPos.x, canvasPos.y, activeLayerId, sourceCache);
+
+  return {
+    drawing: true,
+    lastPoint: canvasPos,
+    pixelBuffer: null,
+    originalPixelBuffer: null,
+    layerId: activeLayerId,
+    tool: 'history-brush',
+    startPoint: layerPos,
+    layerStartX: activeLayer.x,
+    layerStartY: activeLayer.y,
+    ...DEFAULT_TRANSFORM_FIELDS,
+  };
+}
+
+export function handleHistoryBrushMove(state: InteractionState, ctx: InteractionContext): void {
+  if (!state.lastPoint || !state.layerId || !sourceCache) return;
+
+  const toolSettings = useToolSettingsStore.getState();
+  const size = toolSettings.historyBrushSize;
+  const spacing = Math.max(1, size * 0.25);
+
+  const pts = interpolateFlat(state.lastPoint, ctx.canvasPos, spacing);
+  for (let i = 0; i < pts.length; i += 2) {
+    applyDabAtDocPos(pts[i]!, pts[i + 1]!, state.layerId, sourceCache);
+  }
+
+  state.lastPoint = ctx.canvasPos;
+}
+
+export function handleHistoryBrushUp(_ctx: InteractionContext, _state: InteractionState): void {
+  sourceCache = null;
+}

--- a/src/tools/history-brush/history-brush.test.ts
+++ b/src/tools/history-brush/history-brush.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { brushWeight, applyHistoryBrushDab } from './history-brush';
+import { PixelBuffer } from '../../engine/pixel-data';
+
+// ---------------------------------------------------------------------------
+// brushWeight
+// ---------------------------------------------------------------------------
+
+describe('brushWeight', () => {
+  it('returns 1 at center for any hardness', () => {
+    expect(brushWeight(0, 10, 1)).toBe(1);
+    expect(brushWeight(0, 10, 0.5)).toBe(1);
+    expect(brushWeight(0, 10, 0)).toBe(1);
+  });
+
+  it('returns 0 at or beyond radius', () => {
+    expect(brushWeight(10, 10, 1)).toBe(0);
+    expect(brushWeight(15, 10, 0.5)).toBe(0);
+  });
+
+  it('returns 1 inside the hard core', () => {
+    // hardness=1: entire brush is hard core
+    expect(brushWeight(5, 10, 1)).toBe(1);
+    // hardness=0.8: hard core radius = 8; d=7 is inside
+    expect(brushWeight(7, 10, 0.8)).toBe(1);
+  });
+
+  it('returns a value in (0, 1) in the feather zone', () => {
+    // hardness=0, no hard core; d=5 is in the middle → strictly between 0 and 1
+    const w = brushWeight(5, 10, 0);
+    expect(w).toBeGreaterThan(0);
+    expect(w).toBeLessThan(1);
+  });
+
+  it('returns 0 for zero radius', () => {
+    expect(brushWeight(0, 0, 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyHistoryBrushDab
+// ---------------------------------------------------------------------------
+
+describe('applyHistoryBrushDab', () => {
+  it('paints source pixels onto the destination', () => {
+    const source = new PixelBuffer(20, 20);
+    source.setPixel(10, 10, { r: 255, g: 0, b: 0, a: 1 });
+
+    const dest = new PixelBuffer(20, 20);
+
+    applyHistoryBrushDab({
+      destX: 10,
+      destY: 10,
+      source,
+      dest,
+      radius: 2,
+      hardness: 1,
+      opacity: 1,
+    });
+
+    const px = dest.getPixel(10, 10);
+    expect(px.r).toBe(255);
+    expect(px.g).toBe(0);
+    expect(px.b).toBe(0);
+    expect(px.a).toBeGreaterThan(0);
+  });
+
+  it('does not paint over destinations when source has no content', () => {
+    const source = new PixelBuffer(20, 20); // all transparent
+    const dest = new PixelBuffer(20, 20);
+    dest.setPixel(10, 10, { r: 100, g: 100, b: 100, a: 1 });
+
+    applyHistoryBrushDab({
+      destX: 10,
+      destY: 10,
+      source,
+      dest,
+      radius: 2,
+      hardness: 1,
+      opacity: 1,
+    });
+
+    // Destination pixel must be unchanged since source has no content
+    const px = dest.getPixel(10, 10);
+    expect(px.r).toBe(100);
+  });
+
+  it('blends at reduced opacity', () => {
+    const source = new PixelBuffer(20, 20);
+    source.setPixel(10, 10, { r: 200, g: 0, b: 0, a: 1 });
+
+    const dest = new PixelBuffer(20, 20);
+    dest.setPixel(10, 10, { r: 0, g: 0, b: 0, a: 1 });
+
+    applyHistoryBrushDab({
+      destX: 10,
+      destY: 10,
+      source,
+      dest,
+      radius: 2,
+      hardness: 1,
+      opacity: 0.5,
+    });
+
+    const px = dest.getPixel(10, 10);
+    // At 50% opacity: blended r = 200*0.5 + 0*0.5 = 100
+    expect(px.r).toBeCloseTo(100, -1);
+  });
+
+  it('only affects pixels within the circular radius', () => {
+    const source = new PixelBuffer(30, 30);
+    // fill source with red
+    for (let y = 0; y < 30; y++) {
+      for (let x = 0; x < 30; x++) {
+        source.setPixel(x, y, { r: 255, g: 0, b: 0, a: 1 });
+      }
+    }
+
+    const dest = new PixelBuffer(30, 30);
+
+    applyHistoryBrushDab({
+      destX: 15,
+      destY: 15,
+      source,
+      dest,
+      radius: 4,
+      hardness: 1,
+      opacity: 1,
+    });
+
+    // Pixel far from center should be untouched (transparent)
+    const farPixel = dest.getPixel(0, 0);
+    expect(farPixel.a).toBe(0);
+  });
+});

--- a/src/tools/history-brush/history-brush.ts
+++ b/src/tools/history-brush/history-brush.ts
@@ -1,0 +1,74 @@
+import type { PixelSurface } from '../../types';
+import type { Color } from '../../types/color';
+
+export interface HistoryBrushDabParams {
+  /** Center of the dab in destination layer coordinates. */
+  destX: number;
+  destY: number;
+  /** The source snapshot surface to sample from (layer-aligned). */
+  source: PixelSurface;
+  /** Destination surface to paint onto. */
+  dest: PixelSurface;
+  /** Brush radius in pixels. */
+  radius: number;
+  /** Brush hardness 0–1. 1 = hard edge, 0 = fully feathered. */
+  hardness: number;
+  /** Brush opacity 0–1. */
+  opacity: number;
+}
+
+/**
+ * Compute the soft-brush coverage weight for a pixel at distance `d`
+ * from center, given a brush of `radius` and `hardness` (0–1).
+ *
+ * Weight is 1 at the hard core (d <= hardRadius) and falls off
+ * smoothly to 0 at the outer radius edge.
+ */
+export function brushWeight(d: number, radius: number, hardness: number): number {
+  if (radius <= 0) return 0;
+  if (d >= radius) return 0;
+  const hardRadius = radius * hardness;
+  if (d <= hardRadius) return 1;
+  // Smooth falloff from hardRadius to radius
+  const t = (d - hardRadius) / Math.max(1e-6, radius - hardRadius);
+  return 1 - t * t;
+}
+
+/**
+ * Apply a single history-brush dab: sample each pixel from the source
+ * snapshot and composite it over the destination at the given brush weight.
+ *
+ * Coordinates are in the destination layer's local space. The source surface
+ * is assumed to be co-registered with the destination (same document origin).
+ */
+export function applyHistoryBrushDab(params: HistoryBrushDabParams): void {
+  const { destX, destY, source, dest, radius, hardness, opacity } = params;
+  const r = Math.floor(radius);
+  const cx = Math.round(destX);
+  const cy = Math.round(destY);
+
+  for (let dy = -r; dy <= r; dy++) {
+    for (let dx = -r; dx <= r; dx++) {
+      const d = Math.sqrt(dx * dx + dy * dy);
+      const weight = brushWeight(d, radius, hardness);
+      if (weight <= 0) continue;
+
+      const px = cx + dx;
+      const py = cy + dy;
+
+      const srcPixel = source.getPixel(px, py);
+      if (srcPixel.a <= 0) continue;
+
+      const dstPixel = dest.getPixel(px, py);
+      const alpha = weight * opacity * srcPixel.a;
+
+      const blended: Color = {
+        r: Math.round(srcPixel.r * alpha + dstPixel.r * (1 - alpha)),
+        g: Math.round(srcPixel.g * alpha + dstPixel.g * (1 - alpha)),
+        b: Math.round(srcPixel.b * alpha + dstPixel.b * (1 - alpha)),
+        a: Math.min(1, dstPixel.a + alpha * (1 - dstPixel.a)),
+      };
+      dest.setPixel(px, py, blended);
+    }
+  }
+}

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -13,6 +13,7 @@ import { handleSpongeDown, handleSpongeMove, handleSpongeUp } from './sponge/spo
 import { handleSmudgeDown, handleSmudgeMove } from './smudge/smudge-interaction';
 import { handleStampDown, handleStampMove } from './stamp/stamp-interaction';
 import { handleHealingDown, handleHealingMove } from './healing/healing-interaction';
+import { handleHistoryBrushDown, handleHistoryBrushMove, handleHistoryBrushUp } from './history-brush/history-brush-interaction';
 import { handleTextDown, handleTextMove, handleTextUp, commitTextEditing } from './text/text-interaction';
 import { handleCropDown, handleCropMove, handleCropUp } from './crop/crop-interaction';
 import { handlePathDown, handlePathMove, handlePathUp } from './path/path-interaction';
@@ -35,6 +36,7 @@ import { ShapeOptions } from '../app/OptionsBar/tool-options/ShapeOptions';
 import { GradientOptions } from '../app/OptionsBar/tool-options/GradientOptions';
 import { StampOptions } from '../app/OptionsBar/tool-options/StampOptions';
 import { HealingOptions } from './healing/HealingOptions';
+import { HistoryBrushOptions } from './history-brush/HistoryBrushOptions';
 import { PathOptions } from '../app/OptionsBar/tool-options/PathOptions';
 import { TextOptions } from '../app/OptionsBar/tool-options/TextOptions';
 import { MagneticLassoOptions } from '../app/OptionsBar/tool-options/MagneticLassoOptions';
@@ -331,6 +333,18 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
       down: (ctx) => handleSprayDown(ctx),
       move: (ctx, state) => handleSprayMove(ctx, state),
       up: () => handleSprayUp(),
+    },
+  },
+  'history-brush': {
+    id: 'history-brush',
+    label: 'History Brush',
+    shortcut: 'y',
+    optionsComponent: HistoryBrushOptions,
+    isPaint: true,
+    handler: {
+      down: (ctx) => handleHistoryBrushDown(ctx),
+      move: (ctx, state) => handleHistoryBrushMove(state, ctx),
+      up: (ctx, state) => handleHistoryBrushUp(ctx, state),
     },
   },
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -23,7 +23,8 @@ export type ToolId =
   | 'crop'
   | 'path'
   | 'spray'
-  | 'healing';
+  | 'healing'
+  | 'history-brush';
 
 export interface PixelSurface {
   readonly width: number;


### PR DESCRIPTION
Paint pixels from a prior history snapshot onto the current layer. Source icon in History panel, shortcut Y, size/opacity/hardness controls. 9 unit tests + 4 E2E tests. 🤖 Generated with Claude Code