### PR TITLE
feat: UI polish — noise seed, histograms, layer panel, default adjustments

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/api/filter/noise.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/filter/noise.rs
@@ -8,9 +8,8 @@ use crate::filter_gpu;
 #[wasm_bindgen(js_name = "filterAddNoise")]
 pub fn filter_add_noise(
     engine: &mut Engine, layer_id: &str,
-    amount: f32, monochrome: bool,
+    amount: f32, monochrome: bool, seed: f32,
 ) {
-    let seed = engine.inner.selection_time as f32; // Use time as seed for randomness
     filter_gpu::apply_filter(
         &mut engine.inner,
         layer_id,
@@ -30,9 +29,8 @@ pub fn filter_add_noise(
 }
 
 #[wasm_bindgen(js_name = "filterFillWithNoise")]
-pub fn filter_fill_with_noise(engine: &mut Engine, layer_id: &str, monochrome: bool) {
-    // Fill with noise = add noise at maximum amount to a cleared layer
-    filter_add_noise(engine, layer_id, 255.0, monochrome);
+pub fn filter_fill_with_noise(engine: &mut Engine, layer_id: &str, monochrome: bool, seed: f32) {
+    filter_add_noise(engine, layer_id, 255.0, monochrome, seed);
 }
 
 #[wasm_bindgen(js_name = "filterClouds")]

--- a/src/app/MenuBar/filter-actions.ts
+++ b/src/app/MenuBar/filter-actions.ts
@@ -178,7 +178,7 @@ export function applyAddNoise(amount: number, monochrome: boolean): void {
   if (!engine) return;
 
   useEditorStore.getState().pushHistory('Add Noise');
-  filterAddNoise(engine, activeId, amount, monochrome);
+  filterAddNoise(engine, activeId, amount, monochrome, Math.random() * 1000);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
 }
@@ -191,7 +191,7 @@ export function applyFillWithNoise(monochrome: boolean): void {
   if (!engine) return;
 
   useEditorStore.getState().pushHistory('Fill with Noise');
-  filterFillWithNoise(engine, activeId, monochrome);
+  filterFillWithNoise(engine, activeId, monochrome, Math.random() * 1000);
   clearJsPixelData(activeId);
   useEditorStore.getState().notifyRender();
 }

--- a/src/app/MenuBar/menus/layer-menu.ts
+++ b/src/app/MenuBar/menus/layer-menu.ts
@@ -1,4 +1,5 @@
 import { useEditorStore } from '../../editor-store';
+import { useUIStore } from '../../ui-store';
 import type { MenuDef } from './types';
 
 export const layerMenu: MenuDef = {
@@ -7,6 +8,16 @@ export const layerMenu: MenuDef = {
     { label: 'New Layer', shortcut: '\u21E7\u2318N', action: () => useEditorStore.getState().addLayer() },
     { label: 'Duplicate Layer', shortcut: '\u2318J', action: () => useEditorStore.getState().duplicateLayer() },
     { label: 'Group Layers', shortcut: '\u2318G', action: () => useEditorStore.getState().groupSelectedLayers() },
+    { separator: true, label: '' },
+    {
+      label: 'Adjustment Layer\u2026',
+      action: () => {
+        const rootGroupId = useEditorStore.getState().document.rootGroupId;
+        if (rootGroupId) useEditorStore.getState().setActiveLayer(rootGroupId);
+        useUIStore.getState().setShowEffectsDrawer(true);
+        useUIStore.getState().openModal({ kind: 'adjustmentLayerInfo' });
+      },
+    },
     { separator: true, label: '' },
     { label: 'Merge Down', shortcut: '\u2318E', action: () => useEditorStore.getState().mergeDown() },
     { label: 'Flatten Image', action: () => useEditorStore.getState().flattenImage() },

--- a/src/app/editor-store.test.ts
+++ b/src/app/editor-store.test.ts
@@ -138,7 +138,7 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
   it('addAdjustmentNode appends a new enabled node with defaults', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');
-    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group')!.id;
+    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group' && l.name === 'Test Group')!.id;
 
     state.addAdjustmentNode(groupId, 'exposure');
     state.addAdjustmentNode(groupId, 'contrast');
@@ -156,7 +156,7 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
   it('updateAdjustmentNode changes node params without affecting other nodes', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');
-    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group')!.id;
+    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group' && l.name === 'Test Group')!.id;
 
     state.addAdjustmentNode(groupId, 'exposure');
     state.addAdjustmentNode(groupId, 'saturation');
@@ -179,7 +179,7 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
   it('removeAdjustmentNode removes only the specified node', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');
-    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group')!.id;
+    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group' && l.name === 'Test Group')!.id;
 
     state.addAdjustmentNode(groupId, 'exposure');
     state.addAdjustmentNode(groupId, 'vignette');
@@ -198,7 +198,7 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
   it('toggleAdjustmentNode flips the enabled field', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');
-    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group')!.id;
+    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group' && l.name === 'Test Group')!.id;
 
     state.addAdjustmentNode(groupId, 'exposure');
     const midGroup = useEditorStore.getState().document.layers.find((l) => l.id === groupId);
@@ -219,7 +219,7 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
   it('reorderAdjustmentNodes reorders nodes to the requested sequence', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');
-    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group')!.id;
+    const groupId = useEditorStore.getState().document.layers.find((l) => l.type === 'group' && l.name === 'Test Group')!.id;
 
     state.addAdjustmentNode(groupId, 'exposure');
     state.addAdjustmentNode(groupId, 'contrast');

--- a/src/app/store/actions/create-document.ts
+++ b/src/app/store/actions/create-document.ts
@@ -2,6 +2,7 @@ import type { Layer } from '../../../types';
 import type { SelectionData, ActionResult } from '../types';
 import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
 import { createImageData } from '../../../engine/color-space';
+import { createDefaultAdjustments } from '../../../filters/adjustment-node-utils';
 
 export function computeCreateDocument(
   width: number,
@@ -34,7 +35,7 @@ export function computeCreateDocument(
     activeLayerId = drawLayer.id;
   }
 
-  const rootGroup = createGroupLayer({ name: 'Project', children: childIds });
+  const rootGroup = createGroupLayer({ name: 'Project', children: childIds, adjustments: createDefaultAdjustments() });
   layers.push(rootGroup);
   layerOrder.push(rootGroup.id);
 

--- a/src/app/store/actions/flatten-image.ts
+++ b/src/app/store/actions/flatten-image.ts
@@ -2,6 +2,7 @@ import type { DocumentState } from '../../../types';
 import type { ActionResult } from '../types';
 import type { Layer } from '../../../types';
 import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
+import { createDefaultAdjustments } from '../../../filters/adjustment-node-utils';
 import { getEngine } from '../../../engine-wasm/engine-state';
 import { compositeForExport, uploadLayerPixels, addLayer } from '../../../engine-wasm/wasm-bridge';
 
@@ -47,7 +48,7 @@ export function computeFlattenImage(
 
   const pixelData = new Map<string, ImageData>();
 
-  const rootGroup = createGroupLayer({ name: 'Project', children: [flatLayer.id] });
+  const rootGroup = createGroupLayer({ name: 'Project', children: [flatLayer.id], adjustments: createDefaultAdjustments() });
 
   return {
     document: {

--- a/src/app/store/actions/open-image.ts
+++ b/src/app/store/actions/open-image.ts
@@ -1,12 +1,13 @@
 import type { SelectionData, ActionResult } from '../types';
 import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model';
+import { createDefaultAdjustments } from '../../../filters/adjustment-node-utils';
 
 export function computeOpenImage(
   imageData: ImageData,
   name: string,
 ): ActionResult {
   const layer = createRasterLayer({ name: 'Background', width: imageData.width, height: imageData.height });
-  const rootGroup = createGroupLayer({ name: 'Project', children: [layer.id] });
+  const rootGroup = createGroupLayer({ name: 'Project', children: [layer.id], adjustments: createDefaultAdjustments() });
   const pixelData = new Map<string, ImageData>();
   pixelData.set(layer.id, imageData);
   const selection: SelectionData = { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 };

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -2,7 +2,7 @@ import type { BlendMode, LayerEffects, Layer, Rect } from '../../types';
 import type { AdjustmentNodeType, AdjustmentNode } from '../../types/adjustment-nodes';
 import type { AlignEdge } from '../../tools/move/move';
 import { createRasterLayer, createGroupLayer } from '../../layers/layer-model';
-import { createDefaultNode } from '../../filters/adjustment-node-utils';
+import { createDefaultNode, createDefaultAdjustments } from '../../filters/adjustment-node-utils';
 import { createImageData } from '../../engine/color-space';
 import { moveLayerToGroup as moveLayerToGroupUtil, getInsertionGroupId, getInsertionOrderIndex, addToGroup as addToGroupUtil, getDescendantIds as getDescendantIdsUtil, buildFlatDisplayList, findParentGroup, removeFromParentGroup } from '../../layers/group-utils';
 import { sparseToImageData } from '../../engine/canvas-ops';
@@ -120,7 +120,7 @@ function syncPixelDataToGpu(
 
 function createInitialDocument() {
   const bg = createRasterLayer({ name: 'Background', width: 800, height: 600 });
-  const rootGroup = createGroupLayer({ name: 'Project', children: [bg.id] });
+  const rootGroup = createGroupLayer({ name: 'Project', children: [bg.id], adjustments: createDefaultAdjustments() });
   const imgData = createImageData(800, 600);
   for (let i = 0; i < imgData.data.length; i += 4) {
     imgData.data[i] = 255;

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -103,7 +103,8 @@ export type ModalState =
   | { kind: 'strokePath'; pathId: string }
   | { kind: 'guideColor' }
   | { kind: 'brush' }
-  | { kind: 'loading'; message: string };
+  | { kind: 'loading'; message: string }
+  | { kind: 'adjustmentLayerInfo' };
 
 export interface SnapLine {
   orientation: 'vertical' | 'horizontal';

--- a/src/components/CurveEditor/CurveEditor.module.css
+++ b/src/components/CurveEditor/CurveEditor.module.css
@@ -2,16 +2,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  align-items: center;
 }
 
 .canvas {
   display: block;
+  width: 100%;
+  height: 220px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   cursor: crosshair;
   touch-action: none;
-  background: var(--color-bg-tertiary);
+  background: rgba(0, 0, 0, 0.4);
 }
 
 .hint {

--- a/src/components/CurveEditor/CurveEditor.tsx
+++ b/src/components/CurveEditor/CurveEditor.tsx
@@ -6,7 +6,10 @@ import {
   normalizePoints,
   type CurvePoint,
 } from '../../filters/curves';
+import { histogramPercentile, type Histogram } from '../../panels/AdjustmentsPanel/histogram-compute';
 import styles from './CurveEditor.module.css';
+
+type ChannelKey = 'rgb' | 'r' | 'g' | 'b';
 
 interface CurveEditorProps {
   /**
@@ -17,13 +20,26 @@ interface CurveEditorProps {
   onChange: (points: CurvePoint[]) => void;
   /** Tint of the curve stroke and active control point. */
   color?: string;
-  /** Square size in CSS pixels. */
-  size?: number;
+  histogram?: Histogram;
+  channel?: ChannelKey;
 }
 
 const HIT_RADIUS_PX = 8;
 const POINT_RADIUS_PX = 4;
 const POINT_REMOVE_THRESHOLD_PX = 24;
+
+const HIST_SHADES: Record<'r' | 'g' | 'b', string> = {
+  r: 'rgba(180, 60, 60, 0.45)',
+  g: 'rgba(60, 160, 80, 0.45)',
+  b: 'rgba(60, 90, 180, 0.45)',
+};
+const HIST_SHADE_FOCUS: Record<ChannelKey, string> = {
+  rgb: 'rgba(220, 220, 220, 0.92)',
+  r: 'rgba(200, 80, 80, 0.85)',
+  g: 'rgba(80, 200, 100, 0.85)',
+  b: 'rgba(80, 120, 220, 0.85)',
+};
+const HIST_SHADE_MUTED = 'rgba(60, 60, 60, 0.35)';
 
 interface DragState {
   index: number;
@@ -36,12 +52,11 @@ export function CurveEditor({
   points,
   onChange,
   color = 'var(--color-text-primary)',
-  size = 220,
+  histogram,
+  channel = 'rgb',
 }: CurveEditorProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [drag, setDrag] = useState<DragState | null>(null);
-  // Mirror of the props points so dragging stays smooth without waiting
-  // for the parent to re-render between pointer events.
   const [localPoints, setLocalPoints] = useState<readonly CurvePoint[]>(points);
 
   useEffect(() => {
@@ -54,17 +69,54 @@ export function CurveEditor({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const dpr = window.devicePixelRatio || 1;
-    const w = canvas.width;
-    const h = canvas.height;
+    const cw = canvas.clientWidth;
+    const ch = canvas.clientHeight;
+    canvas.width = cw * dpr;
+    canvas.height = ch * dpr;
 
     ctx.save();
     ctx.scale(dpr, dpr);
-    const cw = w / dpr;
-    const ch = h / dpr;
 
     // Background.
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
     ctx.fillRect(0, 0, cw, ch);
+
+    // Histogram behind everything.
+    if (histogram && histogram.total > 0) {
+      const cap = Math.max(
+        histogramPercentile(histogram.r, 0.995),
+        histogramPercentile(histogram.g, 0.995),
+        histogramPercentile(histogram.b, 0.995),
+        1,
+      );
+
+      const drawHistChannel = (bins: Uint32Array, fill: string) => {
+        ctx.fillStyle = fill;
+        ctx.beginPath();
+        ctx.moveTo(0, ch);
+        for (let i = 0; i < 256; i++) {
+          const x = (i / 255) * cw;
+          const barH = Math.min(1, bins[i]! / cap) * ch;
+          ctx.lineTo(x, ch - barH);
+        }
+        ctx.lineTo(cw, ch);
+        ctx.closePath();
+        ctx.fill();
+      };
+
+      if (channel === 'rgb') {
+        ctx.globalCompositeOperation = 'lighter';
+        drawHistChannel(histogram.b, HIST_SHADES.b);
+        drawHistChannel(histogram.g, HIST_SHADES.g);
+        drawHistChannel(histogram.r, HIST_SHADES.r);
+        ctx.globalCompositeOperation = 'source-over';
+      } else {
+        const others: Array<'r' | 'g' | 'b'> = (['r', 'g', 'b'] as const).filter((c) => c !== channel);
+        drawHistChannel(histogram[others[0]!], HIST_SHADE_MUTED);
+        drawHistChannel(histogram[others[1]!], HIST_SHADE_MUTED);
+        drawHistChannel(histogram[channel], HIST_SHADE_FOCUS[channel]);
+      }
+    }
 
     // Grid (quarters + diagonal reference).
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
@@ -109,19 +161,9 @@ export function CurveEditor({
     }
 
     ctx.restore();
-  }, [localPoints, color]);
+  }, [localPoints, color, histogram, channel]);
 
-  // Resize for HiDPI.
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = size * dpr;
-    canvas.height = size * dpr;
-    canvas.style.width = `${size}px`;
-    canvas.style.height = `${size}px`;
-    draw();
-  }, [size, draw]);
+  useEffect(() => { draw(); }, [draw]);
 
   useEffect(() => { draw(); }, [draw]);
 

--- a/src/components/ModalHost/ModalHost.tsx
+++ b/src/components/ModalHost/ModalHost.tsx
@@ -29,7 +29,7 @@ export function ModalHost() {
   // two that didn't before (NewDocument and ShapeSize) to avoid double-firing.
   useEffect(() => {
     if (!modal) return;
-    if (modal.kind !== 'newDocument' && modal.kind !== 'shapeSize') return;
+    if (modal.kind !== 'newDocument' && modal.kind !== 'shapeSize' && modal.kind !== 'adjustmentLayerInfo') return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') closeModal();
     };
@@ -105,9 +105,70 @@ export function ModalHost() {
       // Rendered separately in App.tsx — it needs canvas-container-relative
       // positioning, not the fixed overlay a ModalHost provides.
       return null;
+    case 'adjustmentLayerInfo':
+      return <AdjustmentLayerInfoModal onClose={closeModal} />;
     case 'loading':
       return <LoadingOverlay message={modal.message} />;
   }
+}
+
+function AdjustmentLayerInfoModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: 'rgba(0, 0, 0, 0.6)', zIndex: 9999,
+      }}
+      role="dialog"
+      aria-label="Adjustment layers"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div style={{
+        background: 'var(--color-bg-secondary, #1e1e1e)',
+        border: '1px solid var(--color-border, #333)',
+        borderRadius: 'var(--radius-lg, 8px)',
+        padding: '24px 28px',
+        maxWidth: 420,
+        color: 'var(--color-text-primary, #e0e0e0)',
+        fontSize: 'var(--font-size-sm, 13px)',
+        lineHeight: 1.6,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+      }}>
+        <h2 style={{ margin: 0, fontSize: 'var(--font-size-lg, 16px)' }}>
+          Group Adjustments
+        </h2>
+        <p style={{ margin: 0, color: 'var(--color-text-secondary, #aaa)' }}>
+          Lopsy uses <strong>group adjustments</strong> instead of separate adjustment layers.
+          Adjustments like Levels, Curves, Exposure, and Hue/Saturation live directly on
+          the Project group and apply non-destructively to all layers within it.
+        </p>
+        <p style={{ margin: 0, color: 'var(--color-text-secondary, #aaa)' }}>
+          The Group Adjustments panel is now open on the right. You can add, remove,
+          reorder, and toggle adjustments from there.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: 'var(--color-accent, #4a9eff)',
+              border: 'none',
+              borderRadius: 'var(--radius-sm, 4px)',
+              padding: '6px 20px',
+              color: '#fff',
+              fontSize: 'var(--font-size-sm, 13px)',
+              cursor: 'pointer',
+            }}
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function LoadingOverlay({ message }: { message: string }) {

--- a/src/filters/adjustment-node-utils.ts
+++ b/src/filters/adjustment-node-utils.ts
@@ -188,6 +188,16 @@ export function createDefaultNode(type: AdjustmentNodeType): AdjustmentNode {
   }
 }
 
+/** Default adjustment nodes added to every new document's root group. */
+export function createDefaultAdjustments(): AdjustmentNode[] {
+  return [
+    createDefaultNode('levels'),
+    createDefaultNode('curves'),
+    createDefaultNode('exposure'),
+    createDefaultNode('hue-saturation'),
+  ];
+}
+
 /** Human-readable label for each node type, shown in the Add menu and node headers. */
 export const ADJUSTMENT_NODE_LABELS: Record<AdjustmentNodeType, string> = {
   'exposure': 'Exposure',

--- a/src/layers/layer-model.ts
+++ b/src/layers/layer-model.ts
@@ -66,7 +66,7 @@ export function createTextLayer(params: {
   };
 }
 
-export function createGroupLayer(params: { name: string; children?: string[] }): GroupLayer {
+export function createGroupLayer(params: { name: string; children?: string[]; adjustments?: readonly import('../types/adjustment-nodes').AdjustmentNode[] }): GroupLayer {
   return {
     id: crypto.randomUUID(),
     name: params.name,
@@ -84,7 +84,7 @@ export function createGroupLayer(params: { name: string; children?: string[] }):
     mask: null,
     children: params.children ?? [],
     collapsed: false,
-    adjustments: [],
+    adjustments: params.adjustments ? [...params.adjustments] : [],
     adjustmentsEnabled: true,
   };
 }

--- a/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
+++ b/src/panels/AdjustmentsPanel/AdjustmentsPanel.tsx
@@ -3,6 +3,7 @@ import { Eye, EyeOff, X, ChevronDown, ChevronRight, GripVertical, Trash2, Plus }
 import { Slider } from '../../components/Slider/Slider';
 import { IconButton } from '../../components/IconButton/IconButton';
 import type { DragProps } from '../../app/hooks/useDraggablePanel';
+import { useGroupHistogram } from './useGroupHistogram';
 import { CurveEditor } from '../../components/CurveEditor/CurveEditor';
 import { useEditorStore } from '../../app/editor-store';
 import { useUIStore } from '../../app/ui-store';
@@ -44,6 +45,13 @@ import { ColorPicker } from '../../components/ColorPicker/ColorPicker';
 import styles from './AdjustmentsPanel.module.css';
 
 const CHANNEL_COLORS: Record<CurveChannel, string> = {
+  rgb: '#e0e0e0',
+  r: '#e0e0e0',
+  g: '#e0e0e0',
+  b: '#e0e0e0',
+};
+
+const CHANNEL_TAB_COLORS: Record<CurveChannel, string> = {
   rgb: '#e0e0e0',
   r: '#ff5e5e',
   g: '#5eff7e',
@@ -403,6 +411,7 @@ function VignetteControls({ node, onChange }: { node: VignetteNode; onChange: (p
 
 function CurvesControls({ node, onChange }: { node: CurvesNode; onChange: (p: Partial<AdjustmentNode>) => void }) {
   const [channel, setChannel] = useState<CurveChannel>('rgb');
+  const histogram = useGroupHistogram(false);
   const curves: Curves = node.curves;
   const points = curves[channel];
   const isIdentity = isIdentityCurve(points);
@@ -427,7 +436,7 @@ function CurvesControls({ node, onChange }: { node: CurvesNode; onChange: (p: Pa
               role="tab"
               aria-selected={channel === c}
               className={`${styles.channelTab} ${channel === c ? styles.channelTabActive : ''}`}
-              style={{ color: CHANNEL_COLORS[c] }}
+              style={{ color: CHANNEL_TAB_COLORS[c] }}
               onClick={() => setChannel(c)}
             >
               {CHANNEL_LABELS[c]}
@@ -447,6 +456,8 @@ function CurvesControls({ node, onChange }: { node: CurvesNode; onChange: (p: Pa
         points={points}
         color={CHANNEL_COLORS[channel]}
         onChange={(pts) => handleCurveChange(channel, pts)}
+        histogram={histogram}
+        channel={channel}
       />
     </div>
   );

--- a/src/panels/AdjustmentsPanel/LevelsEditor.module.css
+++ b/src/panels/AdjustmentsPanel/LevelsEditor.module.css
@@ -74,8 +74,7 @@
 /* ─── Histogram ───────────────────────────────────────────────────────── */
 
 .histogram {
-  width: 256px;
-  align-self: center;
+  width: 100%;
   border: 1px solid var(--color-border);
   border-bottom: none;
   border-top-left-radius: var(--radius-sm);
@@ -86,8 +85,8 @@
 
 .histogramCanvas {
   display: block;
-  width: 256px;
-  height: 90px;
+  width: 100%;
+  height: 120px;
 }
 
 /* ─── Axes (input + output) ──────────────────────────────────────────── */
@@ -95,8 +94,7 @@
 .axis {
   display: flex;
   flex-direction: column;
-  align-self: center;
-  width: 256px;
+  width: 100%;
   gap: 2px;
 }
 
@@ -155,8 +153,7 @@
 /* ─── Gradient bar between input & output axes ───────────────────────── */
 
 .gradient {
-  align-self: center;
-  width: 256px;
+  width: 100%;
   height: 12px;
   background: linear-gradient(to right, #000 0%, #fff 100%);
   border: 1px solid var(--color-border);

--- a/src/panels/AdjustmentsPanel/LevelsEditor.tsx
+++ b/src/panels/AdjustmentsPanel/LevelsEditor.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
-import { useEditorStore } from '../../app/editor-store';
-import { readLayerAsImageData } from '../../engine-wasm/gpu-pixel-access';
-import { pixelDataManager } from '../../engine/pixel-data-manager';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type Levels, type LevelsChannel, isIdentityChannel } from '../../filters/levels';
 import { clamp } from '../../utils/math';
-import { computeHistogram, EMPTY_HISTOGRAM, histogramPercentile, type Histogram } from './histogram-compute';
+import { histogramPercentile, type Histogram } from './histogram-compute';
+import { useGroupHistogram } from './useGroupHistogram';
 import styles from './LevelsEditor.module.css';
 
 const CHANNEL_ORDER = ['rgb', 'r', 'g', 'b'] as const;
@@ -18,9 +16,6 @@ const CHANNEL_TAB_COLORS: Record<ChannelKey, string> = {
   b: '#789cff',
 };
 
-/** Distinct shades of gray for each channel's layered histogram. Lightest
- *  on top, darkest on bottom; with 'lighter' compositing the overlap is
- *  additive so common ranges read as near-white. */
 const HIST_SHADES: Record<'r' | 'g' | 'b', string> = {
   r: 'rgba(210, 210, 210, 0.55)',
   g: 'rgba(140, 140, 140, 0.55)',
@@ -28,14 +23,11 @@ const HIST_SHADES: Record<'r' | 'g' | 'b', string> = {
 };
 const HIST_SHADE_FOCUS: Record<'r' | 'g' | 'b' | 'rgb', string> = {
   rgb: 'rgba(220, 220, 220, 0.92)',
-  r: 'rgba(220, 220, 220, 0.92)',
-  g: 'rgba(160, 160, 160, 0.92)',
-  b: 'rgba(110, 110, 110, 0.92)',
+  r: 'rgba(200, 80, 80, 0.85)',
+  g: 'rgba(80, 200, 100, 0.85)',
+  b: 'rgba(80, 120, 220, 0.85)',
 };
 const HIST_SHADE_MUTED = 'rgba(60, 60, 60, 0.35)';
-
-const TRACK_W = 256;
-const HISTOGRAM_H = 90;
 
 interface LevelsEditorProps {
   levels: Levels;
@@ -108,25 +100,24 @@ function HistogramView({ histogram, channel }: { histogram: Histogram; channel: 
     if (!ctx) return;
 
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = TRACK_W * dpr;
-    canvas.height = HISTOGRAM_H * dpr;
-    canvas.style.width = `${TRACK_W}px`;
-    canvas.style.height = `${HISTOGRAM_H}px`;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
 
     ctx.save();
     ctx.scale(dpr, dpr);
 
     ctx.fillStyle = 'rgba(0, 0, 0, 0.35)';
-    ctx.fillRect(0, 0, TRACK_W, HISTOGRAM_H);
+    ctx.fillRect(0, 0, w, h);
 
-    // Quartile reference grid.
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.05)';
     ctx.lineWidth = 1;
     for (let i = 1; i < 4; i++) {
-      const x = (i / 4) * TRACK_W;
+      const x = (i / 4) * w;
       ctx.beginPath();
       ctx.moveTo(x, 0);
-      ctx.lineTo(x, HISTOGRAM_H);
+      ctx.lineTo(x, h);
       ctx.stroke();
     }
 
@@ -134,13 +125,11 @@ function HistogramView({ histogram, channel }: { histogram: Histogram; channel: 
       ctx.fillStyle = 'rgba(160, 160, 160, 0.4)';
       ctx.font = '11px var(--font-ui)';
       ctx.textAlign = 'center';
-      ctx.fillText('No image data', TRACK_W / 2, HISTOGRAM_H / 2 + 4);
+      ctx.fillText('No image data', w / 2, h / 2 + 4);
       ctx.restore();
       return;
     }
 
-    // Use the 99.5th-percentile bin height as the vertical scale so
-    // a single dominant column doesn't squash everything to a flat line.
     const cap = Math.max(
       histogramPercentile(histogram.r, 0.995),
       histogramPercentile(histogram.g, 0.995),
@@ -151,25 +140,23 @@ function HistogramView({ histogram, channel }: { histogram: Histogram; channel: 
     const drawChannel = (bins: Uint32Array, fill: string) => {
       ctx.fillStyle = fill;
       ctx.beginPath();
-      ctx.moveTo(0, HISTOGRAM_H);
+      ctx.moveTo(0, h);
       for (let i = 0; i < 256; i++) {
-        const x = (i / 255) * TRACK_W;
-        const h = Math.min(1, bins[i]! / cap) * HISTOGRAM_H;
-        ctx.lineTo(x, HISTOGRAM_H - h);
+        const x = (i / 255) * w;
+        const barH = Math.min(1, bins[i]! / cap) * h;
+        ctx.lineTo(x, h - barH);
       }
-      ctx.lineTo(TRACK_W, HISTOGRAM_H);
+      ctx.lineTo(w, h);
       ctx.closePath();
       ctx.fill();
     };
 
     if (channel === 'rgb') {
-      // Layered shades of gray, additively blended so common ranges read brighter.
       ctx.globalCompositeOperation = 'lighter';
       drawChannel(histogram.b, HIST_SHADES.b);
       drawChannel(histogram.g, HIST_SHADES.g);
       drawChannel(histogram.r, HIST_SHADES.r);
     } else {
-      // Single-channel: mute the others, emphasise the active one.
       ctx.globalCompositeOperation = 'source-over';
       const others: Array<'r' | 'g' | 'b'> = (['r', 'g', 'b'] as const).filter((c) => c !== channel);
       drawChannel(histogram[others[0]!], HIST_SHADE_MUTED);
@@ -355,66 +342,6 @@ function useDragHandle(
 
 function GradientBar() {
   return <div className={styles.gradient} aria-hidden="true" />;
-}
-
-// ─── Active group's histogram ─────────────────────────────────────────────
-
-function useGroupHistogram(skip: boolean): Histogram {
-  // Cheap subscription that fires on any layer pixel mutation.
-  const pixelVersion = useSyncExternalStore(
-    pixelDataManager.subscribe.bind(pixelDataManager),
-    () => pixelDataManager.version(),
-  );
-  const activeGroupChildren = useEditorStore((s) => {
-    const id = s.document.activeLayerId;
-    const layers = s.document.layers;
-    const active = id ? layers.find((l) => l.id === id) : undefined;
-    if (active?.type === 'group') return active.children;
-    const root = layers.find((l) => l.id === s.document.rootGroupId);
-    return root?.type === 'group' ? root.children : [];
-  });
-  const layersMap = useEditorStore((s) => s.document.layers);
-
-  const [histogram, setHistogram] = useState<Histogram>(EMPTY_HISTOGRAM);
-
-  const childKey = useMemo(() => activeGroupChildren.join(','), [activeGroupChildren]);
-
-  useEffect(() => {
-    if (skip) return;
-    let cancelled = false;
-    let retries = 0;
-
-    const tryRead = () => {
-      if (cancelled) return;
-      const images: ImageData[] = [];
-      for (const id of activeGroupChildren) {
-        const layer = layersMap.find((l) => l.id === id);
-        if (!layer || !layer.visible) continue;
-        if (layer.type === 'group') continue;
-        const img = readLayerAsImageData(id);
-        if (img) images.push(img);
-      }
-      if (images.length === 0) {
-        // Texture may not be uploaded yet for a brand-new layer — retry a few frames.
-        if (retries < 8) {
-          retries++;
-          requestAnimationFrame(tryRead);
-        } else {
-          setHistogram(EMPTY_HISTOGRAM);
-        }
-        return;
-      }
-      setHistogram(computeHistogram(images));
-    };
-
-    const rafId = requestAnimationFrame(tryRead);
-    return () => {
-      cancelled = true;
-      cancelAnimationFrame(rafId);
-    };
-  }, [skip, childKey, pixelVersion, activeGroupChildren, layersMap]);
-
-  return histogram;
 }
 
 // ─── Math helpers ─────────────────────────────────────────────────────────

--- a/src/panels/AdjustmentsPanel/useGroupHistogram.ts
+++ b/src/panels/AdjustmentsPanel/useGroupHistogram.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useEditorStore } from '../../app/editor-store';
+import { readLayerAsImageData } from '../../engine-wasm/gpu-pixel-access';
+import { pixelDataManager } from '../../engine/pixel-data-manager';
+import { computeHistogram, EMPTY_HISTOGRAM, type Histogram } from './histogram-compute';
+
+export function useGroupHistogram(skip: boolean): Histogram {
+  const pixelVersion = useSyncExternalStore(
+    pixelDataManager.subscribe.bind(pixelDataManager),
+    () => pixelDataManager.version(),
+  );
+  const activeGroupChildren = useEditorStore((s) => {
+    const id = s.document.activeLayerId;
+    const layers = s.document.layers;
+    const active = id ? layers.find((l) => l.id === id) : undefined;
+    if (active?.type === 'group') return active.children;
+    const root = layers.find((l) => l.id === s.document.rootGroupId);
+    return root?.type === 'group' ? root.children : [];
+  });
+  const layersMap = useEditorStore((s) => s.document.layers);
+
+  const [histogram, setHistogram] = useState<Histogram>(EMPTY_HISTOGRAM);
+
+  const childKey = useMemo(() => activeGroupChildren.join(','), [activeGroupChildren]);
+
+  useEffect(() => {
+    if (skip) return;
+    let cancelled = false;
+    let retries = 0;
+
+    const tryRead = () => {
+      if (cancelled) return;
+      const images: ImageData[] = [];
+      for (const id of activeGroupChildren) {
+        const layer = layersMap.find((l) => l.id === id);
+        if (!layer || !layer.visible) continue;
+        if (layer.type === 'group') continue;
+        const img = readLayerAsImageData(id);
+        if (img) images.push(img);
+      }
+      if (images.length === 0) {
+        if (retries < 8) {
+          retries++;
+          requestAnimationFrame(tryRead);
+        } else {
+          setHistogram(EMPTY_HISTOGRAM);
+        }
+        return;
+      }
+      setHistogram(computeHistogram(images));
+    };
+
+    const rafId = requestAnimationFrame(tryRead);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
+  }, [skip, childKey, pixelVersion, activeGroupChildren, layersMap]);
+
+  return histogram;
+}

--- a/src/panels/LayerPanel/LayerPanel.module.css
+++ b/src/panels/LayerPanel/LayerPanel.module.css
@@ -208,6 +208,14 @@
   color: var(--color-accent);
 }
 
+.effectsBtnHasEffects {
+  color: #4caf50;
+}
+
+.effectsBtnHasEffects:hover {
+  color: #66bb6a;
+}
+
 .opacity {
   appearance: none;
   background: none;

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -365,8 +365,39 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
                   {layer.name}
                 </span>
               )}
+              {!isRootGroup(layer.id) && (
+                <button
+                  className={styles.opacity}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setEditingOpacityId(editingOpacityId === layer.id ? null : layer.id);
+                  }}
+                  type="button"
+                  aria-label={`Opacity ${Math.round(layer.opacity * 100)}% for ${layer.name}`}
+                  title="Click to adjust opacity"
+                >
+                  {Math.round(layer.opacity * 100)}%
+                </button>
+              )}
+              {!isRootGroup(layer.id) && (
+                <button
+                  className={styles.visibilityBtn}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleVisibility(layer.id);
+                  }}
+                  type="button"
+                  aria-label={layer.visible ? 'Hide layer' : 'Show layer'}
+                >
+                  {layer.visible ? <Eye size={14} /> : <EyeOff size={14} />}
+                </button>
+              )}
               <button
-                className={`${styles.effectsBtn} ${showEffectsDrawer && layer.id === activeLayerId ? styles.effectsBtnActive : ''}`}
+                className={[
+                  styles.effectsBtn,
+                  showEffectsDrawer && layer.id === activeLayerId ? styles.effectsBtnActive : '',
+                  hasActiveEffects(layer) ? styles.effectsBtnHasEffects : '',
+                ].filter(Boolean).join(' ')}
                 onClick={(e) => {
                   e.stopPropagation();
                   if (showEffectsDrawer && layer.id === activeLayerId) {
@@ -382,20 +413,6 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
               >
                 <Sparkles size={12} />
               </button>
-              {!isRootGroup(layer.id) && (
-                <button
-                  className={styles.opacity}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setEditingOpacityId(editingOpacityId === layer.id ? null : layer.id);
-                  }}
-                  type="button"
-                  aria-label={`Opacity ${Math.round(layer.opacity * 100)}% for ${layer.name}`}
-                  title="Click to adjust opacity"
-                >
-                  {Math.round(layer.opacity * 100)}%
-                </button>
-              )}
               <button
                 className={`${styles.lockBtn} ${layer.locked ? styles.lockBtnActive : ''}`}
                 onClick={(e) => {
@@ -407,19 +424,6 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
               >
                 {layer.locked ? <Lock size={12} /> : <Unlock size={12} />}
               </button>
-              {!isRootGroup(layer.id) && (
-                <button
-                  className={styles.visibilityBtn}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleVisibility(layer.id);
-                  }}
-                  type="button"
-                  aria-label={layer.visible ? 'Hide layer' : 'Show layer'}
-                >
-                  {layer.visible ? <Eye size={14} /> : <EyeOff size={14} />}
-                </button>
-              )}
             </div>
             {editingOpacityId === layer.id && !isRootGroup(layer.id) && (
               <div className={styles.opacitySlider}>
@@ -564,6 +568,17 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
     )}
     </>
   );
+}
+
+function hasActiveEffects(layer: import('../../types').Layer): boolean {
+  const fx = layer.effects;
+  if (fx.stroke.enabled || fx.dropShadow.enabled || fx.outerGlow.enabled || fx.innerGlow.enabled || fx.colorOverlay.enabled) {
+    return true;
+  }
+  if (layer.type === 'group') {
+    return layer.adjustments.length > 0;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix noise filter seed**: each application now generates a fresh random seed instead of reusing `selection_time` (always 0), so noise patterns differ across layers
- **Levels editor**: full-width layout, taller histogram (120px), dynamic canvas sizing; RGB tab shows tonal gray layers, individual R/G/B tabs show colored fills
- **Curves editor**: histogram background behind the curve graph with colored R/G/B channel shading on all tabs; white curve line on all channels; full-width canvas; darker background matching levels
- **Layer panel**: swapped eye/lock button order (lock always far right), moved effects button next to lock, effects icon turns green when layer has active effects
- **Default adjustments**: new/opened documents start with Levels, Curves, Exposure, and Hue/Saturation on the root group
- **Adjustment Layer menu item**: Layer > Adjustment Layer… selects the Project group, opens the adjustments panel, and shows an info modal explaining group adjustments
- **Shared histogram hook**: extracted `useGroupHistogram` for reuse between Levels and Curves editors

## Test plan

- [ ] Apply noise filter to two different layers — patterns should differ
- [ ] Open Levels on a group — histogram should be full-width, taller, gray-toned on RGB tab, colored on R/G/B tabs
- [ ] Open Curves on a group — histogram background should match levels darkness, show colored R/G/B, white curve line
- [ ] Check layer panel — eye icon before lock, effects sparkle icon next to lock, green when effects are active
- [ ] Create new document — should have Levels, Curves, Exposure, Hue/Sat adjustments on Project group
- [ ] Open an image — same default adjustments should be present
- [ ] Layer > Adjustment Layer… — should select Project, open adjustments panel, show info modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)