### PR TITLE
ci: wire lint, typecheck, unit tests, and e2e into PR workflow

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Block pushes when `tsc --noEmit` fails. Bypass with `git push --no-verify`.
+# Block pushes when local quality gates fail. Bypass with `git push --no-verify`.
+#
+# Skip individual gates with env vars:
+#   SKIP_LINT=1   git push   — skip eslint + pixel-debt
+#   SKIP_TEST=1   git push   — skip vitest
+#   FAST_PUSH=1   git push   — skip lint + test (typecheck still runs)
 set -e
 
 cd "$(git rev-parse --show-toplevel)"
@@ -11,3 +16,17 @@ fi
 
 echo "pre-push: running tsc --noEmit"
 npm run typecheck
+
+if [ "${FAST_PUSH:-0}" = "1" ] || [ "${SKIP_LINT:-0}" = "1" ]; then
+  echo "pre-push: skipping lint (SKIP_LINT or FAST_PUSH set)"
+else
+  echo "pre-push: running lint (eslint + pixel-debt)"
+  npm run lint
+fi
+
+if [ "${FAST_PUSH:-0}" = "1" ] || [ "${SKIP_TEST:-0}" = "1" ]; then
+  echo "pre-push: skipping unit tests (SKIP_TEST or FAST_PUSH set)"
+else
+  echo "pre-push: running unit tests (vitest)"
+  npm run test
+fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,147 @@
+name: PR Checks
+
+on:
+  pull_request:
+  push:
+    branches-ignore: [main]
+
+# Cancel in-progress runs for the same ref when a new push arrives.
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm-build:
+    name: Build WASM engine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Cache WASM pkg output
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: src/engine-wasm/pkg
+          key: wasm-pkg-${{ hashFiles('engine-rs/**/*.rs', 'engine-rs/**/Cargo.toml', 'engine-rs/**/Cargo.lock', 'engine-rs/**/*.glsl') }}
+
+      - name: Cache cargo registry, git, and target
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            engine-rs/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('engine-rs/**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install wasm-pack
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install dependencies
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build WASM
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: npm run wasm:build
+
+      - name: Upload WASM pkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: src/engine-wasm/pkg
+          retention-days: 1
+
+  lint:
+    name: Lint (ESLint + pixel-debt)
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Download WASM pkg artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: src/engine-wasm/pkg
+      - run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Download WASM pkg artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: src/engine-wasm/pkg
+      - run: npm run typecheck
+
+  test:
+    name: Unit tests (Vitest)
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Download WASM pkg artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: src/engine-wasm/pkg
+      - run: npm run test
+
+  e2e:
+    name: E2E tests (Playwright, chromium)
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Download WASM pkg artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: src/engine-wasm/pkg
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run e2e tests (chromium only)
+        run: npx playwright test --project=chromium
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ The rendering pipeline is GPU-accelerated via WebGL 2, compiled from Rust to Web
 
 Lopsy supports canvases up to 32,000 x 32,000 pixels, Display P3 wide-gamut color on supported displays, and pen tablet pressure sensitivity.
 
+## Contributing
+
+PRs must pass four required CI checks before merge:
+
+| Job        | What it runs                                   |
+| ---------- | ---------------------------------------------- |
+| `lint`     | `eslint src` + `scripts/check-pixel-debt.mjs`  |
+| `typecheck`| `tsc --noEmit`                                 |
+| `test`     | `vitest run`                                   |
+| `e2e`      | `playwright test --project=chromium`           |
+
+The same gates run on `git push` via `.githooks/pre-push`. To temporarily bypass during local iteration set `FAST_PUSH=1` (skips lint + test) or the per-gate `SKIP_LINT=1` / `SKIP_TEST=1`. Never bypass on a final push of an upstreaming branch.
+
+See [AGENTS.md](AGENTS.md) for the contribution workflow and [CLAUDE.md](CLAUDE.md) for the project layout and rules.
+
 ## License
 
 Commons Clause + MIT. See [LICENSE.md](LICENSE.md) for details.

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -670,7 +670,7 @@ export function handlePaintMove(
 
       const jittered = advanceJitterWalk(state, segDist, size, baseHardness, sizeJitter, hardnessJitter);
       size = jittered.size;
-      let hardness = jittered.hardness;
+      const hardness = jittered.hardness;
 
       // Taper: shrink brush size to zero over taperDistance
       const brushTaper = toolSettings.brushTaper;


### PR DESCRIPTION
## Summary

Wires the four documented quality gates — `lint`, `typecheck`, `test`, `e2e` — into CI on every PR, and extends the pre-push hook to run them locally before push. Until this lands, the only thing protecting `main` is the deploy workflow's `tsc --noEmit`; the 95-file Vitest suite and the pixel-debt enforcer are honour-system.

Closes #433.

## What changed

- **`.github/workflows/pr.yml`** — new workflow on `pull_request` + non-main push, with five jobs:
  - `wasm-build` builds the Rust/WASM engine once and uploads the `src/engine-wasm/pkg/` output as a 1-day artifact. Caches Cargo registry/git/target keyed off `Cargo.lock` and the pkg output itself keyed off `engine-rs/**/*.{rs,toml,glsl}` so unchanged engine source skips rebuilds.
  - `lint` runs `eslint src && node scripts/check-pixel-debt.mjs`.
  - `typecheck` runs `tsc --noEmit`.
  - `test` runs Vitest.
  - `e2e` runs Playwright on chromium only (cost trade-off; full matrix can return as a nightly later).
  - Concurrency group cancels in-progress runs on the same ref when a new push arrives.
- **`.githooks/pre-push`** — was typecheck-only; now also runs lint + unit tests by default. Three escape hatches for fast local iteration: `FAST_PUSH=1` (skip lint+test), `SKIP_LINT=1`, `SKIP_TEST=1`. Typecheck still runs always.
- **`README.md`** — documents the contract: the four required CI checks and the local bypass envs.
- **`src/app/interactions/paint-handlers.ts:673`** — pre-existing eslint `prefer-const` error (`let hardness` → `const hardness`). Without this, ESLint short-circuits `npm run lint` before pixel-debt ever runs, so the actual scope of #434 was hidden behind a one-line nit. Fixed here so the lint failure on this PR points at the real culprit.

## Expected CI state on this PR

- `wasm-build` — :green_circle:
- `typecheck` — :green_circle:
- `test` — :red_circle: (one pre-existing failing test in `engine-sync.test.ts:209` — `syncGroupAdjustments` mock expectation. Unrelated to this PR. Worth its own follow-up issue.)
- `lint` — :red_circle: (pixel-debt linter has 30 unallowlisted files + 7 budget regressions — this is exactly the scope of #434, and the visible-red CI is the intended pressure mechanism)
- `e2e` — :grey_question: (no signal yet on whether Playwright is currently green on main)

## After this lands

1. Configure the four jobs as **required status checks** on `main` in repo settings → Branches.
2. Land #434 to make lint green.
3. Triage the failing `engine-sync.test.ts` test (file follow-up issue) so `test` goes green.
4. Verify Playwright passes in CI; if not, the failure surfaces a real regression to triage.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/pr.yml"))'` — workflow YAML parses.
- [x] `bash -n .githooks/pre-push` — hook script syntactically valid.
- [x] `npm run wasm:build` succeeds locally.
- [x] `npm run typecheck` passes locally.
- [x] `npm run test` produces the same pre-existing 1/962 failure on `main` and this branch — confirms this PR didn't introduce a regression.
- [x] `npx eslint src` exits 0 after the `prefer-const` fix.
- [x] `npm run lint` then fails specifically on pixel-debt (the scope of #434), not on eslint.
- [x] Local push with the new pre-push hook honours `FAST_PUSH=1` (used to push this branch since the existing-state pixel-debt failure would otherwise block).
- [ ] Run the workflow in CI; verify each job produces the expected state above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_