### PR TITLE
fix(build): remove tracked pkg symlink and pre-clean wasm output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ storybook-static
 
 # Rust build artifacts
 engine-rs/target/
+src/engine-wasm/pkg/
 
 # Playwright test artifacts
 test-results/

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "A browser-based image editor",
   "scripts": {
-    "wasm:build": "cd engine-rs && wasm-pack build crates/lopsy-wasm --target web --out-dir ../../../src/engine-wasm/pkg",
-    "wasm:build:dev": "cd engine-rs && wasm-pack build crates/lopsy-wasm --target web --dev --out-dir ../../../src/engine-wasm/pkg",
+    "wasm:build": "rm -rf src/engine-wasm/pkg && cd engine-rs && wasm-pack build crates/lopsy-wasm --target web --out-dir ../../../src/engine-wasm/pkg",
+    "wasm:build:dev": "rm -rf src/engine-wasm/pkg && cd engine-rs && wasm-pack build crates/lopsy-wasm --target web --dev --out-dir ../../../src/engine-wasm/pkg",
     "wasm:test": "cd engine-rs && cargo test",
     "dev": "vite",
     "build": "npm run wasm:build && tsc --noEmit && vite build",

--- a/src/engine-wasm/pkg
+++ b/src/engine-wasm/pkg
@@ -1,1 +1,0 @@
-/Users/seamus/conductor/repos/lopsy.art/src/engine-wasm/pkg


### PR DESCRIPTION
## Summary
- Removes `src/engine-wasm/pkg` symlink that was accidentally committed to git, causing CI builds to fail with "File exists (os error 17)" when wasm-pack tried to write to the existing target
- Adds `src/engine-wasm/pkg/` to `.gitignore` (generated build output)
- Adds `rm -rf src/engine-wasm/pkg` pre-clean step to `wasm:build` and `wasm:build:dev` scripts

## Test plan
- [ ] CI build passes (wasm-pack no longer errors on existing directory)
- [ ] `npm run wasm:build` succeeds locally
- [ ] `npm run build` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)