### PR TITLE
fix(history): correct redo after image resize

### DIFF
--- a/src/app/store/history-slice.ts
+++ b/src/app/store/history-slice.ts
@@ -51,7 +51,10 @@ function snapshotGpuLayers(
     if (!dirtyIds.has(layerId) && previous?.gpuSnapshots.has(layerId)) {
       const curLayer = layers.find((l) => l.id === layerId);
       const prevLayer = previous.document.layers.find((l) => l.id === layerId);
-      if (curLayer && prevLayer && curLayer.x === prevLayer.x && curLayer.y === prevLayer.y) {
+      const posMatch = curLayer && prevLayer && curLayer.x === prevLayer.x && curLayer.y === prevLayer.y;
+      const dimsChanged = curLayer?.type === 'raster' && prevLayer?.type === 'raster' &&
+        (curLayer.width !== prevLayer.width || curLayer.height !== prevLayer.height);
+      if (posMatch && !dimsChanged) {
         gpuSnapshots.set(layerId, previous.gpuSnapshots.get(layerId)!);
         continue;
       }

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -150,7 +150,6 @@ function renderFrameGpu(
   const guideColor = uiState.guideColor;
 
   const textEditing = uiState.textEditing;
-  const artboards = editorState.artboards;
 
   syncDocumentSize(engine, doc.width, doc.height);
   syncBackgroundColor(engine, doc.backgroundColor.r, doc.backgroundColor.g, doc.backgroundColor.b, doc.backgroundColor.a);
@@ -248,7 +247,6 @@ function renderFrameGpu(
       renderPerspectiveCropOverlay(overlayCtx, perspectiveCropQuad, viewport.zoom);
     }
     renderGradientPreview(overlayCtx, gradientPreview, viewport.zoom);
-    renderArtboards(overlayCtx, artboards, viewport.zoom);
 
     // Text tool overlays
     const textDrag = uiState.textDrag;


### PR DESCRIPTION
## Summary
- **Fixed**: redo after Image > Image Size showed the image at the wrong size. The GPU snapshot reuse check in `snapshotGpuLayers` compared layer position but not dimensions, so after a resize (which changes texture size but often keeps position at 0,0), undo would cache the stale pre-resize blob. On redo, the original full-size pixels were restored against the smaller document dimensions.
- Added a `dimsChanged` guard for raster layers so the snapshot is re-read from GPU when width/height differ.
- Also removed two dead references to a nonexistent `artboards` property that were causing pre-existing type errors on main.

## Test plan
- [ ] Open a photo
- [ ] Image > Image Size — resize smaller
- [ ] Undo (image gets bigger) — verify content is correct
- [ ] Redo (image gets smaller) — verify content is correctly resized, not the original full-size image

🤖 Generated with [Claude Code](https://claude.com/claude-code)