### PR TITLE
fix(bitmap-cache): wire cleanup into layer-removal path, drop duplicate function

### DIFF
--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -262,6 +262,15 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       if (eng) removeTextLayerState(eng, id);
     }
 
+    // Close any cached ImageBitmap for the removed layer (and descendants
+    // when it's a group) so the bitmaps actually get GC'd.
+    invalidateBitmapCache(id);
+    if (removedLayer && removedLayer.type === 'group') {
+      for (const descId of getDescendantIdsUtil(s.document.layers, id)) {
+        invalidateBitmapCache(descId);
+      }
+    }
+
     s.pushHistory('Delete Layer');
     applyActionResult(set, result);
   },
@@ -719,6 +728,19 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     );
     if (toRemove.length === 0) return;
     s.pushHistory('Delete Layers');
+
+    // Close cached ImageBitmaps for every layer that's about to vanish —
+    // walk the pre-delete doc so descendants of groups are reachable.
+    for (const id of toRemove) {
+      const layer = doc.layers.find((l) => l.id === id);
+      invalidateBitmapCache(id);
+      if (layer && layer.type === 'group') {
+        for (const descId of getDescendantIdsUtil(doc.layers, id)) {
+          invalidateBitmapCache(descId);
+        }
+      }
+    }
+
     let currentDoc = doc;
     for (const id of toRemove) {
       const result = computeRemoveLayer(

--- a/src/engine/bitmap-cache.ts
+++ b/src/engine/bitmap-cache.ts
@@ -165,14 +165,6 @@ export function invalidateBitmapCache(layerId: string): void {
   cache.delete(layerId);
 }
 
-/** Remove a layer's cached bitmap (e.g. when the layer is deleted). */
-export function removeBitmapCache(layerId: string): void {
-  pending.delete(layerId);
-  const old = cache.get(layerId);
-  if (old) old.close();
-  cache.delete(layerId);
-}
-
 /** Clear the entire cache (e.g. when creating a new document). */
 export function clearBitmapCache(): void {
   for (const bitmap of cache.values()) bitmap.close();


### PR DESCRIPTION
## Summary

`src/engine/bitmap-cache.ts:169` exported `removeBitmapCache` — fully implemented but **never called anywhere**. The audit flagged this as "dead function masking a real cleanup gap": cached `ImageBitmap` objects for deleted layers were only closed if `invalidateBitmapCache` happened to fire later (conditional on edit flows), never deterministically on layer removal.

Closes #466.

## What I found

`removeBitmapCache` was a literal duplicate of `invalidateBitmapCache` — byte-for-byte identical:

```ts
export function invalidateBitmapCache(layerId: string): void {
  pending.delete(layerId);
  const old = cache.get(layerId);
  if (old) old.close();
  cache.delete(layerId);
}

export function removeBitmapCache(layerId: string): void {     // ← deleted
  pending.delete(layerId);
  const old = cache.get(layerId);
  if (old) old.close();
  cache.delete(layerId);
}
```

## Fix

- Deleted `removeBitmapCache` (the duplicate).
- Wired `invalidateBitmapCache` into both layer-removal paths in `document-slice.ts`:
  - `removeLayer` — closes the cached bitmap for the directly-removed layer + walks `getDescendantIds` for groups.
  - `removeSelectedLayers` — same walk, evaluated against the **pre-delete** doc so descendants of groups deleted earlier in the loop are still reachable.

Pattern matches the text-layer-state cleanup in #437/#478. The two walk-the-descendants blocks will collapse into one shared helper when #478 lands; for now they're inlined.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass (no test changes)

No new unit test: testing this in isolation requires mocking the `ImageBitmap` API and the `pending`/`cache` Maps, and the assertion is "after deletion, the bitmap closed" — observable only via tracking `close()` call counts. The fix is mechanical (calling an existing function from two more sites) and a diff review is sufficient. The audit acceptance criterion ("bitmap-cache size returns to baseline after creating and deleting layers in a loop") is the right shape for an e2e test, filed as follow-up.

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_