### PR TITLE
fix(compositor): route sub-group descendants into adjusted group scratch

### DIFF
--- a/src/engine-wasm/engine-sync.test.ts
+++ b/src/engine-wasm/engine-sync.test.ts
@@ -217,3 +217,82 @@ describe('syncGroupAdjustments — group mask registration', () => {
     expect(vi.mocked(bridge.setGroupAdjustments)).not.toHaveBeenCalled();
   });
 });
+
+describe('flattenGroupDescendants', () => {
+  it('returns the direct children of a flat group', () => {
+    const a = createRasterLayer({ name: 'A', width: 10, height: 10 });
+    const b = createRasterLayer({ name: 'B', width: 10, height: 10 });
+    const group = createGroupLayer({ name: 'Group', children: [a.id, b.id] });
+    const out = sync.flattenGroupDescendants([a, b, group], group.id);
+    expect(out).toEqual([a.id, b.id]);
+  });
+
+  it('includes descendants of a nested sub-group', () => {
+    const a = createRasterLayer({ name: 'A', width: 10, height: 10 });
+    const b = createRasterLayer({ name: 'B', width: 10, height: 10 });
+    const sub = createGroupLayer({ name: 'Sub', children: [a.id, b.id] });
+    const c = createRasterLayer({ name: 'C', width: 10, height: 10 });
+    const root = createGroupLayer({ name: 'Root', children: [sub.id, c.id] });
+    const out = sync.flattenGroupDescendants([a, b, sub, c, root], root.id);
+    // Sub-group marker is included along with its descendants. The WASM
+    // compositor skips Group-type entries when iterating layer_stack, so
+    // including them is harmless and keeps the descendant walk simple.
+    expect(out).toEqual([sub.id, a.id, b.id, c.id]);
+  });
+
+  it('walks deeply nested groups recursively', () => {
+    const leaf = createRasterLayer({ name: 'Leaf', width: 10, height: 10 });
+    const inner = createGroupLayer({ name: 'Inner', children: [leaf.id] });
+    const mid = createGroupLayer({ name: 'Mid', children: [inner.id] });
+    const root = createGroupLayer({ name: 'Root', children: [mid.id] });
+    const out = sync.flattenGroupDescendants([leaf, inner, mid, root], root.id);
+    expect(out).toEqual([mid.id, inner.id, leaf.id]);
+  });
+
+  it('returns empty array when group id is unknown', () => {
+    const a = createRasterLayer({ name: 'A', width: 10, height: 10 });
+    expect(sync.flattenGroupDescendants([a], 'no-such-group')).toEqual([]);
+  });
+
+  it('returns empty array for a leaf layer (non-group)', () => {
+    const a = createRasterLayer({ name: 'A', width: 10, height: 10 });
+    expect(sync.flattenGroupDescendants([a], a.id)).toEqual([]);
+  });
+});
+
+describe('syncGroupAdjustments — nested descendants are routed to the group', () => {
+  beforeEach(() => {
+    vi.mocked(bridge.setGroupAdjustments).mockClear();
+    vi.mocked(bridge.clearGroupAdjustments).mockClear();
+  });
+
+  it('passes every descendant id (not just direct children) when the root group has adjustments', () => {
+    // This is the regression test for #395. Before the fix the root group's
+    // setGroupAdjustments call only listed direct children, so the on-screen
+    // compositor's child_to_group lookup missed sub-group descendants and
+    // they rendered directly onto the composite. The group's normal-blend
+    // finalize then covered them with the (partial) scratch contents, which
+    // is what the user reported as "viewport near-black, export correct".
+    const engine = makeFakeEngine();
+    const bg = createRasterLayer({ name: 'Background', width: 100, height: 100 });
+    const leaf1 = createRasterLayer({ name: 'Leaf 1', width: 100, height: 100 });
+    const leaf2 = createRasterLayer({ name: 'Leaf 2', width: 100, height: 100 });
+    const subGroup = createGroupLayer({ name: 'Sub', children: [leaf1.id, leaf2.id] });
+    const root = {
+      ...createGroupLayer({ name: 'Root', children: [bg.id, subGroup.id] }),
+      blendMode: 'normal' as const,
+      adjustmentsEnabled: true,
+      adjustments: [{ id: 'c-1', type: 'contrast' as const, enabled: true, contrast: 0.15 }],
+    };
+    sync.syncGroupAdjustments(engine, [bg, leaf1, leaf2, subGroup, root]);
+    expect(vi.mocked(bridge.setGroupAdjustments)).toHaveBeenCalledOnce();
+    const [, , childrenJson] = vi.mocked(bridge.setGroupAdjustments).mock.calls[0]!;
+    const ids = JSON.parse(childrenJson as string) as string[];
+    // Direct children
+    expect(ids).toContain(bg.id);
+    expect(ids).toContain(subGroup.id);
+    // Sub-group descendants — these are the IDs the pre-fix code dropped
+    expect(ids).toContain(leaf1.id);
+    expect(ids).toContain(leaf2.id);
+  });
+});

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -331,6 +331,38 @@ export function syncAdjustments(engine: Engine, adjustments: ImageAdjustments, e
   }
 }
 
+/**
+ * Walk a group's children recursively and collect every descendant layer ID.
+ * Sub-groups are included so the compositor sees both the marker and its
+ * contents — the WASM side ignores Group-type entries via a strict layer-type
+ * check, so the extra IDs are harmless.
+ *
+ * The compositor's `child_to_group` map needs every descendant of an adjusted
+ * group so all descendants get routed into the group scratch FBO. Sending only
+ * direct children causes sub-group descendants to bypass the scratch and
+ * render directly onto the composite, where the group's normal-blend finalize
+ * later covers them up.
+ */
+export function flattenGroupDescendants(
+  layers: readonly Layer[],
+  groupId: string,
+): string[] {
+  const layerMap = new Map<string, Layer>();
+  for (const l of layers) layerMap.set(l.id, l);
+  const result: string[] = [];
+  const walk = (id: string): void => {
+    const layer = layerMap.get(id);
+    if (!layer || layer.type !== 'group') return;
+    const group = layer as import('../types').GroupLayer;
+    for (const childId of group.children) {
+      result.push(childId);
+      walk(childId);
+    }
+  };
+  walk(groupId);
+  return result;
+}
+
 export function syncGroupAdjustments(engine: Engine, layers: readonly Layer[]): void {
   clearGroupAdjustments(engine);
   for (const layer of layers) {
@@ -366,7 +398,7 @@ export function syncGroupAdjustments(engine: Engine, layers: readonly Layer[]): 
     setGroupAdjustments(
       engine,
       group.id,
-      JSON.stringify(group.children),
+      JSON.stringify(flattenGroupDescendants(layers, group.id)),
       adj?.exposure ?? 0,
       adj?.contrast ?? 0,
       adj?.highlights ?? 0,


### PR DESCRIPTION
## Summary

Fixes #395 — viewport renders near-black after setting root group blend mode to `normal` and adding group adjustments, while the exported PNG renders correctly.

### Root cause

`syncGroupAdjustments` was sending only the **direct** children of an adjusted group to the WASM engine:

```ts
setGroupAdjustments(engine, group.id, JSON.stringify(group.children), …)
```

The compositor builds a `child_to_group` map from those ids and uses it in the on-screen `composite` path's strict check:

```rust
let is_group_child = if let Some(_) = child_to_group.get(&layer_id) { … true } else { false };
```

So **sub-group descendants** of an adjusted group bypass the group scratch FBO and render directly onto the composite. When the adjusted group's normal-blend finalize runs at the end of the iteration, the scratch — which only contains the group's direct children, eg. the background fill — covers those descendants up.

The 8-bit export path uses a looser check:

```rust
let is_group_child = active_group_id.is_some();
```

so it incidentally routed sub-group descendants into the scratch and produced the correct image. That's the viewport-vs-export divergence the user observed.

### Fix

Walk the group recursively in `syncGroupAdjustments` and send every descendant id — not just direct children. Sub-group markers come along but the compositor's layer-type check (`Group → continue`) skips them, so this is harmless. The new `flattenGroupDescendants` helper is exported so it can be unit-tested directly.

## Test plan

- [x] `npx vitest run src/engine-wasm/engine-sync.test.ts` — 15/15 pass (8 pre-existing + 7 new):
  - 5 cases for `flattenGroupDescendants`: flat group, nested sub-group, deeply nested, unknown id, leaf layer
  - 1 regression test for #395 verifying nested descendants make it into the `setGroupAdjustments` payload
  - All pre-existing tests still pass
- [x] `npx vitest run` — 817 tests pass. Pre-existing 14 file-level failures from missing `src/engine-wasm/pkg` in CI are unchanged.
- [x] `npm run typecheck` — clean (only the pre-existing `Cannot find module './pkg/lopsy_wasm'` from missing wasm bundle in CI).
- [x] `npm run wasm:build` — engine still builds cleanly with no Rust changes.
- [ ] Manual: open a document with an adjusted root group containing a sub-group, verify viewport now matches the exported PNG.

## Closes

Closes #395.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeFw2rsufBKKqTeWgo9SdQ)_