### PR TITLE
fix: mask sync, quick-select clear, group ordering, mask toggle

### DIFF
--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -761,11 +761,14 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const parentGroup = findParentGroup(doc.layers, firstId);
     const targetGroupId = parentGroup?.id ?? doc.rootGroupId ?? null;
 
-    // Remove selected layers from their current parents, add new group
-    let newLayers = [...doc.layers, group];
+    // Remove selected layers from their current parents BEFORE adding the
+    // group — otherwise removeFromParentGroup also strips children from
+    // the newly created group.
+    let newLayers = [...doc.layers];
     for (const id of orderedIds) {
       newLayers = removeFromParentGroup(newLayers, id);
     }
+    newLayers = [...newLayers, group];
     if (targetGroupId) {
       newLayers = addToGroupUtil(newLayers, group.id, targetGroupId);
     }

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -309,10 +309,15 @@ export function syncLayers(
       }
     }
 
-    // Upload mask
+    // Upload mask — only when the JS-side data reference actually changes,
+    // so GPU-painted mask data isn't overwritten by a stale re-upload.
     if (layer.mask) {
-      const maskBytes = new Uint8Array(layer.mask.data.buffer, layer.mask.data.byteOffset, layer.mask.data.byteLength);
-      uploadLayerMask(engine, layer.id, maskBytes, layer.mask.width, layer.mask.height);
+      const prevMaskData = tracked.maskDataRefs.get(layer.id);
+      if (prevMaskData !== layer.mask.data) {
+        const maskBytes = new Uint8Array(layer.mask.data.buffer, layer.mask.data.byteOffset, layer.mask.data.byteLength);
+        uploadLayerMask(engine, layer.id, maskBytes, layer.mask.width, layer.mask.height);
+        tracked.maskDataRefs.set(layer.id, layer.mask.data);
+      }
       tracked.masksOnEngine.add(layer.id);
     } else if (tracked.masksOnEngine.has(layer.id)) {
       removeLayerMask(engine, layer.id);

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -31,6 +31,7 @@ export interface TrackedState {
    *  decide whether a removeLayerMask call is needed — previously done by
    *  substring-sniffing the cached descriptor JSON, which was fragile. */
   masksOnEngine: Set<string>;
+  maskDataRefs: Map<string, Uint8ClampedArray>;
   pixelDataVersions: Map<string, ImageData | undefined>;
   sparseVersions: Map<string, SparseLayerEntry | undefined>;
   layerOrder: string;
@@ -80,6 +81,7 @@ function createTrackedState(): TrackedState {
     layerRefs: new Map(),
     layerEffectiveVisible: new Map(),
     masksOnEngine: new Set(),
+    maskDataRefs: new Map(),
     pixelDataVersions: new Map(),
     sparseVersions: new Map(),
     layerOrder: '',

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -442,8 +442,9 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   ].filter(Boolean).join(' ')}
                   onClick={(e) => {
                     e.stopPropagation();
+                    const isAlreadyEditing = maskEditMode && layer.id === activeLayerId;
                     onSelectLayer(layer.id);
-                    setMaskEditMode(true);
+                    setMaskEditMode(!isAlreadyEditing);
                   }}
                   role="button"
                   tabIndex={0}

--- a/src/tools/quick-select/quick-select-interaction.ts
+++ b/src/tools/quick-select/quick-select-interaction.ts
@@ -85,6 +85,8 @@ export function handleQuickSelectDown(ctx: InteractionContext): InteractionState
   if (bounds) {
     editorState.setSelection(bounds, seedMask, docW, docH);
     useUIStore.getState().setTransform(createTransformState(bounds));
+  } else {
+    editorState.clearSelection();
   }
 
   return {
@@ -132,6 +134,8 @@ export function handleQuickSelectMove(
   if (bounds) {
     editorState.setSelection(bounds, updatedMask, session.docWidth, session.docHeight);
     useUIStore.getState().setTransform(createTransformState(bounds));
+  } else {
+    editorState.clearSelection();
   }
 }
 


### PR DESCRIPTION
## Summary

Cherry-picked 4 production bug fixes from `claude/charming-hugle-49d108` (that branch also contained feature reverts that made it unmergeable as-is):

- **Mask sync overwriting GPU data**: `syncLayers` now tracks the JS-side mask data reference and skips re-upload when unchanged, preventing GPU-painted mask strokes from being overwritten
- **Quick-select subtract not clearing**: When subtract mode deselects all pixels (`selectionBounds` returns null), the selection is now properly cleared
- **Group children removal order**: `groupSelectedLayers` now removes children from their parents *before* inserting the new group, so `removeFromParentGroup` doesn't accidentally strip the new group's children
- **Mask thumbnail toggle**: Clicking a mask thumbnail now toggles mask edit mode instead of unconditionally enabling it

## Test plan

- [ ] Paint on a layer mask, switch tools, switch back — mask strokes should persist (not be overwritten by sync)
- [ ] Use quick-select in subtract mode to deselect everything — marching ants should disappear
- [ ] Multi-select layers and group them — all selected layers should appear inside the new group
- [ ] Click mask thumbnail to enter edit mode, click again to exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)