### PR TITLE
fix(LayerPanel): clean up keydown listener on context-menu close

### DIFF
--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -249,11 +249,13 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
 
   useEffect(() => {
     if (!contextMenu) return;
-    const handler = () => closeContextMenu();
-    document.addEventListener('mousedown', handler);
-    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeContextMenu(); });
+    const onMouseDown = () => closeContextMenu();
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') closeContextMenu(); };
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
     return () => {
-      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
     };
   }, [contextMenu, closeContextMenu]);
 


### PR DESCRIPTION
## Summary

The right-click context-menu effect in `LayerPanel.tsx:250-258` registered two `document`-level listeners but only removed one on cleanup. The `keydown` listener used an inline arrow, so the `removeEventListener` call could not find it.

Every time the context menu opened, a new keydown listener accumulated on `document`, each closing over the latest `closeContextMenu` via the effect's dependency closure. Open the context menu N times → N leaked listeners.

Closes #438.

## Fix

```diff
 useEffect(() => {
   if (!contextMenu) return;
-  const handler = () => closeContextMenu();
-  document.addEventListener('mousedown', handler);
-  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeContextMenu(); });
+  const onMouseDown = () => closeContextMenu();
+  const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') closeContextMenu(); };
+  document.addEventListener('mousedown', onMouseDown);
+  document.addEventListener('keydown', onKeyDown);
   return () => {
-    document.removeEventListener('mousedown', handler);
+    document.removeEventListener('mousedown', onMouseDown);
+    document.removeEventListener('keydown', onKeyDown);
   };
 }, [contextMenu, closeContextMenu]);
```

Both handlers are now named consts so both `removeEventListener` calls resolve. The keydown handler is typed as `KeyboardEvent` rather than `React.KeyboardEvent` because it's attached via the native `document.addEventListener` API.

## Broader audit

Quick grep for the same inline-arrow `addEventListener` anti-pattern across the codebase:

```
src/main.tsx:134:  window.addEventListener('wheel', (e) => { ... });
src/main.tsx:140:  window.addEventListener('keydown', (e) => { ... });
```

Both are intentional app-lifetime listeners (zoom suppression / pinch-gesture preventDefault). They live for the whole tab session and correctly have no cleanup pair.

The audit-issue mention of "consider an ESLint rule against inline-arrow `addEventListener`" is a follow-up — the codebase doesn't currently have custom ESLint rules and there's not enough surface area to justify one off this single occurrence.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass

**No unit test added.** The codebase has zero `*.test.tsx` files and no React component-test infrastructure. The bug is observable only via DevTools' `getEventListeners(document)`, which is not accessible from Playwright. The fix is mechanical; a one-line diff review is sufficient. Setting up component-level testing is a worthwhile follow-up (#471 covers the integration-test infrastructure work for a different layer).

## CI note

Lint still red on this PR until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_