### PR TITLE
fix(history): tool-specific labels + mask row enters edit mode

### DIFF
--- a/src/app/MenuBar/filter-actions.ts
+++ b/src/app/MenuBar/filter-actions.ts
@@ -60,7 +60,7 @@ export function applyGenericFilter(id: FilterDialogId, values: Record<string, nu
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory(filter.title);
   filter.applyGpu(engine, activeId, values);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -118,7 +118,7 @@ export function applyGenericFilterWithPreview(id: FilterDialogId, values: Record
   clearFilterPreview(engine);
 
   // Now apply for real with history
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory(filter.title);
   filter.applyGpu(engine, activeId, values);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -131,7 +131,7 @@ export function applyInvert(): void {
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Invert');
   filterInvert(engine, activeId);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -144,7 +144,7 @@ export function applyDesaturate(): void {
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Desaturate');
   filterDesaturate(engine, activeId);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -157,7 +157,7 @@ export function applyAddNoise(amount: number, monochrome: boolean): void {
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Add Noise');
   filterAddNoise(engine, activeId, amount, monochrome);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -170,7 +170,7 @@ export function applyFillWithNoise(monochrome: boolean): void {
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Fill with Noise');
   filterFillWithNoise(engine, activeId, monochrome);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
@@ -183,7 +183,7 @@ export function applyFindEdges(): void {
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Find Edges');
   filterFindEdges(engine, activeId);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();

--- a/src/app/MenuBar/menus/edit-menu.ts
+++ b/src/app/MenuBar/menus/edit-menu.ts
@@ -16,7 +16,7 @@ export function fillSelection(): void {
   const engine = getEngine();
   if (!engine) return;
 
-  state.pushHistory();
+  state.pushHistory('Fill');
   const color = useToolSettingsStore.getState().foregroundColor;
 
   // GPU fill: uses the engine's selection mask if active

--- a/src/app/MenuBar/menus/image-menu.ts
+++ b/src/app/MenuBar/menus/image-menu.ts
@@ -17,7 +17,7 @@ export function flipActiveLayer(axis: 'horizontal' | 'vertical'): void {
   const engine = getEngine();
   if (!engine) return;
 
-  state.pushHistory();
+  state.pushHistory(axis === 'horizontal' ? 'Flip Horizontal' : 'Flip Vertical');
   flipLayer(engine, activeId, axis === 'horizontal');
 
   // GPU is now source of truth — clear stale JS pixel data.
@@ -39,7 +39,7 @@ export function rotateActiveLayer(direction: 'cw' | 'ccw'): void {
   const layer = state.document.layers.find((l) => l.id === activeId);
   if (!layer || layer.type !== 'raster') return;
 
-  state.pushHistory();
+  state.pushHistory(direction === 'cw' ? 'Rotate Layer 90° CW' : 'Rotate Layer 90° CCW');
   rotateLayer90(engine, activeId, direction === 'cw');
 
   const cx = layer.x + layer.width / 2;
@@ -67,7 +67,7 @@ export function rotateImage(direction: 'cw' | 'ccw'): void {
   const engine = getEngine();
   if (!engine) return;
 
-  state.pushHistory();
+  state.pushHistory(direction === 'cw' ? 'Rotate Image 90° CW' : 'Rotate Image 90° CCW');
 
   const newWidth = doc.height;
   const newHeight = doc.width;

--- a/src/app/MenuBar/pattern-actions.ts
+++ b/src/app/MenuBar/pattern-actions.ts
@@ -93,7 +93,7 @@ export function applyPatternFill(patternId: string, scale: number, offsetX: numb
   const engine = getEngine();
   if (!engine) return;
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Pattern Fill');
   filterPatternFill(
     engine,
     activeId,
@@ -166,7 +166,7 @@ export function applyPatternFillWithPreview(patternId: string, scale: number, of
   restoreFilterPreview(engine);
   clearFilterPreview(engine);
 
-  useEditorStore.getState().pushHistory();
+  useEditorStore.getState().pushHistory('Pattern Fill');
   filterPatternFill(
     engine,
     activeId,

--- a/src/app/OptionsBar/tool-options/TransformControls.tsx
+++ b/src/app/OptionsBar/tool-options/TransformControls.tsx
@@ -32,7 +32,7 @@ export function applyGpuTransform(invMatrix: Float32Array): void {
   const activeLayerId = editorState.document.activeLayerId;
   if (!activeLayerId) return;
 
-  editorState.pushHistory();
+  editorState.pushHistory('Transform');
 
   // Float if needed
   if (!hasFloat(engine)) {

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -24,9 +24,8 @@ import { DEFAULT_TRANSFORM_FIELDS } from './interaction-types';
 
 export function handleMoveDown(ctx: InteractionContext): InteractionState {
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
-
   const sel = editorState.selection;
+  editorState.pushHistory(ctx.altKey && !(sel.active && sel.mask) ? 'Duplicate Layer' : 'Move');
   const {
     canvasPos,
     altKey,
@@ -282,7 +281,7 @@ export function handleNudgeMove(
   if (!layer || layer.locked) return;
 
   const sel = editor.selection;
-  editor.pushHistory();
+  editor.pushHistory('Nudge');
 
   if (sel.active && sel.mask) {
     const engine = getEngine();

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -52,7 +52,7 @@ export function handlePaintDown(
   // Quick Mask Mode: paint on the GPU quick mask texture in doc-space.
   // Brush paints white (add to selection), eraser paints black (remove).
   if (isQuickMaskMode) {
-    editorState.pushHistory();
+    editorState.pushHistory(tool === 'eraser' ? 'Quick Mask Erase' : 'Quick Mask Paint');
     const engine = getEngine();
 
     // Paint in doc-space (canvasPos), not layer-local coords
@@ -129,7 +129,7 @@ export function handlePaintDown(
 
   // Mask edit mode stays on CPU — small surface, infrequent
   if (maskEditMode && activeLayer.mask) {
-    editorState.pushHistory();
+    editorState.pushHistory(tool === 'eraser' ? 'Mask Erase' : 'Mask Paint');
     const maskBuf = createMaskSurface(activeLayer.mask.data, activeLayer.mask.width, activeLayer.mask.height);
     const maskColor = tool === 'eraser'
       ? { r: 255, g: 255, b: 255, a: 1 }
@@ -188,7 +188,8 @@ export function handlePaintDown(
   }
 
   if (!ctx.isStrokeContinuation) {
-    editorState.pushHistory();
+    const toolLabel = tool === 'brush' ? 'Brush' : tool === 'pencil' ? 'Pencil' : 'Eraser';
+    editorState.pushHistory(toolLabel);
   }
   resetScatterSpacingRemainder();
 

--- a/src/app/interactions/path-stroke.ts
+++ b/src/app/interactions/path-stroke.ts
@@ -18,7 +18,7 @@ export function rasterizePathToLayer(
   color: Color,
 ): void {
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
+  editorState.pushHistory('Stroke Path');
   const imageData = editorState.getOrCreateLayerPixelData(layerId);
   const buf = PixelBuffer.fromImageData(imageData);
   useToolSettingsStore.getState().addRecentColor(color);

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -88,7 +88,7 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
     ? computeRotation(canvasPos, currentTransform) - currentTransform.rotation
     : 0;
 
-  editorState.pushHistory();
+  editorState.pushHistory('Transform');
 
   // Clear floating selection ref when entering transform mode.
   floatingSelectionRef.current = null;

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -564,7 +564,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
   updateLayerEffects: (id: string, effects, skipHistory?: boolean) => {
     finalizePendingStrokeGlobal();
     const s = get();
-    if (!skipHistory) s.pushHistory('Update Effects');
+    if (!skipHistory) s.pushHistory('Edit Effect');
     set(computeUpdateEffects(s.document, s.renderVersion, id, effects));
   },
 

--- a/src/app/store/history-labels.test.ts
+++ b/src/app/store/history-labels.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+
+// Vite's import.meta.glob loads file contents at build time — no node fs.
+// `eager: true, query: '?raw'` returns each module as `{default: string}`.
+const RAW_MODULES = import.meta.glob('/src/**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+function productionFiles(): Array<[string, string]> {
+  return Object.entries(RAW_MODULES).filter(([path]) => {
+    if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) return false;
+    if (path.endsWith('.stories.tsx')) return false;
+    // The slice itself defines `pushHistory(label?: string)` — don't flag the
+    // declaration as an unlabeled call site.
+    if (path.endsWith('/history-slice.ts')) return false;
+    return true;
+  });
+}
+
+// Static scan: every `.pushHistory(...)` in src/ must pass an explicit label
+// argument. Falling back to the default `'Edit'` produces opaque entries in
+// the History panel — see #331.
+describe('pushHistory labels — every call site is labeled', () => {
+  it('no production source calls pushHistory() without a label', () => {
+    const offenders: string[] = [];
+    const callPattern = /\.pushHistory\(\s*\)/;
+    for (const [path, text] of productionFiles()) {
+      const lines = text.split('\n');
+      lines.forEach((line, i) => {
+        if (callPattern.test(line)) {
+          offenders.push(`${path}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('common operations have specific (non-"Edit", non-"Update Effects") labels', () => {
+    const directLabels = new Set<string>();
+    const labelPattern = /\.pushHistory\(\s*['"`]([^'"`]+)['"`]/g;
+    let allText = '';
+    for (const [, text] of productionFiles()) {
+      allText += '\n' + text;
+      let m: RegExpExecArray | null;
+      while ((m = labelPattern.exec(text)) !== null) {
+        if (m[1]) directLabels.add(m[1]);
+      }
+    }
+
+    // Tools/ops the user explicitly called out as needing better names.
+    const expectedDirect = [
+      'Shape',
+      'Smudge',
+      'Healing Brush',
+      'Clone Stamp',
+      'Spray',
+      'Stroke Path',
+      'Transform',
+      'Nudge',
+      'Invert',
+      'Desaturate',
+      'Add Noise',
+      'Find Edges',
+      'Pattern Fill',
+      'Bucket Fill',
+      'Quick Mask Fill',
+    ];
+    for (const label of expectedDirect) {
+      expect(directLabels, `missing direct label "${label}"`).toContain(label);
+    }
+
+    // Some labels are passed indirectly through a variable (e.g. paint
+    // handlers branch on tool type) — for those, just check the literal
+    // appears in the source.
+    const expectedAnywhere = [
+      "'Brush'",
+      "'Eraser'",
+      "'Pencil'",
+      "'Mask Paint'",
+      "'Mask Erase'",
+      "'Quick Mask Paint'",
+      "'Quick Mask Erase'",
+    ];
+    for (const lit of expectedAnywhere) {
+      expect(allText.includes(lit), `missing literal label ${lit} in source`).toBe(true);
+    }
+
+    // 'Edit' and 'Update Effects' were the generic defaults the user
+    // complained about — make sure no source code passes them as labels.
+    expect(directLabels).not.toContain('Edit');
+    expect(directLabels).not.toContain('Update Effects');
+  });
+});

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -398,7 +398,7 @@ export function useCanvasInteraction(
           // restores the freehand stroke (not the pre-stroke blank).
           // Stack was: [..., pre-stroke]. After push: [..., pre-stroke, freehand].
           const editor = useEditorStore.getState();
-          editor.pushHistory();
+          editor.pushHistory('Brush');
 
           // Restore the layer to its pre-stroke pixels so we can draw
           // the smooth stroke on a clean slate. We read the pre-stroke

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -267,7 +267,7 @@ function handleDeleteKey(): void {
     const selNow = useEditorStore.getState().selection;
     if (!selNow.active || !selNow.mask) return;
 
-    editor.pushHistory();
+    editor.pushHistory('Clear Selection');
     const bx = selNow.bounds ? Math.round(selNow.bounds.x) : 0;
     const by = selNow.bounds ? Math.round(selNow.bounds.y) : 0;
     const bw = selNow.bounds ? Math.round(selNow.bounds.width) : 0;

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -60,26 +60,31 @@ export function LayerEffectsPanel({ dragProps }: LayerEffectsPanelProps) {
     [activeLayerId, effects, updateLayerEffects],
   );
 
+  const effectLabel = (key: EffectKey): string =>
+    EFFECT_LIST.find((e) => e.key === key)?.label ?? 'Effect';
+
   // Committed update: push a single undo entry (for toggles, color picks, dropdowns)
   const update = useCallback(
-    (partial: Partial<LayerEffects>) => {
+    (partial: Partial<LayerEffects>, label?: string) => {
       if (!activeLayerId || !effects) return;
-      updateLayerEffects(activeLayerId, { ...effects, ...partial });
+      useEditorStore.getState().pushHistory(label ?? `Edit ${effectLabel(selectedEffect)}`);
+      updateLayerEffects(activeLayerId, { ...effects, ...partial }, true);
     },
-    [activeLayerId, effects, updateLayerEffects],
+    [activeLayerId, effects, updateLayerEffects, selectedEffect],
   );
 
   // Push one undo entry at the START of a slider drag so undo restores
   // the pre-drag state (not the post-drag state).
   const beginEffectsDrag = useCallback(() => {
-    useEditorStore.getState().pushHistory('Update Effects');
-  }, []);
+    useEditorStore.getState().pushHistory(`Edit ${effectLabel(selectedEffect)}`);
+  }, [selectedEffect]);
 
   const handleToggle = useCallback(
     (key: EffectKey) => {
       if (!effects) return;
       const current = effects[key];
-      update({ [key]: { ...current, enabled: !current.enabled } });
+      const verb = current.enabled ? 'Disable' : 'Enable';
+      update({ [key]: { ...current, enabled: !current.enabled } }, `${verb} ${effectLabel(key)}`);
     },
     [effects, update],
   );

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -410,7 +410,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   onClick={(e) => {
                     e.stopPropagation();
                     onSelectLayer(layer.id);
-                    setMaskEditMode(!maskEditMode || layer.id !== activeLayerId);
+                    setMaskEditMode(true);
                   }}
                   role="button"
                   tabIndex={0}

--- a/src/tools/dodge/dodge-interaction.ts
+++ b/src/tools/dodge/dodge-interaction.ts
@@ -25,9 +25,9 @@ function dodgeModeToU32(mode: DodgeMode): number {
 export function handleDodgeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
   const toolSettings = useToolSettingsStore.getState();
   const dodgeMode = toolSettings.dodgeMode;
+  editorState.pushHistory(dodgeMode === 'dodge' ? 'Dodge' : 'Burn');
   const exposure = toolSettings.dodgeExposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeShiftLine = shiftKey

--- a/src/tools/fill/fill-interaction.ts
+++ b/src/tools/fill/fill-interaction.ts
@@ -20,7 +20,7 @@ export function handleFillDown(ctx: InteractionContext): void {
 
   // In quick mask mode: fill the quick mask texture instead of the layer
   if (isQuickMaskMode) {
-    editorState.pushHistory();
+    editorState.pushHistory('Quick Mask Fill');
     const toolSettings = useToolSettingsStore.getState();
     const tolerance = toolSettings.fillTolerance;
     const contiguous = toolSettings.fillContiguous;
@@ -37,7 +37,7 @@ export function handleFillDown(ctx: InteractionContext): void {
   }
 
   // Normal mode: fill the active layer
-  editorState.pushHistory();
+  editorState.pushHistory('Bucket Fill');
   const toolSettings = useToolSettingsStore.getState();
   const color = toolSettings.foregroundColor;
   toolSettings.addRecentColor(color);

--- a/src/tools/gradient/gradient-interaction.ts
+++ b/src/tools/gradient/gradient-interaction.ts
@@ -14,8 +14,8 @@ import {
 export function handleGradientDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer } = ctx;
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
   const ts = useToolSettingsStore.getState();
+  editorState.pushHistory(ts.gradientType === 'radial' ? 'Radial Gradient' : 'Linear Gradient');
   ts.addRecentColor(ts.foregroundColor);
   ts.addRecentColor(ts.backgroundColor);
 

--- a/src/tools/healing/healing-interaction.ts
+++ b/src/tools/healing/healing-interaction.ts
@@ -48,7 +48,7 @@ export function handleHealingDown(ctx: InteractionContext): InteractionState | u
   if (!ctx.stampSourceRef.current) return undefined;
 
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
+  editorState.pushHistory('Healing Brush');
 
   if (!ctx.stampOffsetRef.current) {
     ctx.stampOffsetRef.current = {

--- a/src/tools/shape/shape-interaction.ts
+++ b/src/tools/shape/shape-interaction.ts
@@ -44,7 +44,7 @@ function constrainToAspectRatio(center: Point, edge: Point): Point {
 export function handleShapeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer } = ctx;
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
+  editorState.pushHistory('Shape');
 
   const ts = useToolSettingsStore.getState();
   if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
@@ -111,7 +111,7 @@ export function confirmShapeSize(width: number, height: number, click: ShapeSize
   const surface = wrapWithSelectionMask(pixelBuffer, click.layerX, click.layerY);
   const ts = useToolSettingsStore.getState();
 
-  editorState.pushHistory();
+  editorState.pushHistory('Shape');
   if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
   if (ts.shapeStrokeColor) ts.addRecentColor(ts.shapeStrokeColor);
 

--- a/src/tools/smudge/smudge-interaction.ts
+++ b/src/tools/smudge/smudge-interaction.ts
@@ -13,7 +13,7 @@ import { interpolateFlat } from '../common/dab-interpolation';
 export function handleSmudgeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
+  editorState.pushHistory('Smudge');
   const toolSettings = useToolSettingsStore.getState();
   const size = toolSettings.smudgeSize;
   const strength = toolSettings.smudgeStrength / 100;

--- a/src/tools/spray/spray-interaction.ts
+++ b/src/tools/spray/spray-interaction.ts
@@ -64,7 +64,7 @@ export function handleSprayDown(
   const toolSettings = useToolSettingsStore.getState();
   const editorState = useEditorStore.getState();
 
-  editorState.pushHistory();
+  editorState.pushHistory('Spray');
 
   const strokeColor = toolSettings.foregroundColor;
   const state: InteractionState = {

--- a/src/tools/stamp/stamp-interaction.ts
+++ b/src/tools/stamp/stamp-interaction.ts
@@ -22,7 +22,7 @@ export function handleStampDown(ctx: InteractionContext): InteractionState | und
   if (!ctx.stampSourceRef.current) return undefined;
 
   const editorState = useEditorStore.getState();
-  editorState.pushHistory();
+  editorState.pushHistory('Clone Stamp');
 
   if (!ctx.stampOffsetRef.current) {
     ctx.stampOffsetRef.current = {


### PR DESCRIPTION
## Summary

Fixes #331 and addresses one item from #329.

### #331 — Better history names

Audit of every `pushHistory(...)` call site in the codebase. Every call
now passes an explicit, descriptive label so the History panel shows
which tool / operation produced each snapshot instead of a wall of
generic "Edit" and "Update Effects" entries.

Highlights:
- Tool interactions get their tool name: `Brush`, `Eraser`, `Pencil`,
  `Shape`, `Bucket Fill`, `Smudge`, `Healing Brush`, `Clone Stamp`,
  `Spray`, `Stroke Path`, `Dodge` / `Burn`, `Linear Gradient` /
  `Radial Gradient`.
- Selection-aware ops: `Move`, `Nudge`, `Transform`, `Duplicate Layer`
  (option-drag), `Quick Mask Paint` / `Quick Mask Erase` /
  `Quick Mask Fill`, `Mask Paint` / `Mask Erase`, `Clear Selection`.
- Menu actions: `Flip Horizontal` / `Flip Vertical`,
  `Rotate Layer 90° CW/CCW`, `Rotate Image 90° CW/CCW`, `Pattern Fill`,
  `Invert`, `Desaturate`, `Add Noise`, `Fill with Noise`, `Find Edges`,
  and dialog filters now use the filter's own `title`.
- `LayerEffectsPanel` swaps the generic `Update Effects` for context-
  aware labels: `Edit Drop Shadow`, `Enable Stroke`, `Disable Outer
  Glow`, etc., based on which effect is active and what action was
  taken.

### #329 (partial) — Mask row enters edit mode

Clicking a layer's mask thumbnail now always enters mask-edit mode for
that layer instead of toggling. Toggling was confusing when the mask was
already active on a different layer; selecting the mask should always
mean "edit this mask".

The other bullets in #329 (filled-mask init, layer/mask deletion
coupling, mask follows layer position) are already covered in main; the
remaining fill/gradient-on-quick-mask feature work is tracked in #315.

## Test plan

New `src/app/store/history-labels.test.ts` (passes locally):

- `no production source calls pushHistory() without a label` — static
  scan over all `.ts` / `.tsx` in `src/` that fails if any call site
  reverts to the unlabeled default.
- `common operations have specific (non-"Edit", non-"Update Effects")
  labels` — asserts the expected tool/op label set is present and that
  the old generic strings are not.

Existing test suite: typecheck clean for these changes; the 12 pre-
existing test-file failures are all the wasm-pkg import error from a
missing `wasm-pack` build, unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyrCYScSK69ezsxwNWHU95)_