### PR TITLE
style: increase PreciseAdjustmentHandle size

### DIFF
--- a/src/components/PreciseAdjustmentHandle/PreciseAdjustmentHandle.module.css
+++ b/src/components/PreciseAdjustmentHandle/PreciseAdjustmentHandle.module.css
@@ -2,8 +2,8 @@
   position: absolute;
   top: 0;
   transform: translateX(-50%);
-  width: 10px;
-  height: 12px;
+  width: 12px;
+  height: 14px;
   cursor: grab;
   touch-action: none;
   outline: none;


### PR DESCRIPTION
## Summary
- Bump handle dimensions from 10×12px to 12×14px for better visibility and click target

## Test plan
- [ ] Verify handles are slightly larger in both gradient editor and levels editor
- [ ] Confirm drag interaction still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)