### PR TITLE
fix(filters): preserve previewed content for randomized filters

### DIFF
--- a/src/app/MenuBar/MenuBar.tsx
+++ b/src/app/MenuBar/MenuBar.tsx
@@ -273,6 +273,7 @@ export function MenuBar() {
         <FilterDialog
           title={filterDef.title}
           params={filterDef.params}
+          showRegenerate={filterDef.randomized}
           onApply={handleGenericFilterApply}
           onCancel={handleDialogCancel}
           onPreviewStart={handlePreviewStart}

--- a/src/app/MenuBar/filter-actions.ts
+++ b/src/app/MenuBar/filter-actions.ts
@@ -11,6 +11,7 @@ import {
   restoreFilterPreview,
   clearFilterPreview,
 } from '../../engine-wasm/wasm-bridge';
+import { readLayerCompressed, uploadCompressed } from '../../engine-wasm/gpu-pixel-access';
 import { filterRegistry } from '../../filters/filter-registry';
 import type { FilterDefinition } from '../../filters/filter-types';
 
@@ -113,13 +114,22 @@ export function applyGenericFilterWithPreview(id: FilterDialogId, values: Record
   const engine = getEngine();
   if (!engine) return;
 
-  // Restore original first so history captures the unfiltered state
+  // Snapshot the current GPU texture (the preview the user is looking at)
+  // so we can restore it after capturing history from the original.
+  const previewPixels = readLayerCompressed(activeId);
+
+  // Restore original so history captures the unfiltered state
   restoreFilterPreview(engine);
   clearFilterPreview(engine);
 
-  // Now apply for real with history
   useEditorStore.getState().pushHistory(filter.title);
-  filter.applyGpu(engine, activeId, values);
+
+  if (previewPixels) {
+    uploadCompressed(activeId, previewPixels);
+  } else {
+    filter.applyGpu(engine, activeId, values);
+  }
+
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
 }

--- a/src/components/FilterDialog/FilterDialog.module.css
+++ b/src/components/FilterDialog/FilterDialog.module.css
@@ -72,6 +72,12 @@
   gap: var(--space-2);
 }
 
+.footerLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .footerButtons {
   display: flex;
   align-items: center;
@@ -94,6 +100,25 @@
   height: 14px;
   accent-color: var(--color-accent);
   cursor: pointer;
+}
+
+.regenerateButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.regenerateButton:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
 }
 
 .cancelButton {

--- a/src/components/FilterDialog/FilterDialog.tsx
+++ b/src/components/FilterDialog/FilterDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { Slider } from '../Slider/Slider';
 import { useDraggablePanel } from '../../app/hooks/useDraggablePanel';
 import { useEditorStore } from '../../app/editor-store';
@@ -19,6 +20,7 @@ interface FilterParam {
 interface FilterDialogProps {
   title: string;
   params: FilterParam[];
+  showRegenerate?: boolean;
   onApply: (values: Record<string, number>) => void;
   onCancel: () => void;
   onPreviewChange?: (values: Record<string, number>) => void;
@@ -28,7 +30,7 @@ interface FilterDialogProps {
 
 export type { FilterParam, FilterDialogProps };
 
-export function FilterDialog({ title, params, onApply, onCancel, onPreviewChange, onPreviewStart, onPreviewStop }: FilterDialogProps) {
+export function FilterDialog({ title, params, showRegenerate, onApply, onCancel, onPreviewChange, onPreviewStart, onPreviewStop }: FilterDialogProps) {
   const [values, setValues] = useState<Record<string, number>>(() => {
     const initial: Record<string, number> = {};
     for (const param of params) {
@@ -55,6 +57,17 @@ export function FilterDialog({ title, params, onApply, onCancel, onPreviewChange
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [values, preview, onPreviewChange]);
+
+  const handleRegenerate = useCallback(() => {
+    if (!preview) {
+      setPreview(true);
+      previewActiveRef.current = true;
+      onPreviewStart?.();
+    }
+    if (onPreviewChange) {
+      setTimeout(() => onPreviewChange(values), 0);
+    }
+  }, [preview, onPreviewStart, onPreviewChange, values]);
 
   const handlePreviewToggle = useCallback(() => {
     setPreview((prev) => {
@@ -131,15 +144,28 @@ export function FilterDialog({ title, params, onApply, onCancel, onPreviewChange
           })}
         </div>
         <div className={styles.footer}>
-          <label className={styles.previewLabel}>
-            <input
-              type="checkbox"
-              checked={preview}
-              onChange={handlePreviewToggle}
-              className={styles.previewCheckbox}
-            />
-            Preview
-          </label>
+          <div className={styles.footerLeft}>
+            <label className={styles.previewLabel}>
+              <input
+                type="checkbox"
+                checked={preview}
+                onChange={handlePreviewToggle}
+                className={styles.previewCheckbox}
+              />
+              Preview
+            </label>
+            {showRegenerate && (
+              <button
+                className={styles.regenerateButton}
+                onClick={handleRegenerate}
+                type="button"
+                title="Regenerate"
+                aria-label="Regenerate"
+              >
+                <RefreshCw size={14} />
+              </button>
+            )}
+          </div>
           <div className={styles.footerButtons}>
             <button className={styles.cancelButton} onClick={handleCancel} type="button">
               Cancel

--- a/src/filters/clouds.ts
+++ b/src/filters/clouds.ts
@@ -7,6 +7,7 @@ export const clouds: FilterDefinition = {
   params: [
     { key: 'scale', label: 'Scale', min: 1, max: 20, step: 1, defaultValue: 5 },
   ],
+  randomized: true,
   applyGpu: (engine, layerId, values) => {
     const seed = Math.random() * 1000;
     filterClouds(engine, layerId, values['scale'] ?? 5, seed);

--- a/src/filters/filter-types.ts
+++ b/src/filters/filter-types.ts
@@ -5,5 +5,6 @@ export interface FilterDefinition {
   id: string;
   title: string;
   params: FilterParam[];
+  randomized?: boolean;
   applyGpu: (engine: Engine, layerId: string, values: Record<string, number>) => void;
 }

--- a/src/filters/smoke.ts
+++ b/src/filters/smoke.ts
@@ -8,6 +8,7 @@ export const smoke: FilterDefinition = {
     { key: 'scale', label: 'Scale', min: 1, max: 20, step: 1, defaultValue: 4 },
     { key: 'turbulence', label: 'Turbulence', min: 0, max: 100, step: 1, defaultValue: 50 },
   ],
+  randomized: true,
   applyGpu: (engine, layerId, values) => {
     const seed = Math.random() * 1000;
     filterSmoke(


### PR DESCRIPTION
## Summary
- **Bug fix**: When confirming the smoke/clouds filter dialog with preview active, the result was re-generated with a new random seed instead of keeping the previewed content. Now the exact GPU pixels from the preview are captured and restored after history is pushed.
- **Regenerate button**: Adds a cycle (↻) icon button on randomized filter dialogs (smoke, clouds) so users can generate new variations with the same settings without toggling preview off/on.

Closes #357

## Test plan
- [ ] Open Smoke or Clouds filter with preview enabled
- [ ] Adjust parameters and observe the preview
- [ ] Click Apply — verify the result matches what was previewed
- [ ] Click the regenerate (↻) button — verify it produces a new variation with the same settings
- [ ] Verify undo restores the original layer content
- [ ] Verify deterministic filters (e.g. Gaussian Blur) still work correctly with preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)