### PR TITLE
fix(file-menu): revoke object URL on image-load failure

### DIFF
--- a/src/app/MenuBar/menus/file-menu.ts
+++ b/src/app/MenuBar/menus/file-menu.ts
@@ -84,26 +84,45 @@ export function openFileFromDisk(): void {
 
     const img = new Image();
     const url = URL.createObjectURL(file);
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = img.width;
-      canvas.height = img.height;
-      // Use sRGB context — internal pipeline works in sRGB
-      const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
-      if (ctx) {
-        ctx.drawImage(img, 0, 0);
-        const imageData = ctx.getImageData(0, 0, img.width, img.height);
-        const name = file.name.replace(/\.[^.]+$/, '');
-        useEditorStore.getState().openImageAsDocument(imageData, name);
-        // Seed the bitmap cache from the original file so the rendering
-        // path uses the browser's native decoded bitmap rather than one
-        // rebuilt from the canvas-round-tripped ImageData.
-        const layerId = useEditorStore.getState().document.activeLayerId;
-        if (layerId) seedBitmapFromBlob(layerId, file);
-        useEditorStore.getState().fitToView();
-      }
+    // Revoke runs in every branch (success, decode error, fallback timeout).
+    // Without an explicit error path, a corrupt or unsupported image leaked
+    // the blob URL for the lifetime of the tab.
+    let revoked = false;
+    const revoke = () => {
+      if (revoked) return;
+      revoked = true;
       URL.revokeObjectURL(url);
     };
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        // Use sRGB context — internal pipeline works in sRGB
+        const ctx = canvas.getContext('2d', { colorSpace: 'srgb' });
+        if (ctx) {
+          ctx.drawImage(img, 0, 0);
+          const imageData = ctx.getImageData(0, 0, img.width, img.height);
+          const name = file.name.replace(/\.[^.]+$/, '');
+          useEditorStore.getState().openImageAsDocument(imageData, name);
+          // Seed the bitmap cache from the original file so the rendering
+          // path uses the browser's native decoded bitmap rather than one
+          // rebuilt from the canvas-round-tripped ImageData.
+          const layerId = useEditorStore.getState().document.activeLayerId;
+          if (layerId) seedBitmapFromBlob(layerId, file);
+          useEditorStore.getState().fitToView();
+        }
+      } finally {
+        revoke();
+      }
+    };
+    img.onerror = () => {
+      notifyError(`Failed to open image: ${file.name}`);
+      revoke();
+    };
+    // Browser quirk fallback: if neither onload nor onerror fires within
+    // a generous window (shouldn't happen in practice), reclaim the blob.
+    setTimeout(revoke, 60_000);
     img.src = url;
   };
   input.click();


### PR DESCRIPTION
## Summary

`src/app/MenuBar/menus/file-menu.ts:85-107` created an object URL with `URL.createObjectURL(file)` and revoked it only inside `img.onload`. If the file was corrupt or unsupported, `img.onerror` fired instead and the blob was retained for the lifetime of the tab.

Closes #468.

## Fix

Idempotent `revoke()` runs in three places:

- `onload` success path — wrapped in a `try / finally` so even a decode error inside the image-data plumbing still reclaims the URL.
- `onerror` — surfaces a user-facing toast via the existing `notifyError(...)` and revokes.
- 60-second `setTimeout` fallback — covers the rare browser quirk where neither event fires.

A `revoked` boolean prevents double-revoke (harmless on modern browsers but tidier).

## Broader audit of URL.createObjectURL sites

Other call sites already paired with revoke — confirmed:

- `src/components/BrushModal/BrushModal.tsx:212-235` — both `onload` and `onerror` revoke.
- `src/components/ExportDialog/ExportDialog.tsx:54` — useEffect cleanup.
- `src/app/MenuBar/menus/file-menu.ts:238` — `setTimeout(revokeObjectURL, 60_000)` on export download.

This was the only leak path.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`

No unit test added: testing this in isolation requires mocking `URL.createObjectURL`/`revokeObjectURL` and the `Image` element's load/error events. The fix is mechanical; a diff review is sufficient. An e2e fixture that feeds a corrupt file to the open dialog and asserts no blob retention via `performance.memory` is the right shape for behavioural coverage — filed as a follow-up if needed.

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_