### PR TITLE
fix(shader): remove duplicate bloom field declarations

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
@@ -227,8 +227,6 @@ pub struct ShaderPrograms {
     pub bloom_threshold: ShaderProgram,
     pub bloom_combine: ShaderProgram,
     pub tilt_shift_blur: ShaderProgram,
-    pub bloom_threshold: ShaderProgram,
-    pub bloom_combine: ShaderProgram,
     pub selection_mask_blend: ShaderProgram,
     // Brush — these use fullscreen quad vert for now (dab positioning via uniforms)
     pub brush_dab: ShaderProgram,
@@ -312,8 +310,6 @@ impl ShaderPrograms {
             bloom_threshold: compile_program(gl, v, BLOOM_THRESHOLD_FRAG)?,
             bloom_combine: compile_program(gl, v, BLOOM_COMBINE_FRAG)?,
             tilt_shift_blur: compile_program(gl, v, TILT_SHIFT_BLUR_FRAG)?,
-            bloom_threshold: compile_program(gl, v, BLOOM_THRESHOLD_FRAG)?,
-            bloom_combine: compile_program(gl, v, BLOOM_COMBINE_FRAG)?,
             selection_mask_blend: compile_program(gl, v, SELECTION_MASK_BLEND_FRAG)?,
             // Brush — use standard fullscreen quad vert; dab positioning via fragment shader
             brush_dab: compile_program(gl, v, BRUSH_DAB_FRAG)?,


### PR DESCRIPTION
## Summary
- The tilt-shift blur PR (#227) accidentally duplicated `bloom_threshold` and `bloom_combine` fields in the `ShaderPrograms` struct and its constructor in `shader.rs`
- This caused a Rust compilation error (`E0124: field already declared`) that broke the WASM build on main

## Test plan
- [x] `npm run wasm:build` compiles successfully
- [x] CI should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)