### PR TITLE
fix(shape): preserve user-set fill color across re-activations (#424)

### DIFF
--- a/e2e/shape-fill-persists-on-reactivate.spec.ts
+++ b/e2e/shape-fill-persists-on-reactivate.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression test for #424:
+ *
+ * The Shape tool's `onActivate` callback used to unconditionally set
+ * `shapeFillColor = foregroundColor` on every `setActiveTool('shape')` call.
+ * Pressing `U` while the Shape tool was already active, or switching to
+ * another tool and back, would silently overwrite the user's chosen fill
+ * with the current foreground color.
+ *
+ * The fix has two parts (both required to cover both repros in the issue):
+ *   1. `setActiveTool` no longer fires `onActivate` when the requested tool
+ *      is already the active tool — re-pressing `U` is a no-op.
+ *   2. The shape tool's foreground → fill seed is a one-shot per session —
+ *      after the very first activation, switching to another tool and back
+ *      does not clobber the user's chosen fill.
+ *
+ * Both repros from the issue are covered below: pressing `U` twice, and
+ * switching away and back. We verify behavior at three levels:
+ *   - the tool-settings store still reports the user-chosen fill,
+ *   - a fresh shape drag actually paints with the user-chosen fill,
+ *   - the options-bar Fill swatch UI still reflects the user-chosen fill.
+ */
+import { test, expect, type Page } from './fixtures';
+import {
+  createDocument,
+  waitForStore,
+  getPixelAt,
+  selectTool,
+  setForegroundColor,
+} from './helpers';
+
+const GOLD = { r: 0xbc, g: 0x90, b: 0x4c };
+const CRIMSON = { r: 0x91, g: 0x26, b: 0x20 };
+
+async function docToScreen(page: Page, docX: number, docY: number) {
+  return page.evaluate(
+    ({ docX, docY }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number };
+          viewport: { zoom: number; panX: number; panY: number };
+        };
+      };
+      const state = store.getState();
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      if (!container) return { x: 0, y: 0 };
+      const rect = container.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      const screenX =
+        (docX - state.document.width / 2) * state.viewport.zoom +
+        state.viewport.panX +
+        cx;
+      const screenY =
+        (docY - state.document.height / 2) * state.viewport.zoom +
+        state.viewport.panY +
+        cy;
+      return { x: rect.left + screenX, y: rect.top + screenY };
+    },
+    { docX, docY },
+  );
+}
+
+async function dragShape(
+  page: Page,
+  fromDoc: { x: number; y: number },
+  toDoc: { x: number; y: number },
+) {
+  const start = await docToScreen(page, fromDoc.x, fromDoc.y);
+  const end = await docToScreen(page, toDoc.x, toDoc.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 5 });
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Set the shape fill color via the store. The popover UI driving this is
+ * an HSV picker with no hex input — there is no UI path to set a specific
+ * RGB value, so this matches the existing pattern in shape-tool.spec.ts.
+ */
+async function setShapeFillColor(page: Page, color: { r: number; g: number; b: number; a?: number }) {
+  await page.evaluate((c) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeFillColor: (c: unknown) => void };
+    };
+    store.getState().setShapeFillColor({ r: c.r, g: c.g, b: c.b, a: c.a ?? 1 });
+  }, color);
+}
+
+async function getShapeFillColor(page: Page) {
+  return page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { shapeFillColor: { r: number; g: number; b: number; a: number } | null };
+    };
+    return store.getState().shapeFillColor;
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await waitForStore(page);
+  await createDocument(page, 400, 300);
+  await page.waitForSelector('[data-testid="canvas-container"]');
+});
+
+test.describe('Shape tool fill color persists on re-activation (#424)', () => {
+  test('pressing U twice does not reset fill to foreground', async ({ page }) => {
+    // 1. Foreground = gold, then activate Shape — fill seeds from foreground.
+    await setForegroundColor(page, GOLD.r, GOLD.g, GOLD.b);
+    await selectTool(page, 'shape');
+
+    // 2. User picks a distinctive fill in the options-bar popover (crimson).
+    await setShapeFillColor(page, CRIMSON);
+    expect(await getShapeFillColor(page)).toEqual({ ...CRIMSON, a: 1 });
+
+    // 3. Change the foreground to gold again (it already is, but in the
+    //    real workflow the user might be cycling colors). The key step is:
+    // 4. Re-press U with the Shape tool already active.
+    await page.keyboard.press('u');
+
+    // The fill swatch must NOT have been silently reset to foreground.
+    const fillAfter = await getShapeFillColor(page);
+    expect(fillAfter).toEqual({ ...CRIMSON, a: 1 });
+
+    // Verify the rendered output matches: a fresh shape drag draws crimson,
+    // not gold. Disable stroke so only fill matters.
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setShapeStrokeColor: (c: unknown) => void };
+      };
+      store.getState().setShapeStrokeColor(null);
+    });
+    await page.locator('[aria-labelledby="shape-mode-label"]').selectOption('ellipse');
+    await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });
+    await page.screenshot({ path: 'e2e/screenshots/shape-fill-after-rereactivate.png' });
+
+    const center = await getPixelAt(page, 200, 150);
+    // Reads must match crimson, not gold. Loose tolerance for AA blending.
+    expect(Math.abs(center.r - CRIMSON.r)).toBeLessThan(8);
+    expect(Math.abs(center.g - CRIMSON.g)).toBeLessThan(8);
+    expect(Math.abs(center.b - CRIMSON.b)).toBeLessThan(8);
+    expect(center.a).toBeGreaterThan(200);
+  });
+
+  test('switching to another tool and back does not reset fill to foreground', async ({ page }) => {
+    // 1. Foreground = gold, then activate Shape — fill seeds from foreground.
+    await setForegroundColor(page, GOLD.r, GOLD.g, GOLD.b);
+    await selectTool(page, 'shape');
+
+    // 2. User picks a distinctive fill (crimson).
+    await setShapeFillColor(page, CRIMSON);
+    expect(await getShapeFillColor(page)).toEqual({ ...CRIMSON, a: 1 });
+
+    // 3. User switches to the move tool, then back to shape.
+    await selectTool(page, 'move');
+    await selectTool(page, 'shape');
+
+    // The fill must still be crimson — this is the second repro from #424.
+    const fillAfter = await getShapeFillColor(page);
+    expect(fillAfter).toEqual({ ...CRIMSON, a: 1 });
+
+    // The options-bar Fill swatch must visually still show crimson, not
+    // gold. The swatch is rendered as an inline background-color on the
+    // ColorSwatch button. We read its computed style.
+    const swatchColor = await page.evaluate(() => {
+      // Fill swatch is the first ColorSwatch inside the shape options group.
+      const fillLabel = Array.from(document.querySelectorAll('span'))
+        .find((el) => el.textContent === 'Fill');
+      if (!fillLabel) return null;
+      const group = fillLabel.nextElementSibling as HTMLElement | null;
+      if (!group) return null;
+      const swatch = group.querySelector('button, div[role="button"], div[style*="background"]')
+        ?? group.firstElementChild;
+      if (!swatch) return null;
+      const style = window.getComputedStyle(swatch as HTMLElement);
+      return style.backgroundColor;
+    });
+    // backgroundColor is "rgb(r, g, b)" or "rgba(...)". Parse and compare.
+    expect(swatchColor).toBeTruthy();
+    const match = (swatchColor ?? '').match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const [, r, g, b] = match!;
+    expect(Math.abs(Number(r) - CRIMSON.r)).toBeLessThan(8);
+    expect(Math.abs(Number(g) - CRIMSON.g)).toBeLessThan(8);
+    expect(Math.abs(Number(b) - CRIMSON.b)).toBeLessThan(8);
+  });
+
+  test('first activation still seeds fill from foreground', async ({ page }) => {
+    // Sanity check: the one-shot logic must not break the "pick a color,
+    // then click shape" workflow on the user's first interaction with the
+    // shape tool. Foreground = gold, never activated shape before → fill
+    // should be gold after the first U press.
+    await setForegroundColor(page, GOLD.r, GOLD.g, GOLD.b);
+    await selectTool(page, 'shape');
+
+    const fill = await getShapeFillColor(page);
+    expect(fill).toEqual({ ...GOLD, a: 1 });
+  });
+
+  test('changing foreground after shape activation does not affect fill', async ({ page }) => {
+    // Foreground = gold, activate shape → fill = gold.
+    await setForegroundColor(page, GOLD.r, GOLD.g, GOLD.b);
+    await selectTool(page, 'shape');
+    expect(await getShapeFillColor(page)).toEqual({ ...GOLD, a: 1 });
+
+    // Switch away, change foreground to crimson, switch back.
+    await selectTool(page, 'move');
+    await setForegroundColor(page, CRIMSON.r, CRIMSON.g, CRIMSON.b);
+    await selectTool(page, 'shape');
+
+    // Fill must remain gold — once seeded, it stays.
+    const fill = await getShapeFillColor(page);
+    expect(fill).toEqual({ ...GOLD, a: 1 });
+  });
+});

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -328,10 +328,8 @@ export const useUIStore = create<UIState>((set, get) => ({
 
   setActiveTool: (tool) => {
     const current = useUIStore.getState();
-    if (current.activeTool !== tool) {
-      toolRegistry[current.activeTool]?.onDeactivate?.();
-    }
-    // Clear path when switching away from path tool
+    if (current.activeTool === tool) return;
+    toolRegistry[current.activeTool]?.onDeactivate?.();
     if (current.activeTool === 'path' && tool !== 'path') {
       set({ activeTool: tool, pathAnchors: [], pathClosed: false });
     } else {

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -43,6 +43,10 @@ import { SprayOptions } from '../app/OptionsBar/tool-options/SprayOptions';
 
 import { useToolSettingsStore } from '../app/tool-settings-store';
 
+// Tracks whether the shape tool has been activated at least once in this
+// session — used to make the foreground → fill seed a one-shot. See #424.
+let shapeFillSeededFromForeground = false;
+
 /**
  * Single source of truth for every tool. Adding a new tool is a single-file
  * change: append a descriptor here. The router, options bar, keyboard
@@ -279,9 +283,13 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
       move: (ctx, state) => handleShapeMove(state, ctx.layerPos, ctx.metaKey),
       up: (ctx, state) => handleShapeUp(state, ctx.layerPos, ctx.metaKey),
     },
-    // Seed the shape's fill color from the current foreground on activation —
-    // users expect "pick a color, then click shape" to draw in that color.
+    // Seed the shape's fill color from the current foreground on the FIRST
+    // activation only — users expect "pick a color, then click shape" to draw
+    // in that color. After that, the user's chosen fill is preserved across
+    // tool switches and re-activations (issue #424).
     onActivate: () => {
+      if (shapeFillSeededFromForeground) return;
+      shapeFillSeededFromForeground = true;
       const ts = useToolSettingsStore.getState();
       ts.setShapeFillColor(ts.foregroundColor);
     },


### PR DESCRIPTION
## Summary

Fixes #424. The Shape tool's `onActivate` previously ran
`setShapeFillColor(foregroundColor)` unconditionally on every
`setActiveTool('shape')` call. Pressing `U` while the Shape tool was
already active, or switching to another tool and back, silently clobbered
a fill color the user had just chosen in the options bar.

## Changes

Two changes — both required to cover both repros described in the issue:

1. **`src/app/ui-store.ts`** — `setActiveTool` early-returns when the
   requested tool is already active, mirroring the existing `onDeactivate`
   guard. Re-pressing `U` no longer fires `onActivate` at all.

2. **`src/tools/tool-registry.ts`** — the shape tool's foreground → fill
   seed is now a one-shot per session, tracked by a module-level flag.
   The seed still runs the first time the user activates Shape
   (preserving the "pick a color, then click shape" workflow), but
   subsequent activations don't touch the user-chosen fill.

## What this fixes

Both reproductions in #424:

- **Press `U` twice.** With Shape already active, re-pressing `U` used
  to silently re-seed the fill from foreground. Now it's a no-op.
- **Switch to another tool and back.** Switching to Move (or anything
  else) and back to Shape used to reset the fill on each return. Now
  the user's chosen fill persists indefinitely.

## What this preserves

- **First-time activation still seeds from foreground.** The "pick a
  color, then click shape" workflow described in the original
  `onActivate` comment is preserved — the seed just doesn't fire on
  every subsequent activation.
- **The double-click swatch → foreground sync** in `ShapeOptions.tsx`
  is unaffected (it was always one-way: fill → foreground).

## Test plan

New e2e file `e2e/shape-fill-persists-on-reactivate.spec.ts` covers:

- [x] Pressing `U` twice keeps the user-chosen fill — verified by store
      read AND by drawing a shape and checking the pixel color via GPU
      readback.
- [x] Switching to Move and back keeps the user-chosen fill — verified
      by store read AND by reading the options-bar Fill swatch's
      computed `background-color`.
- [x] First activation still seeds from foreground (regression guard).
- [x] Changing foreground after the first shape activation does not
      affect the fill on subsequent re-activations.

Verified locally:
- [x] `npm run typecheck` — clean.
- [x] `npx vitest run` — 912/913 pass. The single failure
      (`engine-sync.test.ts > syncGroupAdjustments`) exists on `main`
      and is unrelated to this change.

## Why other open issues are not addressed here

This PR is scoped to #424 because it's the only tractable issue in
this pass:

- **#380** — bullet 2 already has PR #381; bullet 1 (initial brush
  hesitation on large canvases) needs Rust/WASM-side GPU pre-allocation
  in `engine-rs` and stays open for that.
- **#349** — non-destructive wrap-around for the seamless preview
  needs a new texture lifecycle in `engine-rs/crates/lopsy-wasm/src/layer_manager.rs`,
  ~250–350 LOC across Rust + a new GPU blit + TS wiring. Beyond
  focused-autofix scope.
- **#315** — corruption guard already landed in PR #386; the remaining
  work (moving the painted quick-mask content with the marquee) needs
  GPU ops symmetric to the layer-pixel float path plus a new GLSL
  shader. Stays open for that.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HpAdswSXF6Mc8Xz13qEj73)_