### PR TITLE
fix(adjustments): prevent slider drag from triggering node reorder

### DIFF
--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -257,13 +257,15 @@ function AdjustmentNodeRow({
   return (
     <div
       className={`${styles.nodeRow} ${isDragOver ? styles.nodeRowDragOver : ''}`}
-      draggable
-      onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
-      onDragEnd={onDragEnd}
     >
-      <div className={styles.nodeHeader}>
+      <div
+        className={styles.nodeHeader}
+        draggable
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+      >
         <button type="button" className={styles.nodeExpandBtn} onClick={onToggleExpand} aria-label={isExpanded ? 'Collapse' : 'Expand'}>
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </button>


### PR DESCRIPTION
## Summary
- `draggable` was on the entire `nodeRow` div, so interacting with sliders (exposure, contrast, etc.) initiated a drag-to-reorder instead of adjusting the value
- Moved `draggable` and `onDragStart` to just the `nodeHeader` div (the grab handle area with the label and buttons)
- `onDragOver`/`onDrop` stay on the full row so drop targets work correctly

## Test plan
- [ ] Add an Exposure adjustment node, expand it, drag the slider — value should change without triggering reorder
- [ ] Drag the node header (label area) — should still reorder nodes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)