### PR TITLE
fix(engine-state): release Zustand subscription and cacheTimer on destroyEngine

### DIFF
--- a/src/engine-wasm/engine-state.ts
+++ b/src/engine-wasm/engine-state.ts
@@ -15,6 +15,13 @@ import { useToolSettingsStore } from '../app/tool-settings-store';
 let engine: Engine | null = null;
 let engineCanvas: HTMLCanvasElement | null = null;
 
+// Resources held by the current engine that must be released on
+// destroyEngine. Without this, WebGL context-loss → initEngine adds a new
+// Zustand subscriber on every recovery and the previous setTimeout fires
+// against a freed engine.
+let subBrushUnsubscribe: (() => void) | null = null;
+let subBrushCacheTimer: ReturnType<typeof setTimeout> | null = null;
+
 export function getEngine(): Engine | null {
   return engine;
 }
@@ -49,14 +56,13 @@ export async function initEngine(canvas: HTMLCanvasElement): Promise<Engine> {
     cacheSubBrushTips(engine, initialSubs);
   }
   let prevSubBrushes = initialSubs;
-  let cacheTimer: ReturnType<typeof setTimeout> | null = null;
-  useToolSettingsStore.subscribe((state) => {
+  subBrushUnsubscribe = useToolSettingsStore.subscribe((state) => {
     if (state.activeSubBrushes !== prevSubBrushes) {
       prevSubBrushes = state.activeSubBrushes;
-      if (cacheTimer) clearTimeout(cacheTimer);
+      if (subBrushCacheTimer) clearTimeout(subBrushCacheTimer);
       const subs = state.activeSubBrushes;
-      cacheTimer = setTimeout(() => {
-        cacheTimer = null;
+      subBrushCacheTimer = setTimeout(() => {
+        subBrushCacheTimer = null;
         const eng = getEngine();
         if (!eng || subs.length === 0) return;
         cacheSubBrushTips(eng, subs);
@@ -85,6 +91,17 @@ export function clearEngine(): void {
 }
 
 export function destroyEngine(): void {
+  // Release engine-scoped subscriptions and timers before freeing the
+  // engine itself — otherwise the next initEngine stacks a second
+  // subscriber and a stale timer can fire against a dropped engine.
+  if (subBrushUnsubscribe) {
+    subBrushUnsubscribe();
+    subBrushUnsubscribe = null;
+  }
+  if (subBrushCacheTimer) {
+    clearTimeout(subBrushCacheTimer);
+    subBrushCacheTimer = null;
+  }
   if (engine) {
     engine.free();
   }


### PR DESCRIPTION
## Summary

`initEngine` at `engine-state.ts:53` subscribed to `useToolSettingsStore` and **discarded the returned unsubscribe**. The `cacheTimer` setTimeout (line 52) was also never cleared in `destroyEngine`. On WebGL context-loss → `initEngine` re-run, a fresh subscriber stacked on top of the previous one, and a pending timer could fire against a freed engine.

Closes #439.

## Fix

Promotes both resources to module-scoped `let`s — `subBrushUnsubscribe` and `subBrushCacheTimer` — and releases them in `destroyEngine` before calling `engine.free()`. The order matters: drop the subscriber first so a queued setTimeout cannot race the free.

```diff
+let subBrushUnsubscribe: (() => void) | null = null;
+let subBrushCacheTimer: ReturnType<typeof setTimeout> | null = null;
 ...
-  let cacheTimer: ReturnType<typeof setTimeout> | null = null;
-  useToolSettingsStore.subscribe((state) => {
+  subBrushUnsubscribe = useToolSettingsStore.subscribe((state) => {
     ...
-      cacheTimer = setTimeout(() => {
+      subBrushCacheTimer = setTimeout(() => {
 ...
 export function destroyEngine(): void {
+  if (subBrushUnsubscribe) { subBrushUnsubscribe(); subBrushUnsubscribe = null; }
+  if (subBrushCacheTimer) { clearTimeout(subBrushCacheTimer); subBrushCacheTimer = null; }
   if (engine) { engine.free(); }
   ...
```

A one-line comment at the top of the file documents the invariant: "Resources held by the current engine that must be released on destroyEngine." Anyone adding a new engine-scoped subscription should extend the new release block.

## What about other engine-bound globals?

The audit issue called out `window.__engineState` and `window.__wasmBridge` (lines 68-71) as additional test handles. They are deliberately app-lifetime: the wasm-bridge dynamic import resolves to a module, not engine-scoped state. Confirmed they don't hold a reference to the dropped engine via the bridge import (the bridge holds engine-creating functions, not engines). Not touched here.

A subsequent refactor could shape this as a `Disposable[]` returned from `initEngine` so `destroyEngine` is mechanical — that's nicer but out of scope for the leak fix.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same pre-existing 1/962 failure as `main`

**No unit test added.** Testing this in isolation would require mocking `useToolSettingsStore`, `initWasm`, `createEngine`, and the engine-sync helpers — a heavier setup than the fix. The fix is mechanical and a diff review covers the change. A WebGL `loseContext` / `restoreContext` e2e fixture is the right shape for behavioural coverage; filing a follow-up issue for that infrastructure is a worthwhile next step.

## CI note

Lint still red on this PR until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_