### PR TITLE
fix(layers): mask row click always enters mask-edit, layer row exits

### DIFF
--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -131,7 +131,24 @@ test.describe('Mask Sub-Row', () => {
     expect(uiAfter.maskEditMode).toBe(true);
   });
 
-  test('clicking mask thumbnail again exits mask edit mode', async ({ page }) => {
+  test('clicking mask thumbnail again stays in mask edit mode (not a toggle)', async ({ page }) => {
+    const state = await getEditorState(page);
+    const layerId = state.document.layers[0]!.id;
+
+    await addMaskViaStore(page, layerId);
+
+    // First click enters mask edit mode
+    await page.locator('[title="Click to edit mask"]').click();
+    const ui1 = await getUIState(page);
+    expect(ui1.maskEditMode).toBe(true);
+
+    // Second click on the same mask thumbnail stays in mask edit mode
+    await page.locator('[title="Click to edit mask"]').click();
+    const ui2 = await getUIState(page);
+    expect(ui2.maskEditMode).toBe(true);
+  });
+
+  test('clicking the layer row exits mask edit mode', async ({ page }) => {
     const state = await getEditorState(page);
     const layerId = state.document.layers[0]!.id;
 
@@ -142,10 +159,42 @@ test.describe('Mask Sub-Row', () => {
     const ui1 = await getUIState(page);
     expect(ui1.maskEditMode).toBe(true);
 
-    // Exit mask edit mode
-    await page.locator('[title="Click to edit mask"]').click();
+    // Clicking the layer row (not the mask) exits mask edit mode
+    await page.locator(`[data-layer-id="${layerId}"]`).click();
     const ui2 = await getUIState(page);
     expect(ui2.maskEditMode).toBe(false);
+  });
+
+  test('clicking a different layer mask switches edit target to that layer', async ({ page }) => {
+    // Add a second layer so we have two layers with masks
+    await addLayer(page);
+    const state = await getEditorState(page);
+    const layer1Id = state.document.layers[0]!.id;
+    const layer2Id = state.document.layers[1]!.id;
+
+    // Add mask to layer1 (active layer is layer2 since it was just added)
+    await page.locator(`[data-layer-id="${layer1Id}"]`).click();
+    await addMaskViaStore(page, layer1Id);
+
+    // Add mask to layer2
+    await page.locator(`[data-layer-id="${layer2Id}"]`).click();
+    await addMaskViaStore(page, layer2Id);
+
+    // Click layer1's mask thumbnail — enter mask edit for layer1
+    await page.locator(`[data-layer-id="${layer1Id}"]`)
+      .locator('[title="Click to edit mask"]').click();
+    let ui = await getUIState(page);
+    expect(ui.maskEditMode).toBe(true);
+    let editorState = await getEditorState(page);
+    expect(editorState.document.activeLayerId).toBe(layer1Id);
+
+    // Click layer2's mask thumbnail — switch mask edit to layer2 (no toggle off)
+    await page.locator(`[data-layer-id="${layer2Id}"]`)
+      .locator('[title="Click to edit mask"]').click();
+    ui = await getUIState(page);
+    expect(ui.maskEditMode).toBe(true);
+    editorState = await getEditorState(page);
+    expect(editorState.document.activeLayerId).toBe(layer2Id);
   });
 
   test('deleting mask exits mask edit mode', async ({ page }) => {

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -81,10 +81,12 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
       e.preventDefault();
       selectLayerRange(activeLayerId, layerId);
     } else {
-      // Plain click: select only this layer
+      // Selecting the layer row exits mask-edit mode; the mask thumbnail is
+      // the only entry point, so clicking the layer makes it the paint target.
       onSelectLayer(layerId);
+      setMaskEditMode(false);
     }
-  }, [toggleLayerSelection, selectLayerRange, onSelectLayer, activeLayerId]);
+  }, [toggleLayerSelection, selectLayerRange, onSelectLayer, activeLayerId, setMaskEditMode]);
 
   // Keyboard shortcuts: Cmd+A to select all, Delete/Backspace to delete selected
   useEffect(() => {
@@ -442,9 +444,8 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   ].filter(Boolean).join(' ')}
                   onClick={(e) => {
                     e.stopPropagation();
-                    const isAlreadyEditing = maskEditMode && layer.id === activeLayerId;
                     onSelectLayer(layer.id);
-                    setMaskEditMode(!isAlreadyEditing);
+                    setMaskEditMode(true);
                   }}
                   role="button"
                   tabIndex={0}


### PR DESCRIPTION
## Summary

Addresses the first bullet of #329:

> We should switch to mask editing whenever the mask row is selected.

The mask thumbnail click was toggling — a second click on the same mask exited mask-edit mode. Make it a one-way entry point: clicking the mask thumbnail always sets `maskEditMode = true`. Clicking the parent layer row (plain-click selection) clears it, so the user has an obvious exit path that matches the natural "select the layer to paint the layer, select the mask to paint the mask" mental model.

## Changes

- `src/panels/LayerPanel/LayerPanel.tsx`
  - Mask thumbnail `onClick` now unconditionally calls `setMaskEditMode(true)` (was a toggle).
  - Plain-click branch of `handleLayerClick` now calls `setMaskEditMode(false)` so selecting a layer row exits mask-edit mode. Cmd/Shift modifier clicks are untouched (they don't change activeLayerId).

## Test plan

- [x] `e2e/layer-panel.spec.ts`
  - Updated the prior `'clicking mask thumbnail again exits mask edit mode'` test (which asserted the broken toggle behavior) to instead assert the second click *stays* in mask-edit mode.
  - Added `'clicking the layer row exits mask edit mode'` — verifies the new exit path.
  - Added `'clicking a different layer mask switches edit target to that layer'` — verifies switching between two layers' masks doesn't pass through an off state.
- [x] Existing `setActiveLayer(page, layerId)` usages in other specs (e.g. `composition-koi-fish.spec.ts`) checked — none rely on the layer-row click *preserving* mask-edit mode, so this won't regress them.

Marking with the `autofix` label.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01USRYRyoGKyZa5Eak9hKYAK)_