### PR TITLE
refactor(ui-store): wrap pathAnchors + pathClosed into a single pathDraft union

### DIFF
--- a/src/app/interactions/path-stroke.ts
+++ b/src/app/interactions/path-stroke.ts
@@ -46,11 +46,12 @@ export function rasterizePathToLayer(
 export function commitCurrentPath(): void {
   const uiState = useUIStore.getState();
   const editorState = useEditorStore.getState();
-  const anchors = uiState.pathAnchors;
-  if (anchors.length < 2) {
+  const draft = uiState.pathDraft;
+  if (!draft || draft.anchors.length < 2) {
     uiState.clearPath();
     return;
   }
+  const anchors = draft.anchors;
 
   // Convert from layer-local to document space
   const activeLayer = editorState.document.layers.find(
@@ -68,7 +69,7 @@ export function commitCurrentPath(): void {
       : null,
   }));
 
-  editorState.addPath(docAnchors, uiState.pathClosed);
+  editorState.addPath(docAnchors, draft.closed);
   uiState.clearPath();
 }
 

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -135,8 +135,11 @@ interface UIState {
   gridSize: number;
   guideColor: Color;
   sidebarCollapsed: boolean;
-  pathAnchors: PathAnchor[];
-  pathClosed: boolean;
+  /** In-progress path being drawn with the path tool. null when the tool
+   *  is inactive or has been cleared. `closed` is only meaningful while
+   *  draft exists; closing without anchors was previously representable
+   *  but nonsense. */
+  pathDraft: { anchors: PathAnchor[]; closed: boolean } | null;
   lassoPoints: Point[];
   cropRect: { x: number; y: number; width: number; height: number } | null;
   /** When set, the crop tool is in perspective mode with 4 draggable corners. */
@@ -275,8 +278,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   gridSize: 16,
   guideColor: { r: 0, g: 180, b: 255, a: 1 },
   sidebarCollapsed: false,
-  pathAnchors: [],
-  pathClosed: false,
+  pathDraft: null,
   lassoPoints: [],
   cropRect: null,
   perspectiveCropQuad: null,
@@ -350,7 +352,7 @@ export const useUIStore = create<UIState>((set, get) => ({
     if (current.activeTool === tool) return;
     toolRegistry[current.activeTool]?.onDeactivate?.();
     if (current.activeTool === 'path' && tool !== 'path') {
-      set({ activeTool: tool, pathAnchors: [], pathClosed: false });
+      set({ activeTool: tool, pathDraft: null });
     } else if (current.activeTool === 'crop' && tool !== 'crop') {
       set({ activeTool: tool, perspectiveCropQuad: null, perspectiveCropDragging: null });
     } else {
@@ -374,17 +376,27 @@ export const useUIStore = create<UIState>((set, get) => ({
   setGridSize: (size) => set({ gridSize: size }),
   setGuideColor: (color) => set({ guideColor: color }),
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
-  addPathAnchor: (anchor) => set((state) => ({ pathAnchors: [...state.pathAnchors, anchor] })),
+  addPathAnchor: (anchor) =>
+    set((state) => {
+      const prev = state.pathDraft;
+      const anchors = prev ? [...prev.anchors, anchor] : [anchor];
+      return { pathDraft: { anchors, closed: prev?.closed ?? false } };
+    }),
   updateLastPathAnchor: (anchor) =>
     set((state) => {
-      const anchors = [...state.pathAnchors];
-      if (anchors.length > 0) {
-        anchors[anchors.length - 1] = anchor;
-      }
-      return { pathAnchors: anchors };
+      const prev = state.pathDraft;
+      if (!prev || prev.anchors.length === 0) return {};
+      const anchors = [...prev.anchors];
+      anchors[anchors.length - 1] = anchor;
+      return { pathDraft: { anchors, closed: prev.closed } };
     }),
-  closePath: () => set({ pathClosed: true }),
-  clearPath: () => set({ pathAnchors: [], pathClosed: false }),
+  closePath: () =>
+    set((state) => {
+      const prev = state.pathDraft;
+      if (!prev) return {};
+      return { pathDraft: { anchors: prev.anchors, closed: true } };
+    }),
+  clearPath: () => set({ pathDraft: null }),
   setLassoPoints: (points) => set({ lassoPoints: points }),
   clearLassoPoints: () => set({ lassoPoints: [] }),
   setCropRect: (rect) => set({ cropRect: rect }),

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -134,8 +134,8 @@ function renderFrameGpu(
   const gridSize = uiState.gridSize;
   const adjustments = uiState.adjustments;
   const adjustmentsEnabled = uiState.adjustmentsEnabled;
-  const pathAnchors = uiState.pathAnchors;
-  const pathClosed = uiState.pathClosed;
+  const pathAnchors = uiState.pathDraft?.anchors ?? [];
+  const pathClosed = uiState.pathDraft?.closed ?? false;
   const lassoPoints = uiState.lassoPoints;
   const cropRect = uiState.cropRect;
   const perspectiveCropQuad = uiState.perspectiveCropQuad;

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -121,7 +121,7 @@ export function useKeyboardShortcuts({
 
       if (e.key === 'Escape') {
         const uiState = useUIStore.getState();
-        if (uiState.activeTool === 'path' && uiState.pathAnchors.length > 0) {
+        if (uiState.activeTool === 'path' && (uiState.pathDraft?.anchors.length ?? 0) > 0) {
           uiState.clearPath();
         } else {
           useEditorStore.getState().clearSelection();
@@ -133,7 +133,7 @@ export function useKeyboardShortcuts({
 
       if (e.key === 'Enter') {
         const uiState = useUIStore.getState();
-        if (uiState.activeTool === 'path' && uiState.pathAnchors.length >= 2) {
+        if (uiState.activeTool === 'path' && (uiState.pathDraft?.anchors.length ?? 0) >= 2) {
           strokeCurrentPath();
         }
         return;

--- a/src/components/PathActionButtons/PathActionButtons.tsx
+++ b/src/components/PathActionButtons/PathActionButtons.tsx
@@ -3,14 +3,20 @@ import { Check, X } from 'lucide-react';
 import { useUIStore } from '../../app/ui-store';
 import { useEditorStore } from '../../app/editor-store';
 import { commitCurrentPath } from '../../app/interactions/path-stroke';
+import type { PathAnchor } from '../../app/ui-store';
 import styles from './PathActionButtons.module.css';
+
+// Stable reference so the selector returns the same array when the draft
+// is null — useUIStore would otherwise see a fresh `[]` every render and
+// re-fire the subscription.
+const EMPTY_ANCHORS: PathAnchor[] = [];
 
 interface PathActionButtonsProps {
   containerRef: RefObject<HTMLDivElement | null>;
 }
 
 export function PathActionButtons({ containerRef }: PathActionButtonsProps) {
-  const pathAnchors = useUIStore((s) => s.pathAnchors);
+  const pathAnchors = useUIStore((s) => s.pathDraft?.anchors ?? EMPTY_ANCHORS);
   const viewport = useEditorStore((s) => s.viewport);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);

--- a/src/tools/path/path-interaction.ts
+++ b/src/tools/path/path-interaction.ts
@@ -32,7 +32,7 @@ function toggleAnchorSpline(
 export function handlePathDown(ctx: InteractionContext): InteractionState | undefined {
   const { layerPos, canvasPos, activeLayerId, activeLayer, metaKey } = ctx;
   const uiState = useUIStore.getState();
-  const anchors = uiState.pathAnchors;
+  const anchors = uiState.pathDraft?.anchors ?? [];
   const editorState = useEditorStore.getState();
   const selectedPathId = editorState.selectedPathId;
 


### PR DESCRIPTION
## Summary

`ui-store.ts:138-139` kept `pathAnchors: PathAnchor[]` and `pathClosed: boolean` as parallel fields. They were always read together, zeroed together (`ui-store.ts:353` resets both on tool re-init), and a "closed path with zero anchors" was representable but nonsensical.

Closes #450.

## Fix

```diff
-  pathAnchors: PathAnchor[];
-  pathClosed: boolean;
+  pathDraft: { anchors: PathAnchor[]; closed: boolean } | null;
```

`null` means "no draft in progress." When non-null, `anchors` and `closed` are meaningful together. The illegal combos go away.

Setters keep their existing names (`addPathAnchor`, `updateLastPathAnchor`, `closePath`, `clearPath`) so callers don't churn — only the internal state shape changes. `closePath` is now a no-op when no draft exists (previously it would set `closed: true` on the non-draft state, which had no observable effect but was logically wrong).

## Readers updated

- `src/components/PathActionButtons/PathActionButtons.tsx` — selector returns a stable empty-array reference when the draft is null so the Zustand subscription doesn't re-fire on every render.
- `src/app/useKeyboardShortcuts.ts` — two Escape/Enter handlers.
- `src/app/interactions/path-stroke.ts` — `commitCurrentPath`.
- `src/app/useCanvasRendering.ts` — overlay render selector.
- `src/tools/path/path-interaction.ts` — path tool down handler.

The tool re-init at `setActiveTool` collapses from `{ pathAnchors: [], pathClosed: false }` to `{ pathDraft: null }`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass

This is one of three "boolean fossil" cleanups identified in the audit. Sibling issues: #447 (maskMode enum), #449 (SelectionData nullable union).

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_