### PR TITLE
fix(brush): correct color bleed with rotated color brush dabs

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/brush_gpu.rs
+++ b/engine-rs/crates/lopsy-wasm/src/brush_gpu.rs
@@ -138,15 +138,22 @@ pub fn apply_dab_batch(
     gl.active_texture(WebGl2RenderingContext::TEXTURE2);
     gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
 
-    // MAX blending for dab accumulation. Each pixel takes the highest
+    // Dab accumulation blending.
+    // Alpha/circle brushes: MAX blending — each pixel takes the highest
     // alpha from any overlapping dab, preventing opacity compounding.
-    // Base opacity is NOT in the shader — it's applied once when the
-    // stroke is composited onto the layer. Opacity jitter varies
-    // per-dab intensity within the MAX accumulation.
+    // Color brushes: premultiplied alpha "over" compositing — overlapping
+    // rotated dabs layer correctly instead of per-channel MAX which would
+    // create phantom colors (e.g. blue + orange → pink).
     gl.enable(WebGl2RenderingContext::BLEND);
-    gl.blend_equation(WebGl2RenderingContext::MAX);
+    let is_color_tip = engine.brush_has_tip && engine.brush_tip_is_color;
+    if is_color_tip {
+        gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);
+        gl.blend_func(WebGl2RenderingContext::ONE, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+    } else {
+        gl.blend_equation(WebGl2RenderingContext::MAX);
+    }
 
-    let shader = if engine.brush_has_tip && engine.brush_tip_is_color {
+    let shader = if is_color_tip {
         &engine.shaders.brush_dab_color
     } else if engine.brush_has_tip {
         &engine.shaders.brush_dab_alpha
@@ -306,6 +313,7 @@ pub fn apply_dab_batch(
     gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
     gl.disable(WebGl2RenderingContext::BLEND);
     gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);
+    gl.blend_func(WebGl2RenderingContext::ONE, WebGl2RenderingContext::ZERO);
 
     gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
 


### PR DESCRIPTION
## Summary
- **Fix phantom colors with color brush rotation**: the GPU dab accumulation used `MAX` blending, which takes the per-channel maximum of overlapping dabs. When a color brush tip is rotated (via angle jitter), different colored pixels overlap at the same screen position across dabs. MAX blending cherry-picks the highest R, G, B independently — e.g. blue `(0,0,200)` + orange `(200,100,0)` → pink `(200,100,200)`.
- Switched color brush tips to premultiplied alpha "over" compositing (`ONE, ONE_MINUS_SRC_ALPHA`) so overlapping rotated dabs layer correctly. Alpha and circle brushes retain MAX blending.

## Test plan
- [ ] Select a color brush with angle jitter at 100% and paint a stroke — only colors from the original tip should appear (no pink/magenta bleed)
- [ ] Verify alpha brushes still accumulate correctly with MAX blending (no opacity compounding)
- [ ] Test color brush without angle jitter to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)