### PR TITLE
fix(pixel-data-manager): drain layerVersions on remove() and clearAll()

### DIFF
--- a/src/engine/pixel-data-manager.test.ts
+++ b/src/engine/pixel-data-manager.test.ts
@@ -76,6 +76,16 @@ describe('PixelDataManager', () => {
     expect(mgr.version()).toBe(v);
   });
 
+  it('remove() drains the layerVersions entry so it does not accumulate', () => {
+    // Set + remove a layer 10 times; versionOf should always reset to 0
+    // after the remove (i.e. no permanent entry per id ever seen).
+    for (let i = 0; i < 10; i++) {
+      mgr.setDense(`layer-${i}`, makeImageData());
+      mgr.remove(`layer-${i}`);
+      expect(mgr.versionOf(`layer-${i}`)).toBe(0);
+    }
+  });
+
   it('removeDense leaves sparse data alone', () => {
     mgr.setSparse('a', makeSparse());
     // Directly populate dense too for the test (bypasses the setDense

--- a/src/engine/pixel-data-manager.ts
+++ b/src/engine/pixel-data-manager.ts
@@ -83,6 +83,11 @@ export class PixelDataManager {
     const hadDense = this.pixelData.delete(layerId);
     const hadSparse = this.sparseData.delete(layerId);
     if (hadDense || hadSparse) this.bump(layerId);
+    // Drop the version entry too — the layer is gone, no remaining
+    // subscriber should be observing it (components that displayed it
+    // have unmounted). Without this, layerVersions accumulates one
+    // entry per layer the document ever saw, for the document's life.
+    this.layerVersions.delete(layerId);
   }
 
   /** Drop the dense entry but keep any sparse entry. Used after a
@@ -110,18 +115,19 @@ export class PixelDataManager {
 
   /** Drop every layer's data. Used on document create/open. */
   clearAll(): void {
-    if (this.pixelData.size === 0 && this.sparseData.size === 0) return;
+    if (this.pixelData.size === 0 && this.sparseData.size === 0 && this.layerVersions.size === 0) return;
     this.pixelData.clear();
     this.sparseData.clear();
-    // Don't reset versionOf — callers watching a specific layer should see
-    // the cleanup bump, not a silent rewind to zero.
-    const touched = new Set<string>();
-    for (const id of this.layerVersions.keys()) touched.add(id);
-    for (const id of touched) {
+    // Bump every known layer once so any still-mounted subscriber sees
+    // the change, then drop the entries. The document is going away,
+    // so callers will unmount; surviving subscribers re-mount against
+    // the new document with fresh ids.
+    for (const id of this.layerVersions.keys()) {
       this.layerVersions.set(id, (this.layerVersions.get(id) ?? 0) + 1);
     }
     this.globalVersion++;
     this.notify();
+    this.layerVersions.clear();
   }
 
   // ─── Subscriptions ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`PixelDataManager`'s `remove(layerId)` deleted from `pixelData` and `sparseData` but left `layerVersions` untouched. The "Don't reset versionOf" comment at line 116 explained the intent — watchers should see a bump, not a silent rewind to zero — but the implementation kept the entry around forever, not just past the notify.

After bump-then-notify, the entry can safely be deleted: the layer is gone, the components that displayed it have unmounted, no surviving subscriber observes the entry. Without this, `layerVersions` accumulates one entry per layer the document ever saw.

Closes #467.

## Fix

Two methods:

- **`remove(layerId)`** — bumps the version (notifies), then deletes the `layerVersions` entry. Watchers see the bump exactly once on the way out, just as before.
- **`clearAll()`** — bumps every known layer once, notifies, then clears the Map. Same shape, broader scope. The "is empty" guard now also considers the version Map so we don't re-notify when everything was already drained.

## Test plan

- [x] New test "remove() drains the layerVersions entry so it does not accumulate" — sets + removes a layer 10 times with different ids, asserts `versionOf(id) === 0` after each remove. Fails on `main` (versions grow monotonically), passes on this branch.
- [x] `npx vitest run src/engine/pixel-data-manager.test.ts` — 14/14 pass (was 13, added 1).
- [x] `npm run typecheck` passes.
- [x] `npm run test` — same 1 pre-existing failure as `main`.

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_