### PR TITLE
fix(marquee): use existing OptionsBar styles instead of missing CSS module

### DIFF
--- a/src/app/OptionsBar/tool-options/MarqueeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/MarqueeOptions.tsx
@@ -1,26 +1,15 @@
 import { AspectRatioControl } from './AspectRatioControl';
 import { Slider } from '../../../components/Slider/Slider';
 import { useToolSettingsStore } from '../../tool-settings-store';
-import styles from './ToolOptions.module.css';
 
 export function MarqueeOptions() {
   const marqueeFeather = useToolSettingsStore((s) => s.marqueeFeather);
   const setMarqueeFeather = useToolSettingsStore((s) => s.setMarqueeFeather);
 
   return (
-    <div className={styles.container}>
+    <>
       <AspectRatioControl />
-      <div className={styles.sliderGroup}>
-        <label className={styles.label}>Feather</label>
-        <Slider
-          value={marqueeFeather}
-          onChange={setMarqueeFeather}
-          min={0}
-          max={250}
-          step={1}
-        />
-        <span className={styles.value}>{marqueeFeather} px</span>
-      </div>
-    </div>
+      <Slider label="Feather" value={marqueeFeather} min={0} max={250} onChange={setMarqueeFeather} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes build error from PR #316 where `MarqueeOptions.tsx` imported a non-existent `ToolOptions.module.css`
- Simplified the component to use the existing `Slider` component pattern (matching `WandOptions`, `StampOptions`, etc.)

## Test plan
- [ ] `npm run build` passes
- [ ] Marquee tool options bar shows Feather slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)