### PR TITLE
refactor(adjustments): use GradientStop interface for gradient map node

### DIFF
--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -13,6 +13,7 @@
 import type { Engine } from './wasm-bridge';
 import { getEngine } from './engine-state';
 import type { Layer } from '../types';
+import type { GradientStop } from '../tools/gradient/gradient';
 import type { ImageAdjustments } from '../filters/image-adjustments';
 import { buildCurvesLutRgba, isIdentityCurves } from '../filters/curves';
 import { buildLevelsLutRgba, isIdentityLevels } from '../filters/levels';
@@ -107,7 +108,7 @@ export { resetTrackedState, markPixelDataSynced } from './sync-state';
 export { syncLayers } from './sync-layers';
 
 function buildGradientMapLut(
-  stops: ReadonlyArray<{ position: number; color: { r: number; g: number; b: number } }>,
+  stops: readonly GradientStop[],
 ): Uint8Array {
   const lut = new Uint8Array(256 * 4);
   const sorted = [...stops].sort((a, b) => a.position - b.position);

--- a/src/filters/adjustment-node-utils.ts
+++ b/src/filters/adjustment-node-utils.ts
@@ -174,7 +174,7 @@ export function createDefaultNode(type: AdjustmentNodeType): AdjustmentNode {
     case 'color-balance':
       return { id, enabled: true, type: 'color-balance', shadowsCMY: [0, 0, 0], midtonesCMY: [0, 0, 0], highlightsCMY: [0, 0, 0] };
     case 'gradient-map':
-      return { id, enabled: true, type: 'gradient-map', stops: [{ position: 0, color: { r: 0, g: 0, b: 0 } }, { position: 1, color: { r: 255, g: 255, b: 255 } }] };
+      return { id, enabled: true, type: 'gradient-map', stops: [{ position: 0, color: { r: 0, g: 0, b: 0, a: 1 } }, { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } }] };
     case 'black-white':
       return { id, enabled: true, type: 'black-white', reds: 40, yellows: 60, greens: 40, cyans: 60, blues: 20, magentas: 80 };
     case 'photo-filter':

--- a/src/filters/image-adjustments.ts
+++ b/src/filters/image-adjustments.ts
@@ -3,6 +3,7 @@ import { IDENTITY_CURVES, isIdentityCurves, applyCurvesToImageData } from './cur
 import type { Levels } from './levels';
 import { IDENTITY_LEVELS, isIdentityLevels, applyLevelsToImageData } from './levels';
 import type { AdjustmentNode } from '../types/adjustment-nodes';
+import type { GradientStop } from '../tools/gradient/gradient';
 import { nodesToLegacyAdjustments } from './adjustment-node-utils';
 
 export interface ImageAdjustments {
@@ -45,7 +46,7 @@ export interface ImageAdjustments {
   // Invert
   invert?: boolean;
   // Gradient Map stops
-  gradientMapStops?: ReadonlyArray<{ position: number; color: { r: number; g: number; b: number } }>;
+  gradientMapStops?: readonly GradientStop[];
 }
 
 export const DEFAULT_ADJUSTMENTS: ImageAdjustments = {

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -37,6 +37,7 @@ import type {
 import {
   ADJUSTMENT_NODE_LABELS,
 } from '../../filters/adjustment-node-utils';
+import type { GradientStop } from '../../tools/gradient/gradient';
 import styles from './AdjustmentsPanel.module.css';
 
 const CHANNEL_COLORS: Record<CurveChannel, string> = {
@@ -578,10 +579,11 @@ function ChannelMixerControls({ node, onChange }: { node: ChannelMixerNode; onCh
 function GradientMapControls({ node, onChange }: { node: GradientMapNode; onChange: (p: Partial<AdjustmentNode>) => void }) {
   const toHex = (c: { r: number; g: number; b: number }) =>
     '#' + [c.r, c.g, c.b].map((v) => v.toString(16).padStart(2, '0')).join('');
-  const fromHex = (hex: string): { r: number; g: number; b: number } => ({
+  const fromHex = (hex: string): GradientStop['color'] => ({
     r: parseInt(hex.slice(1, 3), 16),
     g: parseInt(hex.slice(3, 5), 16),
     b: parseInt(hex.slice(5, 7), 16),
+    a: 1,
   });
 
   const updateStop = (index: number, field: 'color' | 'position', value: unknown) => {
@@ -594,7 +596,7 @@ function GradientMapControls({ node, onChange }: { node: GradientMapNode; onChan
   const addStop = () => {
     const sorted = [...node.stops].sort((a, b) => a.position - b.position);
     const last = sorted[sorted.length - 1]!;
-    onChange({ stops: [...node.stops, { position: Math.min(1, last.position + 0.1), color: { r: 128, g: 128, b: 128 } }] });
+    onChange({ stops: [...node.stops, { position: Math.min(1, last.position + 0.1), color: { r: 128, g: 128, b: 128, a: 1 } }] });
   };
 
   const removeStop = (index: number) => {
@@ -626,7 +628,7 @@ function GradientMapControls({ node, onChange }: { node: GradientMapNode; onChan
   );
 }
 
-function buildCssGradient(stops: ReadonlyArray<{ position: number; color: { r: number; g: number; b: number } }>): string {
+function buildCssGradient(stops: readonly GradientStop[]): string {
   const sorted = [...stops].sort((a, b) => a.position - b.position);
   const parts = sorted.map((s) => `rgb(${s.color.r},${s.color.g},${s.color.b}) ${Math.round(s.position * 100)}%`);
   return `linear-gradient(to right, ${parts.join(', ')})`;

--- a/src/types/adjustment-nodes.ts
+++ b/src/types/adjustment-nodes.ts
@@ -1,5 +1,6 @@
 import type { Curves } from '../filters/curves';
 import type { Levels } from '../filters/levels';
+import type { GradientStop } from '../tools/gradient/gradient';
 
 export interface BaseAdjustmentNode {
   readonly id: string;
@@ -54,7 +55,7 @@ export interface ColorBalanceNode extends BaseAdjustmentNode {
 
 export interface GradientMapNode extends BaseAdjustmentNode {
   readonly type: 'gradient-map';
-  readonly stops: ReadonlyArray<{ readonly position: number; readonly color: { readonly r: number; readonly g: number; readonly b: number } }>;
+  readonly stops: readonly GradientStop[];
 }
 
 export interface BlackWhiteNode extends BaseAdjustmentNode {


### PR DESCRIPTION
## Summary
- Replace inline `{ position, color: { r, g, b } }` types in `GradientMapNode` and downstream consumers with the existing `GradientStop` interface from the gradient tool
- Unifies gradient stop representation across the codebase (gradient tool + gradient map adjustment now share the same type)
- Adds alpha channel (`a: 1`) to all gradient map stop defaults for `Color` compatibility

## Test plan
- [x] TypeScript typecheck passes
- [x] Unit tests pass (1 pre-existing failure unrelated to this change)
- [ ] Verify gradient map adjustment still renders correctly in the UI
- [ ] Verify adding/removing/editing gradient map stops works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)