### PR TITLE
fix(adjustments): auto-expand new nodes and make panel resizable

### DIFF
--- a/src/app/App.module.css
+++ b/src/app/App.module.css
@@ -109,6 +109,11 @@
 
 .effectsDrawer {
   width: 420px;
+  min-width: 280px;
+  min-height: 200px;
+  max-height: 80vh;
+  resize: both;
+  overflow: auto;
 }
 
 .referenceDrawer {

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -30,7 +30,6 @@ import type {
 } from '../../types/adjustment-nodes';
 import {
   ADJUSTMENT_NODE_LABELS,
-  createDefaultNode,
 } from '../../filters/adjustment-node-utils';
 import styles from './AdjustmentsPanel.module.css';
 
@@ -120,9 +119,11 @@ export function AdjustmentsPanel({ showHeader, dragProps }: AdjustmentsPanelProp
   const handleAddNode = (type: AdjustmentNodeType) => {
     setShowAddMenu(false);
     addAdjustmentNode(group.id, type);
-    // Auto-expand the new node.
-    const newNode = createDefaultNode(type);
-    setExpandedNodeId(newNode.id);
+    const updated = useEditorStore.getState().document.layers.find(
+      (l) => l.id === group.id && l.type === 'group',
+    ) as GroupLayer | undefined;
+    const lastNode = updated?.adjustments[updated.adjustments.length - 1];
+    if (lastNode) setExpandedNodeId(lastNode.id);
   };
 
   const handleDragStart = (idx: number) => {


### PR DESCRIPTION
## Summary
- **Auto-expand**: New adjustment nodes now open expanded immediately after adding. The previous code created a throwaway `createDefaultNode()` to get its ID, which didn't match the actual node created by the store.
- **Resizable panel**: The effects/adjustments drawer is now resizable via native CSS resize handle (min 280×200, max 80vh).

## Test plan
- [ ] Add a new adjustment node (e.g. Exposure) — should appear already expanded with sliders visible
- [ ] Drag the resize handle at the bottom-right of the panel — should resize both width and height
- [ ] Panel respects min (280×200) and max (80vh) bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)