### PR TITLE
fix: clean up text-layer engine state for descendants on group delete

### DIFF
--- a/src/app/store/actions/remove-layer.test.ts
+++ b/src/app/store/actions/remove-layer.test.ts
@@ -2,8 +2,8 @@
 import '../../../test/canvas-mock';
 import { describe, it, expect } from 'vitest';
 import { computeRemoveLayer } from './remove-layer';
-import { createRasterLayer } from '../../../layers/layer-model';
-import type { DocumentState } from '../../../types';
+import { createRasterLayer, createTextLayer, createGroupLayer } from '../../../layers/layer-model';
+import type { DocumentState, Layer } from '../../../types';
 
 function makeDoc(layerCount: number): { doc: DocumentState; pixelData: Map<string, ImageData> } {
   const layers = Array.from({ length: layerCount }, (_, i) =>
@@ -51,5 +51,40 @@ describe('computeRemoveLayer', () => {
     const result = computeRemoveLayer(doc, pixelData, new Map(), activeId)!;
     expect(result.document!.activeLayerId).not.toBe(activeId);
     expect(result.document!.layerOrder).toContain(result.document!.activeLayerId);
+  });
+
+  it('returns removedLayerIds = [id] for a leaf layer', () => {
+    const { doc, pixelData } = makeDoc(2);
+    const removeId = doc.layers[0]!.id;
+    const result = computeRemoveLayer(doc, pixelData, new Map(), removeId)!;
+    expect(result.removedLayerIds).toEqual([removeId]);
+  });
+
+  it('returns every descendant id when removing a group', () => {
+    // Group → [text, raster]
+    const text = createTextLayer({ name: 'T', text: 'A' });
+    const raster = createRasterLayer({ name: 'R', width: 10, height: 10 });
+    const sibling = createRasterLayer({ name: 'Sibling', width: 10, height: 10 });
+    const group = createGroupLayer({ name: 'G', children: [text.id, raster.id] });
+
+    const layers: Layer[] = [sibling, text, raster, group];
+    const doc: DocumentState = {
+      id: 'doc-1', name: 'Test',
+      width: 10, height: 10,
+      layers,
+      layerOrder: [sibling.id, text.id, raster.id, group.id],
+      activeLayerId: sibling.id,
+      selectedLayerIds: [],
+      backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+    };
+
+    const result = computeRemoveLayer(doc, new Map(), new Map(), group.id)!;
+    expect(result.removedLayerIds).toBeDefined();
+    const removed = new Set(result.removedLayerIds);
+    // Group itself, plus both children.
+    expect(removed).toEqual(new Set([group.id, text.id, raster.id]));
+    // Sibling is untouched.
+    expect(removed.has(sibling.id)).toBe(false);
+    expect(result.document!.layers.find((l) => l.id === sibling.id)).toBeDefined();
   });
 });

--- a/src/app/store/actions/remove-layer.ts
+++ b/src/app/store/actions/remove-layer.ts
@@ -53,5 +53,6 @@ export function computeRemoveLayer(
     document: { ...doc, layers, layerOrder, activeLayerId, selectedLayerIds: finalSelectedIds },
     layerPixelData: pixelData,
     sparseLayerData: sparse,
+    removedLayerIds: Array.from(idsToRemove),
   };
 }

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -82,7 +82,10 @@ function applyActionResult(
   set: (partial: Partial<import('./types').EditorState>) => void,
   result: ActionResult,
 ): void {
-  const { layerPixelData, sparseLayerData, ...storeDelta } = result;
+  // removedLayerIds is metadata for engine-side cleanup; the caller drives
+  // those side effects before calling applyActionResult. Strip it so it
+  // doesn't leak into the store state via the spread below.
+  const { layerPixelData, sparseLayerData, removedLayerIds: _removedLayerIds, ...storeDelta } = result;
   if (layerPixelData !== undefined || sparseLayerData !== undefined) {
     pixelDataManager.replace(
       layerPixelData ?? new Map(),
@@ -90,6 +93,25 @@ function applyActionResult(
     );
   }
   set(storeDelta);
+}
+
+/**
+ * Drop engine-side state held for every removed layer that was a text
+ * layer. The Rust engine keeps a HashMap<String, TextLayerState> keyed
+ * by layer id; entries linger if we forget to evict them on delete.
+ * The document still has the pre-delete layer list (`doc`), so type
+ * lookup is exact.
+ */
+function cleanupRemovedTextLayers(doc: { readonly layers: readonly Layer[] }, removedIds: readonly string[]): void {
+  if (removedIds.length === 0) return;
+  const eng = getEngine();
+  if (!eng) return;
+  for (const id of removedIds) {
+    const layer = doc.layers.find((l) => l.id === id);
+    if (layer?.type === 'text') {
+      removeTextLayerState(eng, id);
+    }
+  }
 }
 
 /** Upload all pixel data entries to the GPU engine.
@@ -255,12 +277,9 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     );
     if (!result) return;
 
-    // Clean up text renderer state if this was a text layer.
-    const removedLayer = s.document.layers.find((l) => l.id === id);
-    if (removedLayer?.type === 'text') {
-      const eng = getEngine();
-      if (eng) removeTextLayerState(eng, id);
-    }
+    // Clean up text renderer state for every removed layer — when `id`
+    // points to a group, every text descendant is gone too.
+    cleanupRemovedTextLayers(s.document, result.removedLayerIds ?? []);
 
     s.pushHistory('Delete Layer');
     applyActionResult(set, result);
@@ -720,6 +739,10 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     if (toRemove.length === 0) return;
     s.pushHistory('Delete Layers');
     let currentDoc = doc;
+    // Accumulate every removed id across the per-selection iterations so
+    // we can run engine-side text-layer cleanup once at the end, against
+    // the pre-delete document (text-layer type is only knowable there).
+    const allRemovedIds: string[] = [];
     for (const id of toRemove) {
       const result = computeRemoveLayer(
         currentDoc,
@@ -729,7 +752,9 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       );
       if (!result || !result.document) continue;
       currentDoc = result.document as typeof doc;
+      if (result.removedLayerIds) allRemovedIds.push(...result.removedLayerIds);
     }
+    cleanupRemovedTextLayers(doc, allRemovedIds);
     const activeId = currentDoc.activeLayerId;
     set({
       document: {

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -166,8 +166,15 @@ export type SliceCreator<T> = StateCreator<EditorState, [], [], T>;
  * the store (they're in PixelDataManager), so callers extract the pixel
  * fields, push them to the manager, and spread the remaining EditorState
  * delta into `set()`.
+ *
+ * `removedLayerIds` is metadata (not store state). Actions that delete
+ * layers populate it with the full set of removed ids — including any
+ * descendants when a group is removed — so the caller can run engine-side
+ * cleanup (e.g. `removeTextLayerState`) for every gone layer.
+ * `applyActionResult` strips this field before calling `set()`.
  */
 export type ActionResult = Partial<EditorState> & {
   layerPixelData?: Map<string, ImageData>;
   sparseLayerData?: Map<string, SparseLayerEntry>;
+  removedLayerIds?: string[];
 };


### PR DESCRIPTION
## Summary

When a group containing text layers was deleted, the Rust engine's per-text-layer state (`HashMap<String, TextLayerState>` in `engine-rs text_gpu.rs:28`) leaked descendants because `document-slice` only called `removeTextLayerState` for the directly-requested layer id. `removeSelectedLayers` skipped the cleanup entirely.

Closes #437.

## Evidence (pre-fix)

`src/app/store/document-slice.ts:258-263` only inspected the layer matching `id` — the group itself — and never the descendants `computeRemoveLayer` had already collected into `idsToRemove` (`remove-layer.ts:18-23`):

```ts
const removedLayer = s.document.layers.find((l) => l.id === id);
if (removedLayer?.type === 'text') {
  const eng = getEngine();
  if (eng) removeTextLayerState(eng, id);
}
```

Same gap in `removeSelectedLayers` (`document-slice.ts:714-739`): no call to `removeTextLayerState` at all.

## Fix

**`computeRemoveLayer`** (`actions/remove-layer.ts`) now returns `removedLayerIds: string[]` — the full descendant-inclusive set it already computed internally as `idsToRemove`.

**`ActionResult`** (`types.ts`) carries `removedLayerIds` as optional metadata with a doc comment explaining that it's not store state, just info for the caller to drive engine-side cleanup.

**`applyActionResult`** destructures it out of the result before calling `set()`, so the field never leaks into store state.

**`cleanupRemovedTextLayers(doc, removedIds)`** — new helper in `document-slice.ts`. Walks the ids against the *pre-delete* doc (the only place where text-layer type is still knowable, since the layer is gone from `currentDoc` by the time we'd otherwise look) and calls `removeTextLayerState` for each text descendant. Skips when there's no engine.

**Both call sites** updated. `removeSelectedLayers` accumulates `removedLayerIds` across its per-selection iterations and runs the cleanup once at the end against the original `doc`, not the partially-mutated intermediate state.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/app/store/actions/remove-layer.test.ts` — 5/5 (was 3, added 2)
- [x] `npm run test` — 963 pass (was 961, gained 2), same 1 pre-existing failure as `main`

New tests:
- "returns `removedLayerIds = [id]` for a leaf layer" — sanity case.
- "returns every descendant id when removing a group" — Group → [text, raster] + sibling. Asserts the descendant set is exactly the group + its two children; sibling untouched.

The integration that actually drives the engine cleanup (`document-slice.removeLayer` → `cleanupRemovedTextLayers` → `removeTextLayerState`) is exercised by the unit-level test through the data flow: any caller can prove the right ids reach them.

A fuller integration test for `document-slice` is tracked by #471 — landing that infrastructure would let us also assert "after deleting a group with text descendants, `removeTextLayerState` was called for each text id."

## CI note

Lint still red on this PR until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_