### PR TITLE
feat(slider): decouple visual slider range from typed-input clamp

### DIFF
--- a/src/app/OptionsBar/tool-options/BrushOptions.tsx
+++ b/src/app/OptionsBar/tool-options/BrushOptions.tsx
@@ -42,7 +42,7 @@ export function BrushOptions() {
           <BrushThumbnail preset={activePreset} size={24} />
         </button>
       )}
-      <Slider label="Size" value={brushSize} min={1} max={sizeMax} onChange={setBrushSize} />
+      <Slider label="Size" value={brushSize} min={1} max={sizeMax} sliderMax={300} onChange={setBrushSize} />
       <Slider label="Opacity" value={brushOpacity} min={1} max={100} onChange={setBrushOpacity} />
       <Slider label="Hardness" value={brushHardness} min={0} max={100} onChange={setBrushHardness} />
       <Slider label="Fade" value={brushFade} min={0} max={fadeMax} onChange={setBrushFade} suffix="px" />

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -29,7 +29,7 @@ export function DodgeOptions() {
         <option value="burn">Burn</option>
       </select>
       <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={setDodgeExposure} />
-      <Slider label="Size" value={brushSize} min={1} max={sizeMax} onChange={setBrushSize} />
+      <Slider label="Size" value={brushSize} min={1} max={sizeMax} sliderMax={300} onChange={setBrushSize} />
     </>
   );
 }

--- a/src/app/OptionsBar/tool-options/EraserOptions.tsx
+++ b/src/app/OptionsBar/tool-options/EraserOptions.tsx
@@ -14,7 +14,7 @@ export function EraserOptions() {
 
   return (
     <>
-      <Slider label="Size" value={eraserSize} min={1} max={sizeMax} onChange={setEraserSize} />
+      <Slider label="Size" value={eraserSize} min={1} max={sizeMax} sliderMax={300} onChange={setEraserSize} />
       <Slider label="Opacity" value={eraserOpacity} min={1} max={100} onChange={setEraserOpacity} />
     </>
   );

--- a/src/app/OptionsBar/tool-options/SmudgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/SmudgeOptions.tsx
@@ -14,7 +14,7 @@ export function SmudgeOptions() {
 
   return (
     <>
-      <Slider label="Size" value={smudgeSize} min={1} max={sizeMax} onChange={setSmudgeSize} />
+      <Slider label="Size" value={smudgeSize} min={1} max={sizeMax} sliderMax={300} onChange={setSmudgeSize} />
       <Slider label="Strength" value={smudgeStrength} min={0} max={100} onChange={setSmudgeStrength} />
     </>
   );

--- a/src/app/OptionsBar/tool-options/SprayOptions.tsx
+++ b/src/app/OptionsBar/tool-options/SprayOptions.tsx
@@ -18,7 +18,7 @@ export function SprayOptions() {
 
   return (
     <>
-      <Slider label="Size" value={spraySize} min={1} max={sizeMax} onChange={setSpraySize} />
+      <Slider label="Size" value={spraySize} min={1} max={sizeMax} sliderMax={500} onChange={setSpraySize} />
       <Slider label="Density" value={sprayDensity} min={1} max={100} onChange={setSprayDensity} />
       <Slider label="Opacity" value={sprayOpacity} min={1} max={100} onChange={setSprayOpacity} />
       <Slider label="Softness" value={sprayHardness} min={0} max={100} onChange={setSprayHardness} />

--- a/src/app/OptionsBar/tool-options/StampOptions.tsx
+++ b/src/app/OptionsBar/tool-options/StampOptions.tsx
@@ -13,7 +13,7 @@ export function StampOptions() {
 
   return (
     <>
-      <Slider label="Size" value={stampSize} min={1} max={sizeMax} onChange={setStampSize} />
+      <Slider label="Size" value={stampSize} min={1} max={sizeMax} sliderMax={300} onChange={setStampSize} />
       <span className={styles.hint}>Alt/Cmd+click to set source</span>
     </>
   );

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -44,3 +44,16 @@ export const FractionalStep: Story = {
   args: { value: 1.5, min: 0, max: 10, step: 0.1, label: 'Flow' },
   render: (args) => <StatefulSlider {...args} />,
 };
+
+export const NarrowSliderRange: Story = {
+  args: {
+    value: 60,
+    min: 1,
+    max: 2880,
+    sliderMin: 1,
+    sliderMax: 300,
+    label: 'Size',
+    suffix: 'px',
+  },
+  render: (args) => <StatefulSlider {...args} />,
+};

--- a/src/components/Slider/Slider.test.ts
+++ b/src/components/Slider/Slider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { commitSliderValue } from './Slider';
+import { commitSliderValue, sliderKnobPosition } from './Slider';
 
 describe('commitSliderValue', () => {
   it('clamps a typed value above max down to max', () => {
@@ -40,5 +40,31 @@ describe('commitSliderValue', () => {
     const result = commitSliderValue('15', 0, -5, 5);
     expect(result).toBe(5);
     expect(result).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('sliderKnobPosition', () => {
+  it('returns the value unchanged when within slider range (linear)', () => {
+    expect(sliderKnobPosition(150, 1, 300)).toBe(150);
+  });
+
+  it('clamps a value above sliderMax to sliderMax (linear)', () => {
+    // Issue #364: brush size can be typed up to e.g. 2880 but the slider
+    // visual range is 1..300. The knob must pin at sliderMax so it stays
+    // visible at the right edge instead of overflowing.
+    expect(sliderKnobPosition(2880, 1, 300)).toBe(300);
+  });
+
+  it('clamps a value below sliderMin to sliderMin (linear)', () => {
+    expect(sliderKnobPosition(-10, 1, 300)).toBe(1);
+  });
+
+  it('maps log scale within bounds and clamps outside the range', () => {
+    // At sliderMin and sliderMax the log mapping is identity (norm 0 and 1).
+    expect(sliderKnobPosition(1, 1, 1000, 'log')).toBe(1);
+    expect(sliderKnobPosition(1000, 1, 1000, 'log')).toBe(1000);
+    // A value beyond sliderMax must clamp before the log mapping so the knob
+    // doesn't slide off the right end of the track.
+    expect(sliderKnobPosition(5000, 1, 1000, 'log')).toBe(1000);
   });
 });

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -6,6 +6,8 @@ interface SliderProps {
   value: number;
   min: number;
   max: number;
+  sliderMin?: number;
+  sliderMax?: number;
   step?: number;
   label?: string;
   defaultValue?: number;
@@ -44,10 +46,22 @@ export function commitSliderValue(
   return clamp(parsed, min, max);
 }
 
+export function sliderKnobPosition(
+  value: number,
+  sliderMin: number,
+  sliderMax: number,
+  scale: 'linear' | 'log' = 'linear',
+): number {
+  const clamped = clamp(value, sliderMin, sliderMax);
+  return scale === 'log' ? posLog(clamped, sliderMin, sliderMax) : clamped;
+}
+
 export function Slider({
   value,
   min,
   max,
+  sliderMin,
+  sliderMax,
   step = 1,
   label,
   defaultValue,
@@ -60,6 +74,9 @@ export function Slider({
 }: SliderProps) {
   const [localValue, setLocalValue] = useState(String(value));
   const [isFocused, setIsFocused] = useState(false);
+
+  const knobMin = Math.max(min, sliderMin ?? min);
+  const knobMax = Math.min(max, sliderMax ?? max);
 
   const handleDoubleClick = () => {
     onChange(defaultValue ?? min);
@@ -98,9 +115,7 @@ export function Slider({
     [value, step, onChange, scale, min, max],
   );
 
-  // For log scale: the slider knob position is mapped logarithmically.
-  // The HTML input stores the knob position, we convert to/from the actual value.
-  const inputValue = scale === 'log' ? posLog(value, min, max) : value;
+  const knobPosition = sliderKnobPosition(value, knobMin, knobMax, scale);
 
   return (
     <div className={styles.container} onDoubleClick={handleDoubleClick}>
@@ -108,15 +123,15 @@ export function Slider({
       <input
         type="range"
         className={styles.slider}
-        value={Math.max(min, Math.min(max, inputValue))}
-        min={min}
-        max={max}
+        value={knobPosition}
+        min={knobMin}
+        max={knobMax}
         step={step}
         aria-label={label ?? 'Value'}
         onChange={(e) => {
           const iv = Number(e.target.value);
-          const v = scale === 'log' ? valLog(iv, min, max) : iv;
-          onChange(v);
+          const v = scale === 'log' ? valLog(iv, knobMin, knobMax) : iv;
+          onChange(clamp(v, min, max));
         }}
         onPointerDown={() => onDragStart?.()}
         onPointerUp={() => onCommit?.()}


### PR DESCRIPTION
## Summary

- Adds `sliderMin`/`sliderMax` props to `<Slider>` so the slider knob's visual range can be narrower than the typed-input clamp range. The new helper `sliderKnobPosition` clamps the knob to `[sliderMin, sliderMax]` so values typed beyond the visual range pin at the edge of the track instead of overflowing.
- Applies `sliderMax` to the doc-scaled size sliders that suffered the worst usable-range squish: brush / eraser / smudge / stamp / dodge get `sliderMax={300}`, spray gets `sliderMax={500}`. The typed clamp still uses the full doc-scaled max so users can still go large by typing.

## Why

On a 1080p document `docScaledMax(1920, 1080, 200)` is ~2880, so the brush size slider's useful 20–200 range was squeezed into the leftmost ~10% of the track. With this change the slider track covers the practical range while typing still allows the full 1–2880 range. (Issue #364)

## Test plan

- [x] `npm run test -- --run src/components/Slider` — passes (12 tests, 4 new for `sliderKnobPosition`).
- [ ] Open the brush, eraser, smudge, stamp, dodge, spray tools on a 1080p+ document and confirm the size slider knob occupies the useful range, while typing a larger value still works and pins the knob at the right edge.
- [ ] Storybook: new `NarrowSliderRange` story renders correctly.

Closes #364

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_016o57RR1tgxnLvxKE7r8K2H)_