### PR TITLE
feat(symmetry): segments number input and center point overlay

### DIFF
--- a/src/app/OptionsBar/tool-options/BrushOptions.tsx
+++ b/src/app/OptionsBar/tool-options/BrushOptions.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { FlipHorizontal2, FlipVertical2 } from 'lucide-react';
+import { FlipHorizontal2, FlipVertical2, Snowflake } from 'lucide-react';
 import { useToolSettingsStore } from '../../tool-settings-store';
 import { useUIStore } from '../../ui-store';
 import { useEditorStore } from '../../editor-store';
@@ -7,6 +7,7 @@ import { Slider } from '../../../components/Slider/Slider';
 import { IconButton } from '../../../components/IconButton/IconButton';
 import { BrushThumbnail } from '../../../components/BrushModal/BrushThumbnail';
 import { docScaledMax } from '../../../utils/slider-ranges';
+import optionStyles from '../OptionsBar.module.css';
 import styles from './BrushOptions.module.css';
 
 export function BrushOptions() {
@@ -22,6 +23,8 @@ export function BrushOptions() {
   const symmetryV = useToolSettingsStore((s) => s.symmetryVertical);
   const setSymH = useToolSettingsStore((s) => s.setSymmetryHorizontal);
   const setSymV = useToolSettingsStore((s) => s.setSymmetryVertical);
+  const radialSegments = useToolSettingsStore((s) => s.symmetryRadialSegments);
+  const setRadialSegments = useToolSettingsStore((s) => s.setSymmetryRadialSegments);
 
   const presets = useToolSettingsStore((s) => s.presets);
   const activePresetId = useToolSettingsStore((s) => s.activePresetId);
@@ -34,6 +37,8 @@ export function BrushOptions() {
   const handleOpenBrushModal = useCallback(() => {
     useUIStore.getState().setShowBrushModal(true);
   }, []);
+
+  const isRadialActive = radialSegments >= 2;
 
   return (
     <>
@@ -59,6 +64,26 @@ export function BrushOptions() {
           isActive={symmetryV}
           onClick={() => setSymV(!symmetryV)}
         />
+        <IconButton
+          icon={<Snowflake size={16} />}
+          label="Radial Symmetry"
+          isActive={isRadialActive}
+          onClick={() => setRadialSegments(isRadialActive ? 0 : 8)}
+        />
+        {isRadialActive && (
+          <>
+            <label className={optionStyles.label} htmlFor="radial-segments">Segments</label>
+            <input
+              id="radial-segments"
+              className={optionStyles.numberInput}
+              type="number"
+              min={2}
+              max={32}
+              value={radialSegments}
+              onChange={(e) => setRadialSegments(Number(e.target.value))}
+            />
+          </>
+        )}
       </div>
     </>
   );

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -25,10 +25,11 @@ import { getMirroredPoints, mirrorBatchPoints, isSymmetryActive } from '../../to
 type PaintTool = 'brush' | 'pencil' | 'eraser';
 
 function getSymmetryConfig(center: { x: number; y: number }): SymmetryConfig {
-  const { symmetryHorizontal, symmetryVertical } = useToolSettingsStore.getState();
+  const { symmetryHorizontal, symmetryVertical, symmetryRadialSegments } = useToolSettingsStore.getState();
   return {
     horizontal: symmetryHorizontal,
     vertical: symmetryVertical,
+    radialSegments: symmetryRadialSegments,
     centerX: center.x,
     centerY: center.y,
   };
@@ -212,12 +213,11 @@ export function handlePaintDown(
 
   const engine = getEngine();
 
-  // Symmetry should mirror around the document center, not the click point.
-  // Convert document center to layer-local coordinates.
   const doc = editorState.document;
+  const storedCenter = useToolSettingsStore.getState().symmetryCenter;
   const docCenter = {
-    x: doc.width / 2 - activeLayer.x,
-    y: doc.height / 2 - activeLayer.y,
+    x: (storedCenter?.x ?? doc.width / 2) - activeLayer.x,
+    y: (storedCenter?.y ?? doc.height / 2) - activeLayer.y,
   };
 
   const strokeColor = useToolSettingsStore.getState().foregroundColor;

--- a/src/app/rendering/render-overlays.ts
+++ b/src/app/rendering/render-overlays.ts
@@ -1,4 +1,4 @@
-import type { Layer, Point, Rect } from '../../types';
+import type { Color, Layer, Point, Rect } from '../../types';
 import type { PathAnchor } from '../../tools/path/path';
 
 interface PathOverlaySource {
@@ -315,6 +315,36 @@ export function renderBrushCursor(
     ctx.arc(position.x, position.y, half, 0, Math.PI * 2);
     ctx.stroke();
   }
+
+  ctx.restore();
+}
+
+export function renderSymmetryCenter(
+  ctx: CanvasRenderingContext2D,
+  center: Point,
+  zoom: number,
+  guideColor: Color,
+): void {
+  const r = 8 / zoom;
+  const cross = 5 / zoom;
+  const lw = 1.5 / zoom;
+  const color = `rgba(${guideColor.r}, ${guideColor.g}, ${guideColor.b}, 0.9)`;
+
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lw;
+  ctx.setLineDash([]);
+
+  ctx.beginPath();
+  ctx.arc(center.x, center.y, r, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(center.x - cross, center.y);
+  ctx.lineTo(center.x + cross, center.y);
+  ctx.moveTo(center.x, center.y - cross);
+  ctx.lineTo(center.x, center.y + cross);
+  ctx.stroke();
 
   ctx.restore();
 }

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -455,6 +455,8 @@ interface ToolSettings {
   activeBrushTip: BrushTipData | null;
   symmetryHorizontal: boolean;
   symmetryVertical: boolean;
+  symmetryRadialSegments: number;
+  symmetryCenter: { x: number; y: number } | null;
   foregroundColor: Color;
   backgroundColor: Color;
   recentColors: readonly Color[];
@@ -558,6 +560,8 @@ interface ToolSettings {
   updateGradientStop: (index: number, stop: Partial<GradientStop>) => void;
   setSymmetryHorizontal: (enabled: boolean) => void;
   setSymmetryVertical: (enabled: boolean) => void;
+  setSymmetryRadialSegments: (segments: number) => void;
+  setSymmetryCenter: (center: { x: number; y: number } | null) => void;
   setForegroundColor: (color: Color) => void;
   setBackgroundColor: (color: Color) => void;
   swapColors: () => void;
@@ -635,6 +639,8 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   activeBrushTip: null,
   symmetryHorizontal: false,
   symmetryVertical: false,
+  symmetryRadialSegments: 0,
+  symmetryCenter: null,
   foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
   backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
   recentColors: [
@@ -776,6 +782,8 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   }),
   setSymmetryHorizontal: (enabled) => set({ symmetryHorizontal: enabled }),
   setSymmetryVertical: (enabled) => set({ symmetryVertical: enabled }),
+  setSymmetryRadialSegments: (segments) => set({ symmetryRadialSegments: Math.max(0, Math.min(32, Math.round(segments))) }),
+  setSymmetryCenter: (center) => set({ symmetryCenter: center }),
   setStampSize: (size) => set({ stampSize: Math.max(1, Math.min(5000, size)) }),
   setHealingSize: (size) => set({ healingSize: Math.max(1, Math.min(5000, size)) }),
   setHealingOpacity: (opacity) => {

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -138,6 +138,14 @@ export function useCanvasInteraction(
 
       const canvasPos = screenToCanvas(e.clientX - rect.left, e.clientY - rect.top);
 
+      if (e.metaKey) {
+        const ts = useToolSettingsStore.getState();
+        if (ts.symmetryRadialSegments >= 2 || ts.symmetryHorizontal || ts.symmetryVertical) {
+          ts.setSymmetryCenter({ x: canvasPos.x, y: canvasPos.y });
+          return;
+        }
+      }
+
       // Pre-tool: mesh warp handle drag. Captures the click before the
       // expensive GPU stroke / pixel-buffer setup runs, so dragging a
       // mesh handle is cheap and doesn't disturb the active layer texture.
@@ -436,13 +444,14 @@ export function useCanvasInteraction(
           gpuBrushDabBatch(eng, layerId, arr, size, hardness, r, g, b, color.a, opacity, 1, 0, 0, 0);
 
           if (symmetryCenter) {
-            const { symmetryHorizontal, symmetryVertical } = useToolSettingsStore.getState();
-            if (symmetryHorizontal || symmetryVertical) {
+            const { symmetryHorizontal, symmetryVertical, symmetryRadialSegments } = useToolSettingsStore.getState();
+            if (symmetryHorizontal || symmetryVertical || symmetryRadialSegments >= 2) {
               const sym = {
                 horizontal: symmetryHorizontal,
                 vertical: symmetryVertical,
                 centerX: symmetryCenter.x,
                 centerY: symmetryCenter.y,
+                radialSegments: symmetryRadialSegments,
               };
               for (const m of mirrorBatchPoints(arr, sym)) {
                 gpuBrushDabBatch(eng, layerId, m, size, hardness, r, g, b, color.a, opacity, 1, 0, 0, 0);

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -28,7 +28,7 @@ import {
 import { renderGrid, renderPixelGrid, renderRulers } from './rendering/render-grid';
 import { renderSelectionAnts, renderTransformHandles } from './rendering/render-selection';
 import { renderMeshWarpOverlay } from './rendering/render-mesh-warp';
-import { renderPathOverlay, renderLassoPreview, renderCropPreview, renderGradientPreview, renderBrushCursor } from './rendering/render-overlays';
+import { renderPathOverlay, renderLassoPreview, renderCropPreview, renderGradientPreview, renderBrushCursor, renderSymmetryCenter } from './rendering/render-overlays';
 import { renderTextDragOverlay, renderTextEditOverlay, renderTextHoverBounds } from './rendering/render-text-overlay';
 import { hitTestTextLayer } from '../tools/text/text-hit-test';
 import { renderGuides, renderGuidePreview, renderGuideRulerOverlays, renderGuideColorSwatch, renderSnapLines } from './rendering/render-guides';
@@ -286,6 +286,11 @@ function renderFrameGpu(
       if (rulerHover && !hoveredGuideId) {
         renderGuidePreview(overlayCtx, rulerHover, doc.width, doc.height, viewport.zoom, guideColor);
       }
+    }
+
+    if (toolState.symmetryRadialSegments >= 2 || toolState.symmetryHorizontal || toolState.symmetryVertical) {
+      const symCenter = toolState.symmetryCenter ?? { x: doc.width / 2, y: doc.height / 2 };
+      renderSymmetryCenter(overlayCtx, symCenter, viewport.zoom, guideColor);
     }
 
     overlayCtx.restore();

--- a/src/tools/symmetry.test.ts
+++ b/src/tools/symmetry.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { getMirroredPoints, mirrorBatchPoints, isSymmetryActive } from './symmetry';
 import type { SymmetryConfig } from './symmetry';
 
-const config = (h: boolean, v: boolean): SymmetryConfig => ({
+const config = (h: boolean, v: boolean, radial = 0): SymmetryConfig => ({
   horizontal: h,
   vertical: v,
   centerX: 100,
   centerY: 50,
+  radialSegments: radial,
 });
 
 describe('getMirroredPoints', () => {
@@ -58,6 +59,7 @@ describe('stroke-start centering', () => {
       vertical: true,
       centerX: 50,
       centerY: 30,
+      radialSegments: 0,
     };
     const pts = getMirroredPoints(70, 30, startConfig);
     expect(pts).toEqual([{ x: 30, y: 30 }]);

--- a/src/tools/symmetry.ts
+++ b/src/tools/symmetry.ts
@@ -3,6 +3,7 @@ export interface SymmetryConfig {
   vertical: boolean;
   centerX: number;
   centerY: number;
+  radialSegments: number;
 }
 
 export function getMirroredPoints(
@@ -11,6 +12,23 @@ export function getMirroredPoints(
   config: SymmetryConfig,
 ): Array<{ x: number; y: number }> {
   const result: Array<{ x: number; y: number }> = [];
+
+  if (config.radialSegments >= 2) {
+    const dx = x - config.centerX;
+    const dy = y - config.centerY;
+    const n = config.radialSegments;
+    for (let k = 1; k < n; k++) {
+      const angle = (2 * Math.PI * k) / n;
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      result.push({
+        x: config.centerX + dx * cos - dy * sin,
+        y: config.centerY + dx * sin + dy * cos,
+      });
+    }
+    return result;
+  }
+
   if (config.vertical) {
     result.push({ x: 2 * config.centerX - x, y });
   }
@@ -28,6 +46,25 @@ export function mirrorBatchPoints(
   config: SymmetryConfig,
 ): Float64Array[] {
   const results: Float64Array[] = [];
+
+  if (config.radialSegments >= 2) {
+    const n = config.radialSegments;
+    for (let k = 1; k < n; k++) {
+      const angle = (2 * Math.PI * k) / n;
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      const rotated = new Float64Array(points.length);
+      for (let i = 0; i < points.length; i += 2) {
+        const dx = (points[i] as number) - config.centerX;
+        const dy = (points[i + 1] as number) - config.centerY;
+        rotated[i] = config.centerX + dx * cos - dy * sin;
+        rotated[i + 1] = config.centerY + dx * sin + dy * cos;
+      }
+      results.push(rotated);
+    }
+    return results;
+  }
+
   if (config.vertical) {
     const mirrored = new Float64Array(points.length);
     for (let i = 0; i < points.length; i += 2) {
@@ -56,5 +93,5 @@ export function mirrorBatchPoints(
 }
 
 export function isSymmetryActive(config: SymmetryConfig): boolean {
-  return config.horizontal || config.vertical;
+  return config.horizontal || config.vertical || config.radialSegments >= 2;
 }


### PR DESCRIPTION
## Summary
- Rebase onto `daily/apr_19_2026`
- Change the radial symmetry Segments control from a slider to a number input (consistent with the Sides input for polygons)
- Show a circle+crosshair overlay at the symmetry center point (using guide color) whenever any symmetry mode is active
- Cmd+click on the canvas repositions the symmetry center when any symmetry is active
- Symmetry center persists in the tool settings store; defaults to document center when unset

## Test plan
- [ ] Enable radial symmetry — verify the center point circle+crosshair appears at document center
- [ ] Cmd+click to reposition the center — overlay moves, paint strokes mirror around the new point
- [ ] Enable horizontal/vertical symmetry — same overlay appears, cmd+click works
- [ ] Verify the Segments control is now a number input (min 2, max 32)
- [ ] Disable all symmetry — overlay disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)