### PR TITLE
fix(compositor): allow group adjustments on pass-through groups

### DIFF
--- a/src/engine-wasm/engine-sync.test.ts
+++ b/src/engine-wasm/engine-sync.test.ts
@@ -193,4 +193,25 @@ describe('syncGroupAdjustments — group mask registration', () => {
     // Should be registered exactly once — mask and adjustments don't double-register
     expect(vi.mocked(bridge.setGroupAdjustments)).toHaveBeenCalledOnce();
   });
+
+  it('registers a pass-through group when it has adjustments', () => {
+    const engine = makeFakeEngine();
+    const raster = createRasterLayer({ name: 'Layer 1', width: 100, height: 100 });
+    const group = {
+      ...createGroupLayer({ name: 'Group', children: [raster.id] }),
+      blendMode: 'pass-through' as const,
+      adjustmentsEnabled: true,
+      adjustments: [{ id: 'exp-1', type: 'exposure' as const, enabled: true, exposure: 1.5 }],
+    };
+    sync.syncGroupAdjustments(engine, [raster, group]);
+    expect(vi.mocked(bridge.setGroupAdjustments)).toHaveBeenCalledOnce();
+  });
+
+  it('does not register a pass-through group with no adjustments and no mask', () => {
+    const engine = makeFakeEngine();
+    const raster = createRasterLayer({ name: 'Layer 1', width: 100, height: 100 });
+    const group = createGroupLayer({ name: 'Group', children: [raster.id] });
+    sync.syncGroupAdjustments(engine, [raster, group]);
+    expect(vi.mocked(bridge.setGroupAdjustments)).not.toHaveBeenCalled();
+  });
 });

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -233,10 +233,12 @@ export function syncGroupAdjustments(engine: Engine, layers: readonly Layer[]): 
   for (const layer of layers) {
     if (layer.type !== 'group') continue;
     const group = layer as import('../types').GroupLayer;
-    // Pass-through groups bypass the scratch FBO entirely — their children
-    // blend directly onto the parent composite, so group adjustments must
-    // not be registered (that would route children into the scratch FBO).
-    if (group.blendMode === 'pass-through') continue;
+    // Pass-through groups normally bypass the scratch FBO, but when a
+    // pass-through group has adjustments or a mask it must use the scratch
+    // FBO path so adjustments/mask apply to the composited group output.
+    const hasAdjNodes = group.adjustmentsEnabled && group.adjustments && group.adjustments.length > 0;
+    const groupHasMask = group.mask != null && group.mask.enabled;
+    if (group.blendMode === 'pass-through' && !hasAdjNodes && !groupHasMask) continue;
     const hasAdj = group.adjustmentsEnabled && group.adjustments && group.adjustments.length > 0;
     const adj = hasAdj ? nodesToLegacyAdjustments(group.adjustments) : null;
     const hasCurves = adj?.curves != null && !isIdentityCurves(adj.curves);

--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -376,4 +376,19 @@ describe('buildPassThroughOpacityMap', () => {
     const map = buildPassThroughOpacityMap(layers, index);
     expect(map.get('group-1')).toBe(1.0);
   });
+
+  it('stops multiplying when pass-through group has active adjustments', () => {
+    const group: GroupLayer = {
+      ...baseGroup,
+      opacity: 0.6,
+      blendMode: 'pass-through',
+      adjustmentsEnabled: true,
+      adjustments: [{ id: 'exp-1', type: 'exposure' as const, enabled: true, exposure: 1.0 }],
+    };
+    const child: RasterLayer = { ...baseRasterLayer };
+    const layers = [child, group];
+    const index = buildLayerIndex(layers);
+    const map = buildPassThroughOpacityMap(layers, index);
+    expect(map.get('raster-1')).toBe(1.0);
+  });
 });

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -165,6 +165,10 @@ export function buildPassThroughOpacityMap(
       const ancestor = index.byId.get(currentId);
       if (!ancestor || ancestor.type !== 'group') break;
       if (ancestor.blendMode === 'pass-through') {
+        const ag = ancestor as GroupLayer;
+        if ((ag.adjustmentsEnabled && ag.adjustments.length > 0) || ag.mask?.enabled) {
+          break;
+        }
         multiplier *= ancestor.opacity;
       } else {
         // Non-pass-through group: it pre-composites its subtree, so
@@ -220,7 +224,9 @@ export function syncLayers(
   // Add or update layers
   for (const layer of layers) {
     const effectiveVisible = isEffectivelyVisible(index, layer.id);
-    const isPassThrough = layer.type === 'group' && layer.blendMode === 'pass-through';
+    const isPassThrough = layer.type === 'group' && layer.blendMode === 'pass-through' &&
+      !((layer as GroupLayer).adjustmentsEnabled && (layer as GroupLayer).adjustments.length > 0) &&
+      !(layer.mask?.enabled);
     const opacityMultiplier = passThroughOpacity.get(layer.id) ?? 1.0;
 
     // Fast path: if both the layer reference and its effective visibility


### PR DESCRIPTION
## Summary
- Pass-through groups were unconditionally skipped in `syncGroupAdjustments`, so adjustments added via the UI were stored in Zustand state but never sent to the WASM engine — they silently did nothing.
- Now pass-through groups with active adjustment nodes or enabled masks use the scratch FBO compositing path, with matching fixes to `buildPassThroughOpacityMap` and `syncLayers` to prevent double-applying group opacity.
- Fixes 2 pre-existing test failures and adds 3 new tests covering the pass-through + adjustments behavior.

## Test plan
- [x] All 33 engine-wasm unit tests pass (up from 30)
- [x] Typecheck passes (no new errors)
- [ ] Create a group, add an Exposure adjustment, drag the slider — the group's children should visually change
- [ ] Verify a pass-through group with no adjustments still behaves as pass-through (children blend directly onto parent composite)
- [ ] Verify group opacity is not double-applied when adjustments are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)