### PR TITLE
refactor(brush): move jitter, speed, texture controls to brush modal

### DIFF
--- a/e2e/brush-jitter-texture.spec.ts
+++ b/e2e/brush-jitter-texture.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from './fixtures';
-import { setToolOption, setBrushModalOption, closeBrushModal } from './helpers';
+import { setToolOption, setBrushModalOption, openBrushModal, closeBrushModal } from './helpers';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -130,21 +130,27 @@ async function setupBrush(page: Page, opts: { size: number; opacity: number; har
 }
 
 async function setJitter(page: Page, sizeJ: number, angleJ: number, opacityJ: number) {
-  await setToolOption(page, 'Size Jitter', sizeJ);
-  await setToolOption(page, 'Angle Jitter', angleJ);
-  await setToolOption(page, 'Opacity Jitter', opacityJ);
+  await openBrushModal(page);
+  await setBrushModalOption(page, 'Size Jitter', sizeJ);
+  await setBrushModalOption(page, 'Angle Jitter', angleJ);
+  await setBrushModalOption(page, 'Opacity Jitter', opacityJ);
+  await closeBrushModal(page);
 }
 
 async function selectTexture(page: Page, textureName: string) {
-  const select = page.locator('role=toolbar >> select[title="Brush texture"]');
+  await openBrushModal(page);
+  const select = page.locator('[role="dialog"][aria-label="Brushes"] select[title="Brush texture"]');
   await select.selectOption({ label: textureName });
   await page.waitForTimeout(100);
+  await closeBrushModal(page);
 }
 
 async function selectTextureBlendMode(page: Page, mode: string) {
-  const select = page.locator('role=toolbar >> select[title="Texture blend mode"]');
+  await openBrushModal(page);
+  const select = page.locator('[role="dialog"][aria-label="Brushes"] select[title="Texture blend mode"]');
   await select.selectOption({ label: mode });
   await page.waitForTimeout(100);
+  await closeBrushModal(page);
 }
 
 // ---------------------------------------------------------------------------
@@ -381,7 +387,8 @@ test.describe('Brush speed size (#346)', () => {
 
     await setupBrush(page, { size: 40, opacity: 100, hardness: 100 });
     await setJitter(page, 0, 0, 0);
-    await setToolOption(page, 'Speed Size', 80);
+    await setBrushModalOption(page, 'Speed Size', 80);
+    await closeBrushModal(page);
 
     // Slow stroke (many steps = slow mouse movement)
     await drawStroke(page, { x: 50, y: 60 }, { x: 350, y: 60 }, 60);
@@ -422,7 +429,8 @@ test.describe('Brush speed size (#346)', () => {
 
     await setupBrush(page, { size: 40, opacity: 100, hardness: 100 });
     await setJitter(page, 0, 0, 0);
-    await setToolOption(page, 'Speed Size', 0);
+    await setBrushModalOption(page, 'Speed Size', 0);
+    await closeBrushModal(page);
 
     // Fast stroke — should still be full width since speed size is disabled
     await drawStroke(page, { x: 50, y: 100 }, { x: 350, y: 100 }, 3);
@@ -549,8 +557,11 @@ test.describe('Brush texture (#346)', () => {
     await setJitter(page, 0, 0, 0);
 
     // Draw with Noise texture at 50% scale (smaller tiles, more oscillation)
-    await selectTexture(page, 'Noise');
-    await setToolOption(page, 'Scale', 50);
+    await openBrushModal(page);
+    const texSelect = page.locator('[role="dialog"][aria-label="Brushes"] select[title="Brush texture"]');
+    await texSelect.selectOption({ label: 'Noise' });
+    await setBrushModalOption(page, 'Scale', 50);
+    await closeBrushModal(page);
     await drawStroke(page, { x: 50, y: 100 }, { x: 350, y: 100 }, 40);
 
     const smallScaleSamples = await readCompositedStrip(page, 100, 80, 320, 2);
@@ -561,7 +572,8 @@ test.describe('Brush texture (#346)', () => {
     await page.keyboard.press('Control+z');
     await page.waitForTimeout(300);
 
-    await setToolOption(page, 'Scale', 200);
+    await setBrushModalOption(page, 'Scale', 200);
+    await closeBrushModal(page);
     await drawStroke(page, { x: 50, y: 100 }, { x: 350, y: 100 }, 40);
 
     const largeScaleSamples = await readCompositedStrip(page, 100, 80, 320, 2);

--- a/src/app/OptionsBar/tool-options/BrushOptions.module.css
+++ b/src/app/OptionsBar/tool-options/BrushOptions.module.css
@@ -18,20 +18,6 @@
   border-color: var(--color-border-strong);
 }
 
-.separator {
-  width: 1px;
-  height: 20px;
-  background: var(--color-border);
-  flex-shrink: 0;
-  margin: 0 var(--spacing-xs);
-}
-
-.textureGroup {
-  display: flex;
-  gap: var(--spacing-xs);
-  align-items: center;
-}
-
 .symmetryGroup {
   display: flex;
   gap: var(--spacing-xs);

--- a/src/app/OptionsBar/tool-options/BrushOptions.tsx
+++ b/src/app/OptionsBar/tool-options/BrushOptions.tsx
@@ -7,8 +7,6 @@ import { Slider } from '../../../components/Slider/Slider';
 import { IconButton } from '../../../components/IconButton/IconButton';
 import { BrushThumbnail } from '../../../components/BrushModal/BrushThumbnail';
 import { docScaledMax } from '../../../utils/slider-ranges';
-import type { BrushTextureBlendMode } from '../../../types/brush';
-import optionStyles from '../OptionsBar.module.css';
 import styles from './BrushOptions.module.css';
 
 export function BrushOptions() {
@@ -25,23 +23,6 @@ export function BrushOptions() {
   const setSymH = useToolSettingsStore((s) => s.setSymmetryHorizontal);
   const setSymV = useToolSettingsStore((s) => s.setSymmetryVertical);
 
-  const sizeJitter = useToolSettingsStore((s) => s.brushSizeJitter);
-  const angleJitter = useToolSettingsStore((s) => s.brushAngleJitter);
-  const opacityJitter = useToolSettingsStore((s) => s.brushOpacityJitter);
-  const speedSize = useToolSettingsStore((s) => s.brushSpeedSize);
-  const setSizeJitter = useToolSettingsStore((s) => s.setBrushSizeJitter);
-  const setAngleJitter = useToolSettingsStore((s) => s.setBrushAngleJitter);
-  const setOpacityJitter = useToolSettingsStore((s) => s.setBrushOpacityJitter);
-  const setSpeedSize = useToolSettingsStore((s) => s.setBrushSpeedSize);
-
-  const textureData = useToolSettingsStore((s) => s.brushTextureData);
-  const textureBlendMode = useToolSettingsStore((s) => s.brushTextureBlendMode);
-  const textureScale = useToolSettingsStore((s) => s.brushTextureScale);
-  const textures = useToolSettingsStore((s) => s.brushTextures);
-  const setTextureData = useToolSettingsStore((s) => s.setBrushTextureData);
-  const setTextureBlendMode = useToolSettingsStore((s) => s.setBrushTextureBlendMode);
-  const setTextureScale = useToolSettingsStore((s) => s.setBrushTextureScale);
-
   const presets = useToolSettingsStore((s) => s.presets);
   const activePresetId = useToolSettingsStore((s) => s.activePresetId);
   const activePreset = presets.find((p) => p.id === activePresetId) ?? presets[0];
@@ -54,20 +35,6 @@ export function BrushOptions() {
     useUIStore.getState().setShowBrushModal(true);
   }, []);
 
-  const handleTextureChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    const id = e.target.value;
-    if (id === 'none') {
-      setTextureData(null);
-    } else {
-      const tex = textures.find((t) => t.id === id);
-      if (tex) setTextureData(tex);
-    }
-  }, [textures, setTextureData]);
-
-  const handleBlendModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    setTextureBlendMode(e.target.value as BrushTextureBlendMode);
-  }, [setTextureBlendMode]);
-
   return (
     <>
       {activePreset && (
@@ -79,45 +46,6 @@ export function BrushOptions() {
       <Slider label="Opacity" value={brushOpacity} min={1} max={100} onChange={setBrushOpacity} />
       <Slider label="Hardness" value={brushHardness} min={0} max={100} onChange={setBrushHardness} />
       <Slider label="Fade" value={brushFade} min={0} max={fadeMax} onChange={setBrushFade} suffix="px" />
-
-      <div className={styles.separator} />
-
-      <Slider label="Size Jitter" value={sizeJitter} min={0} max={100} onChange={setSizeJitter} />
-      <Slider label="Angle Jitter" value={angleJitter} min={0} max={100} onChange={setAngleJitter} />
-      <Slider label="Opacity Jitter" value={opacityJitter} min={0} max={100} onChange={setOpacityJitter} />
-      <Slider label="Speed Size" value={speedSize} min={0} max={100} onChange={setSpeedSize} />
-
-      <div className={styles.separator} />
-
-      <div className={styles.textureGroup}>
-        <select
-          className={optionStyles.select}
-          value={textureData?.id ?? 'none'}
-          onChange={handleTextureChange}
-          title="Brush texture"
-        >
-          <option value="none">No Texture</option>
-          {textures.map((t) => (
-            <option key={t.id} value={t.id}>{t.name}</option>
-          ))}
-        </select>
-        {textureData && (
-          <>
-            <select
-              className={optionStyles.select}
-              value={textureBlendMode}
-              onChange={handleBlendModeChange}
-              title="Texture blend mode"
-            >
-              <option value="multiply">Multiply</option>
-              <option value="subtract">Subtract</option>
-              <option value="overlay">Overlay</option>
-            </select>
-            <Slider label="Scale" value={textureScale} min={10} max={200} onChange={setTextureScale} />
-          </>
-        )}
-      </div>
-
       <div className={styles.symmetryGroup}>
         <IconButton
           icon={<FlipVertical2 size={16} />}

--- a/src/components/BrushModal/BrushModal.module.css
+++ b/src/components/BrushModal/BrushModal.module.css
@@ -14,7 +14,7 @@
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   width: 600px;
-  height: 500px;
+  max-height: 80vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -138,6 +138,31 @@
   display: flex;
   align-items: center;
   gap: var(--space-4);
+}
+
+.sectionLabel {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.textureSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.select {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
 }
 
 .footer {

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -6,7 +6,7 @@ import { Slider } from '../Slider/Slider';
 import { AngleControl } from './AngleControl';
 import { BrushPreview } from './BrushPreview';
 import { BrushThumbnail } from './BrushThumbnail';
-import type { BrushTipData } from '../../types/brush';
+import type { BrushTipData, BrushTextureBlendMode } from '../../types/brush';
 import { describeError, notifyError } from '../../app/notifications-store';
 import { docScaledMax } from '../../utils/slider-ranges';
 import styles from './BrushModal.module.css';
@@ -35,6 +35,23 @@ export function BrushModal() {
   const setBrushSpacing = useToolSettingsStore((s) => s.setBrushSpacing);
   const setBrushScatter = useToolSettingsStore((s) => s.setBrushScatter);
   const setBrushAngle = useToolSettingsStore((s) => s.setBrushAngle);
+
+  const sizeJitter = useToolSettingsStore((s) => s.brushSizeJitter);
+  const angleJitter = useToolSettingsStore((s) => s.brushAngleJitter);
+  const opacityJitter = useToolSettingsStore((s) => s.brushOpacityJitter);
+  const speedSize = useToolSettingsStore((s) => s.brushSpeedSize);
+  const setSizeJitter = useToolSettingsStore((s) => s.setBrushSizeJitter);
+  const setAngleJitter = useToolSettingsStore((s) => s.setBrushAngleJitter);
+  const setOpacityJitter = useToolSettingsStore((s) => s.setBrushOpacityJitter);
+  const setSpeedSize = useToolSettingsStore((s) => s.setBrushSpeedSize);
+
+  const textureData = useToolSettingsStore((s) => s.brushTextureData);
+  const textureBlendMode = useToolSettingsStore((s) => s.brushTextureBlendMode);
+  const textureScale = useToolSettingsStore((s) => s.brushTextureScale);
+  const textures = useToolSettingsStore((s) => s.brushTextures);
+  const setTextureData = useToolSettingsStore((s) => s.setBrushTextureData);
+  const setTextureBlendMode = useToolSettingsStore((s) => s.setBrushTextureBlendMode);
+  const setTextureScale = useToolSettingsStore((s) => s.setBrushTextureScale);
 
   const activePreset = presets.find((p) => p.id === activePresetId);
   const isActiveCustom = activePreset?.isCustom ?? false;
@@ -103,6 +120,20 @@ export function BrushModal() {
     }
   }, [activePresetId, isActiveCustom, removePreset]);
 
+  const handleTextureChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    if (id === 'none') {
+      setTextureData(null);
+    } else {
+      const tex = textures.find((t) => t.id === id);
+      if (tex) setTextureData(tex);
+    }
+  }, [textures, setTextureData]);
+
+  const handleBlendModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setTextureBlendMode(e.target.value as BrushTextureBlendMode);
+  }, [setTextureBlendMode]);
+
   return (
     <div className={styles.overlay} onMouseDown={handleOverlayClick}>
       <div className={styles.modal} role="dialog" aria-label="Brushes">
@@ -163,6 +194,44 @@ export function BrushModal() {
                 opacity={brushOpacity}
                 tip={activeBrushTip}
               />
+            </div>
+
+            <div className={styles.sectionLabel}>Dynamics</div>
+            <div className={styles.sliderSection}>
+              <Slider label="Size Jitter" value={sizeJitter} min={0} max={100} onChange={setSizeJitter} />
+              <Slider label="Angle Jitter" value={angleJitter} min={0} max={100} onChange={setAngleJitter} />
+              <Slider label="Opacity Jitter" value={opacityJitter} min={0} max={100} onChange={setOpacityJitter} />
+              <Slider label="Speed Size" value={speedSize} min={0} max={100} onChange={setSpeedSize} />
+            </div>
+
+            <div className={styles.sectionLabel}>Texture</div>
+            <div className={styles.textureSection}>
+              <select
+                className={styles.select}
+                value={textureData?.id ?? 'none'}
+                onChange={handleTextureChange}
+                title="Brush texture"
+              >
+                <option value="none">No Texture</option>
+                {textures.map((t) => (
+                  <option key={t.id} value={t.id}>{t.name}</option>
+                ))}
+              </select>
+              {textureData && (
+                <>
+                  <select
+                    className={styles.select}
+                    value={textureBlendMode}
+                    onChange={handleBlendModeChange}
+                    title="Texture blend mode"
+                  >
+                    <option value="multiply">Multiply</option>
+                    <option value="subtract">Subtract</option>
+                    <option value="overlay">Overlay</option>
+                  </select>
+                  <Slider label="Scale" value={textureScale} min={10} max={200} onChange={setTextureScale} />
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Move jitter sliders (Size Jitter, Angle Jitter, Opacity Jitter), Speed Size, and texture controls out of the toolbar options bar
- Add them to the brush settings modal under new **Dynamics** and **Texture** sections
- Toolbar now only shows: Size, Opacity, Hardness, Fade, and symmetry toggles

Follow-up to #359 — the toolbar was getting too cluttered with all the new controls.

## Test plan
- [x] All 10 e2e tests pass (updated to use brush modal interactions)
- [x] TypeScript typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)