### PR TITLE
fix(engine-wasm): drain maskDataRefs and pathTextKeys on layer removal

### DIFF
--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -260,6 +260,59 @@ describe('syncLayers — group mask upload', () => {
   });
 });
 
+describe('syncLayers — tracked-state cleanup on layer removal', () => {
+  beforeEach(() => {
+    vi.mocked(bridge.addLayer).mockClear();
+    vi.mocked(bridge.removeLayer).mockClear();
+    vi.mocked(bridge.uploadLayerMask).mockClear();
+  });
+
+  it('drains every per-layer Map / Set when a layer is removed', async () => {
+    const { getTracked, resetTrackedState } = await import('./sync-state');
+    const engine = makeFakeEngine();
+    resetTrackedState(engine);
+
+    const maskData = new Uint8ClampedArray(64 * 64).fill(128);
+    const raster: RasterLayer = {
+      ...baseRasterLayer,
+      id: 'r1',
+      mask: { id: 'm1', enabled: true, data: maskData, width: 64, height: 64 },
+    };
+
+    // First sync: layer is present.
+    syncLayers(engine, [raster], [raster.id], new Set([raster.id]));
+    const tracked = getTracked(engine);
+    // Pre-condition: every per-layer Map / Set carries an entry for r1.
+    expect(tracked.layerIds.has('r1')).toBe(true);
+    expect(tracked.layerVersions.has('r1')).toBe(true);
+    expect(tracked.layerRefs.has('r1')).toBe(true);
+    expect(tracked.layerEffectiveVisible.has('r1')).toBe(true);
+    expect(tracked.layerPassThroughOpacity.has('r1')).toBe(true);
+    expect(tracked.masksOnEngine.has('r1')).toBe(true);
+    expect(tracked.maskDataRefs.has('r1')).toBe(true);
+
+    // Seed pathTextKeys directly so the invariant covers it even though
+    // we don't have a path-text layer in this fixture.
+    if (!tracked.pathTextKeys) tracked.pathTextKeys = new Map();
+    tracked.pathTextKeys.set('r1', 'fake-key');
+
+    // Second sync: layer is gone.
+    syncLayers(engine, [], [], new Set());
+
+    // Post-condition: every per-layer Map / Set is empty for r1.
+    expect(tracked.layerIds.has('r1')).toBe(false);
+    expect(tracked.layerVersions.has('r1')).toBe(false);
+    expect(tracked.layerRefs.has('r1')).toBe(false);
+    expect(tracked.layerEffectiveVisible.has('r1')).toBe(false);
+    expect(tracked.layerPassThroughOpacity.has('r1')).toBe(false);
+    expect(tracked.masksOnEngine.has('r1')).toBe(false);
+    expect(tracked.maskDataRefs.has('r1')).toBe(false);
+    expect(tracked.pixelDataVersions.has('r1')).toBe(false);
+    expect(tracked.sparseVersions.has('r1')).toBe(false);
+    expect(tracked.pathTextKeys?.has('r1')).toBe(false);
+  });
+});
+
 const baseGroup: GroupLayer = {
   id: 'group-1',
   name: 'Group 1',

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -200,7 +200,9 @@ export function syncLayers(
   // Build pass-through opacity multipliers once per sync (O(n*depth)).
   const passThroughOpacity = buildPassThroughOpacityMap(layers, index);
 
-  // Remove layers no longer present
+  // Remove layers no longer present. Every per-layer Map / Set on
+  // tracked-state must be drained here — otherwise stale entries linger
+  // on the engine's WeakMap for the document's lifetime.
   for (const id of tracked.layerIds) {
     if (!currentIds.has(id)) {
       try {
@@ -213,8 +215,10 @@ export function syncLayers(
       tracked.layerEffectiveVisible.delete(id);
       tracked.layerPassThroughOpacity.delete(id);
       tracked.masksOnEngine.delete(id);
+      tracked.maskDataRefs.delete(id);
       tracked.pixelDataVersions.delete(id);
       tracked.sparseVersions.delete(id);
+      tracked.pathTextKeys?.delete(id);
     }
   }
 


### PR DESCRIPTION
## Summary

`src/engine-wasm/sync-layers.ts:204-218` cleaned up most per-layer tracked-state Maps when a layer disappeared, but two were missed:

- `maskDataRefs` (`sync-state.ts:38`)
- `pathTextKeys` (`sync-state.ts:72`)

Both retain references for the engine's lifetime once a layer they tracked is deleted. The mask buffers can be large, so this matters on long sessions.

Closes #436.

## Evidence

Pre-fix, the removal block at `sync-layers.ts:204-218` deleted from 7 of the 9 per-layer Maps/Sets on `TrackedState` but skipped `maskDataRefs` and `pathTextKeys`.

`maskDataRefs` is written at `sync-layers.ts:320-324` — it retains a reference to the `Uint8ClampedArray` mask buffer. Stale entries prevent GC of mask buffers for deleted layers.

`pathTextKeys` was otherwise only cleared via the explicit `invalidatePathTextCache(layerId)` helper (`engine-sync.ts:136-141`), called from path-edit flows — not from `removeLayer`.

## Fix

Two added `delete()` calls in the existing removal loop:

```ts
tracked.maskDataRefs.delete(id);
tracked.pathTextKeys?.delete(id);
```

Plus a comment documenting the invariant ("every per-layer Map / Set on tracked-state must be drained here") so the next contributor adding a Map to `TrackedState` knows to extend this block.

## Test

New `syncLayers — tracked-state cleanup on layer removal` describe block exercises the full invariant: after a sync that adds a layer and a follow-up sync that removes it, **every** per-layer entry — `layerIds`, `layerVersions`, `layerRefs`, `layerEffectiveVisible`, `layerPassThroughOpacity`, `masksOnEngine`, `maskDataRefs`, `pixelDataVersions`, `sparseVersions`, `pathTextKeys` — is empty.

Confirmed the test catches the bug by reverting just `sync-layers.ts` while keeping the test (`git stash` of the source change) — the new test fails. Restore the fix → passes.

## Test plan

- [x] `npx vitest run src/engine-wasm/sync-layers.test.ts` — 25/25 pass
- [x] Test fails on `main` (verified via stash-pop-revert)
- [x] `npm run typecheck` passes
- [x] `npm run test` — 962 pass / 1 pre-existing failure (unchanged from `main`; new test count: 962 was 961)

## CI note

Lint will be red on this PR until #474 (pixel-debt allowlist reconcile) lands — same baseline failure as `main`. Typecheck and unit tests are green on this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_