### PR TITLE
refactor(selection): move feather control into marquee toolbars

### DIFF
--- a/src/app/OptionsBar/tool-options/MarqueeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/MarqueeOptions.tsx
@@ -1,5 +1,26 @@
 import { AspectRatioControl } from './AspectRatioControl';
+import { Slider } from '../../../components/Slider/Slider';
+import { useToolSettingsStore } from '../../tool-settings-store';
+import styles from './ToolOptions.module.css';
 
 export function MarqueeOptions() {
-  return <AspectRatioControl />;
+  const marqueeFeather = useToolSettingsStore((s) => s.marqueeFeather);
+  const setMarqueeFeather = useToolSettingsStore((s) => s.setMarqueeFeather);
+
+  return (
+    <div className={styles.container}>
+      <AspectRatioControl />
+      <div className={styles.sliderGroup}>
+        <label className={styles.label}>Feather</label>
+        <Slider
+          value={marqueeFeather}
+          onChange={setMarqueeFeather}
+          min={0}
+          max={250}
+          step={1}
+        />
+        <span className={styles.value}>{marqueeFeather} px</span>
+      </div>
+    </div>
+  );
 }

--- a/src/app/interactions/selection-handlers.ts
+++ b/src/app/interactions/selection-handlers.ts
@@ -9,6 +9,7 @@ import {
   createEllipseSelection as tsCreateEllipseSelection,
   selectionBounds as tsSelectionBounds,
   getSelectionMaskValue,
+  featherSelection,
 } from '../../selection/selection';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
@@ -206,7 +207,11 @@ export function handleSelectionDown(
     const wandMaskRaw = wandGraduated
       ? wasmFloodFillGraduated(pixelData, docW, docH, cx, cy, wandTolerance, wandContiguous)
       : wasmFloodFill(pixelData, docW, docH, cx, cy, 0, 0, 0, 0, wandTolerance, wandContiguous);
-    const wandMask = new Uint8ClampedArray(wandMaskRaw.buffer, wandMaskRaw.byteOffset, wandMaskRaw.byteLength);
+    let wandMask = new Uint8ClampedArray(wandMaskRaw.buffer, wandMaskRaw.byteOffset, wandMaskRaw.byteLength);
+    const featherRadius = toolSettings.marqueeFeather;
+    if (featherRadius > 0) {
+      wandMask = featherSelection(wandMask, docW, docH, featherRadius);
+    }
     const wandBounds = selectionBounds(wandMask, docW, docH);
     if (wandBounds) {
       editorState.setSelection(wandBounds, wandMask, docW, docH);
@@ -319,9 +324,13 @@ export function handleSelectionMove(
 
     if (w > 0 && h > 0) {
       const selRect = { x, y, width: w, height: h };
-      const mask = state.tool === 'marquee-rect'
+      let mask = state.tool === 'marquee-rect'
         ? createRectSelection(selRect, editorState.document.width, editorState.document.height)
         : createEllipseSelection(selRect, editorState.document.width, editorState.document.height);
+      const featherRadius = toolSettings.marqueeFeather;
+      if (featherRadius > 0) {
+        mask = featherSelection(mask, editorState.document.width, editorState.document.height, featherRadius);
+      }
       editorState.setSelection(selRect, mask, editorState.document.width, editorState.document.height);
       useUIStore.getState().setTransform(createTransformState(selRect));
     }
@@ -391,7 +400,11 @@ export function handleSelectionUp(
     if (lassoPoints.length >= 3) {
       const editorState = useEditorStore.getState();
       const { width: docW, height: docH } = editorState.document;
-      const lassoMask = createPolygonMask(lassoPoints, docW, docH);
+      let lassoMask = createPolygonMask(lassoPoints, docW, docH);
+      const featherRadius = useToolSettingsStore.getState().marqueeFeather;
+      if (featherRadius > 0) {
+        lassoMask = featherSelection(lassoMask, docW, docH, featherRadius);
+      }
       const lassoBounds = selectionBounds(lassoMask, docW, docH);
       if (lassoBounds) {
         editorState.setSelection(lassoBounds, lassoMask, docW, docH);
@@ -417,7 +430,11 @@ export function handleSelectionUp(
       if (polyline.length >= 3) {
         const editorState = useEditorStore.getState();
         const { width: docW, height: docH } = editorState.document;
-        const mask = createPolygonMask(polyline, docW, docH);
+        let mask = createPolygonMask(polyline, docW, docH);
+        const featherRadius = useToolSettingsStore.getState().marqueeFeather;
+        if (featherRadius > 0) {
+          mask = featherSelection(mask, docW, docH, featherRadius);
+        }
         const bounds = selectionBounds(mask, docW, docH);
         if (bounds) {
           editorState.setSelection(bounds, mask, docW, docH);

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -322,6 +322,7 @@ interface ToolSettings {
   aspectRatioW: number;
   aspectRatioH: number;
   aspectRatioLocked: boolean;
+  marqueeFeather: number;
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
@@ -380,6 +381,7 @@ interface ToolSettings {
   setWandTolerance: (tolerance: number) => void;
   setWandContiguous: (contiguous: boolean) => void;
   setWandGraduated: (graduated: boolean) => void;
+  setMarqueeFeather: (feather: number) => void;
   setMagneticLassoWidth: (width: number) => void;
   setMagneticLassoContrast: (contrast: number) => void;
   setMagneticLassoFrequency: (frequency: number) => void;
@@ -447,6 +449,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   aspectRatioW: 1,
   aspectRatioH: 1,
   aspectRatioLocked: false,
+  marqueeFeather: 0,
   gradientType: 'linear',
   gradientStops: [
     { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
@@ -572,6 +575,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setWandTolerance: (tolerance) => set({ wandTolerance: Math.max(0, Math.min(255, tolerance)) }),
   setWandContiguous: (contiguous) => set({ wandContiguous: contiguous }),
   setWandGraduated: (graduated) => set({ wandGraduated: graduated }),
+  setMarqueeFeather: (feather) => set({ marqueeFeather: Math.max(0, Math.min(250, Math.round(feather))) }),
   setMagneticLassoWidth: (width) => set({ magneticLassoWidth: Math.max(1, Math.min(40, Math.round(width))) }),
   setMagneticLassoContrast: (contrast) => set({ magneticLassoContrast: Math.max(1, Math.min(100, Math.round(contrast))) }),
   setMagneticLassoFrequency: (frequency) => set({ magneticLassoFrequency: Math.max(0, Math.min(200, Math.round(frequency))) }),


### PR DESCRIPTION
## Summary
- Adds `marqueeFeather` setting to the tool settings store (0–250 px range)
- Updates `MarqueeOptions` component to include a feather slider alongside the existing aspect ratio control
- Applies feather automatically when creating selections with marquee rect/ellipse, magic wand, lasso, and magnetic lasso tools
- Replaces the modal dialog workflow — feather is now a direct toolbar control

## Test plan
- [ ] Select any marquee tool and verify the Feather slider appears in the options bar
- [ ] Set feather to ~20 px, draw a rectangular selection, confirm soft edges on the marching ants
- [ ] Verify feather applies to elliptical marquee, magic wand, lasso, and magnetic lasso
- [ ] Confirm feather=0 produces hard-edged selections (no regression)
- [ ] Select > Feather menu item still works independently for post-hoc feathering

🤖 Generated with [Claude Code](https://claude.com/claude-code)