### PR TITLE
refactor(ui-store): collapse maskEditMode + isQuickMaskMode into maskMode enum

### DIFF
--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -26,7 +26,7 @@ import { translateSelectionMask } from './quick-mask-move';
 export function handleMoveDown(ctx: InteractionContext): InteractionState {
   const editorState = useEditorStore.getState();
   const sel = editorState.selection;
-  const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+  const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';
   editorState.pushHistory(ctx.altKey && !(sel.active && sel.mask) ? 'Duplicate Layer' : 'Move');
   const {
     canvasPos,
@@ -189,7 +189,7 @@ export function handleMoveMove(
   // float exists (handleMoveDown bypasses it for quick-mask mode to avoid
   // corrupting the layer texture — issue #315).
   if (
-    useUIStore.getState().isQuickMaskMode
+    useUIStore.getState().maskMode === 'quickMask'
     && !floatingSelectionRef.current
     && state.moveOriginalMask
     && state.moveOriginalBounds
@@ -329,7 +329,7 @@ export function handleNudgeMove(
   if (!layer || layer.locked) return;
 
   const sel = editor.selection;
-  const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+  const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';
   editor.pushHistory('Nudge');
 
   // Quick-mask + marquee nudge: translate the marquee in JS only. Floating

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -84,8 +84,9 @@ export function handlePaintDown(
   const lineFrom = shiftLine ? lastPaintPointRef.current!.point : layerPos;
 
   const editorState = useEditorStore.getState();
-  const maskEditMode = useUIStore.getState().maskEditMode;
-  const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+  const maskMode = useUIStore.getState().maskMode;
+  const maskEditMode = maskMode === 'layerMask';
+  const isQuickMaskMode = maskMode === 'quickMask';
 
   // Quick Mask Mode: paint on the GPU quick mask texture in doc-space.
   // Brush paints white (add to selection), eraser paints black (remove).
@@ -598,7 +599,7 @@ export function handlePaintMove(
 
   // Mask modes: quick mask and layer mask both route to GPU
   if (state.maskMode) {
-    const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+    const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';
     const engine = getEngine();
     if (!engine) return;
     if (isQuickMaskMode) {

--- a/src/app/interactions/quick-mask-ops.ts
+++ b/src/app/interactions/quick-mask-ops.ts
@@ -65,7 +65,7 @@ export function exitQuickMaskMode(): void {
 }
 
 export function toggleQuickMaskMode(): void {
-  const isActive = useUIStore.getState().isQuickMaskMode;
+  const isActive = useUIStore.getState().maskMode === 'quickMask';
   if (isActive) {
     exitQuickMaskMode();
   } else {

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -153,8 +153,11 @@ interface UIState {
   meshWarp: MeshWarpSession | null;
   tiltShift: TiltShiftSession | null;
   liquify: LiquifySession | null;
-  maskEditMode: boolean;
-  isQuickMaskMode: boolean;
+  /** Discriminates between editing a layer mask, editing the global quick
+   *  mask, and neither. Replaces the prior pair of mutually-exclusive
+   *  booleans (maskEditMode + isQuickMaskMode) — the illegal "both true"
+   *  combination is now unrepresentable. */
+  maskMode: 'off' | 'layerMask' | 'quickMask';
   /** Active modal, or null when nothing is open. Only one at a time. */
   modal: ModalState | null;
   showEffectsDrawer: boolean;
@@ -286,8 +289,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   meshWarp: null,
   tiltShift: null,
   liquify: null,
-  maskEditMode: false,
-  isQuickMaskMode: false,
+  maskMode: 'off',
   modal: null,
   showEffectsDrawer: false,
   showReferenceModal: false,
@@ -305,8 +307,10 @@ export const useUIStore = create<UIState>((set, get) => ({
   gradientPreview: null,
   setCursorPosition: (pos) => set({ cursorPosition: pos }),
   setCursorOnCanvas: (onCanvas) => set({ cursorOnCanvas: onCanvas }),
-  setMaskEditMode: (mode) => set({ maskEditMode: mode }),
-  toggleQuickMaskMode: () => set((state) => ({ isQuickMaskMode: !state.isQuickMaskMode })),
+  setMaskEditMode: (mode) => set({ maskMode: mode ? 'layerMask' : 'off' }),
+  toggleQuickMaskMode: () => set((state) => ({
+    maskMode: state.maskMode === 'quickMask' ? 'off' : 'quickMask',
+  })),
 
   // ─── Modal slot ────────────────────────────────────────────────────────
   openModal: (next) => set({ modal: next }),

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -192,8 +192,9 @@ export function useCanvasInteraction(
 
       const engine = getEngine();
       const isPaintTool = PAINT_TOOLS.has(activeTool);
-      const maskEditMode = useUIStore.getState().maskEditMode;
-      const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+      const maskMode = useUIStore.getState().maskMode;
+      const maskEditMode = maskMode === 'layerMask';
+      const isQuickMaskMode = maskMode === 'quickMask';
 
       // Fall back to CPU when:
       // - mask edit mode (paints on mask surface)
@@ -590,7 +591,7 @@ export function useCanvasInteraction(
 
     // Sync mask GPU texture back to store
     if (state.maskMode && state.layerId) {
-      const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+      const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';
       if (!isQuickMaskMode) {
         const engine = getEngine();
         if (engine) {

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -206,7 +206,7 @@ function renderFrameGpu(
   syncChannelVisibility(engine, uiState.channelVisibility);
   syncAdjustments(engine, adjustments, adjustmentsEnabled);
   syncGroupAdjustments(engine, layers);
-  syncMaskEditMode(engine, uiState.maskEditMode, doc.activeLayerId);
+  syncMaskEditMode(engine, uiState.maskMode === 'layerMask', doc.activeLayerId);
   syncBrushTip(engine, toolState.activeBrushTip, -toolState.brushAngle * Math.PI / 180, toolState.brushHardness);
   syncBrushTexture(engine, toolState.brushTextureData, toolState.brushTextureScale, toolState.brushTextureBlendMode);
 

--- a/src/panels/LayerPanel/LayerPanel.tsx
+++ b/src/panels/LayerPanel/LayerPanel.tsx
@@ -42,7 +42,7 @@ export function LayerPanel({ onSelectLayer }: LayerPanelProps) {
   const setLayerColorTag = useEditorStore((s) => s.setLayerColorTag);
   const rootGroupId = useEditorStore((s) => s.document.rootGroupId);
   const layerOrder = useEditorStore((s) => s.document.layerOrder);
-  const maskEditMode = useUIStore((s) => s.maskEditMode);
+  const maskEditMode = useUIStore((s) => s.maskMode === 'layerMask');
   const setMaskEditMode = useUIStore((s) => s.setMaskEditMode);
   const showEffectsDrawer = useUIStore((s) => s.showEffectsDrawer);
   const setShowEffectsDrawer = useUIStore((s) => s.setShowEffectsDrawer);

--- a/src/toolbox/Toolbox.tsx
+++ b/src/toolbox/Toolbox.tsx
@@ -117,7 +117,7 @@ const toolGroups: ToolDef[][] = [
 export function Toolbox() {
   const activeTool = useUIStore((s) => s.activeTool);
   const setActiveTool = useUIStore((s) => s.setActiveTool);
-  const isQuickMaskMode = useUIStore((s) => s.isQuickMaskMode);
+  const isQuickMaskMode = useUIStore((s) => s.maskMode === 'quickMask');
 
   return (
     <div className={styles.toolbox} role="toolbar" aria-label="Drawing tools">

--- a/src/tools/fill/fill-interaction.ts
+++ b/src/tools/fill/fill-interaction.ts
@@ -19,7 +19,7 @@ import {
 export function handleFillDown(ctx: InteractionContext): void {
   const { layerPos, canvasPos, activeLayerId } = ctx;
   const editorState = useEditorStore.getState();
-  const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+  const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';
 
   // In quick mask mode: fill the quick mask texture instead of the layer
   if (isQuickMaskMode) {
@@ -40,7 +40,7 @@ export function handleFillDown(ctx: InteractionContext): void {
   }
 
   // Mask edit mode: fill the layer mask texture
-  const maskEditMode = useUIStore.getState().maskEditMode;
+  const maskEditMode = useUIStore.getState().maskMode === 'layerMask';
   const maskLayer = editorState.document.layers.find((l) => l.id === activeLayerId);
   if (maskEditMode && maskLayer?.mask) {
     editorState.pushHistory('Mask Fill');

--- a/src/tools/gradient/gradient-interaction.test.ts
+++ b/src/tools/gradient/gradient-interaction.test.ts
@@ -46,8 +46,11 @@ const uiStateValues: { gradientPreview: unknown; isQuickMaskMode: boolean; maskE
 };
 const uiState = {
   setGradientPreview: vi.fn((p: unknown) => { uiStateValues.gradientPreview = p; }),
-  get isQuickMaskMode() { return uiStateValues.isQuickMaskMode; },
-  get maskEditMode() { return uiStateValues.maskEditMode; },
+  get maskMode(): 'off' | 'layerMask' | 'quickMask' {
+    if (uiStateValues.isQuickMaskMode) return 'quickMask';
+    if (uiStateValues.maskEditMode) return 'layerMask';
+    return 'off';
+  },
 };
 vi.mock('../../app/ui-store', () => ({
   useUIStore: { getState: () => uiState },

--- a/src/tools/gradient/gradient-interaction.ts
+++ b/src/tools/gradient/gradient-interaction.ts
@@ -23,8 +23,8 @@ export function handleGradientDown(ctx: InteractionContext): InteractionState {
   const editorState = useEditorStore.getState();
   const ts = useToolSettingsStore.getState();
   const ui = useUIStore.getState();
-  const maskEditMode = ui.maskEditMode;
-  const isQuickMaskMode = ui.isQuickMaskMode;
+  const maskEditMode = ui.maskMode === 'layerMask';
+  const isQuickMaskMode = ui.maskMode === 'quickMask';
 
   const engine = getEngine();
 


### PR DESCRIPTION
## Summary

Two booleans (`maskEditMode` + `isQuickMaskMode`) encoded three mutually-exclusive states. The illegal "both true" combo was checked-around in six call sites across the codebase but never structurally prevented. Collapsed to a single discriminated field.

Closes #447.

## Fix

```diff
-  maskEditMode: boolean;
-  isQuickMaskMode: boolean;
+  /** Discriminates between editing a layer mask, editing the global quick
+   *  mask, and neither. Replaces the prior pair of mutually-exclusive
+   *  booleans — the illegal "both true" combination is now unrepresentable. */
+  maskMode: 'off' | 'layerMask' | 'quickMask';
```

Setters keep their existing names (`setMaskEditMode`, `toggleQuickMaskMode`) and shape — no consumer's call signature changes:

- `setMaskEditMode(true)` → `'layerMask'`
- `setMaskEditMode(false)` → `'off'`
- `toggleQuickMaskMode()` → flips between `'quickMask'` and `'off'`

## Readers updated

12 files. Pattern is uniform:

```diff
- const isQuickMaskMode = useUIStore.getState().isQuickMaskMode;
+ const isQuickMaskMode = useUIStore.getState().maskMode === 'quickMask';

- const maskEditMode = useUIStore.getState().maskEditMode;
+ const maskEditMode = useUIStore.getState().maskMode === 'layerMask';
```

Files: `useCanvasInteraction`, `useCanvasRendering`, `move-handlers`, `paint-handlers`, `quick-mask-ops`, `Toolbox`, `LayerPanel`, `fill-interaction`, `gradient-interaction`. Where both booleans were read in the same scope (paint-handlers, useCanvasInteraction), the maskMode value is captured once and both derived booleans share that read.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass
- [x] `gradient-interaction.test.ts` mocks the store: updated the mock to expose `maskMode` derived from the existing `isQuickMaskMode`/`maskEditMode` test inputs so the test contract doesn't churn — same 11/11 tests still pass.

## What this enables

Sibling boolean-collapse work that becomes easier to land on top of this baseline:
- #449 (SelectionData nullable union)
- #444 (InteractionState tagged union)

The audit-recommended follow-up — "read maskMode once at the top of handleToolDown and thread it through InteractionContext" — is part of the larger #444 refactor and not in scope here.

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_