### PR TITLE
refactor(selection): SelectionData is now a discriminated union by `active`

### DIFF
--- a/src/app/store/selection-slice.ts
+++ b/src/app/store/selection-slice.ts
@@ -1,5 +1,5 @@
 import type { Rect } from '../../types';
-import type { SelectionData, SliceCreator } from './types';
+import { EMPTY_SELECTION, type SelectionData, type SliceCreator } from './types';
 
 export interface SelectionSlice {
   selection: SelectionData;
@@ -8,13 +8,16 @@ export interface SelectionSlice {
 }
 
 export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => ({
-  selection: { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 },
+  selection: EMPTY_SELECTION,
 
   setSelection: (bounds: Rect, mask: Uint8ClampedArray, maskWidth: number, maskHeight: number) => {
-    set({ selection: { active: true, bounds, mask, maskWidth, maskHeight }, renderVersion: get().renderVersion + 1 });
+    set({
+      selection: { active: true, bounds, mask, maskWidth, maskHeight },
+      renderVersion: get().renderVersion + 1,
+    });
   },
 
   clearSelection: () => {
-    set({ selection: { active: false, bounds: null, mask: null, maskWidth: 0, maskHeight: 0 }, renderVersion: get().renderVersion + 1 });
+    set({ selection: EMPTY_SELECTION, renderVersion: get().renderVersion + 1 });
   },
 });

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -4,13 +4,36 @@ import type { StoredPath } from '../../types/paths';
 import type { PathAnchor } from '../../tools/path/path';
 import type { AlignEdge } from '../../tools/move/move';
 
-export interface SelectionData {
-  active: boolean;
-  bounds: Rect | null;
-  mask: Uint8ClampedArray | null;
-  maskWidth: number;
-  maskHeight: number;
-}
+/**
+ * Selection state — discriminated by `active`. When inactive, every
+ * companion field is structurally null/zero so callers cannot read mask
+ * data without first narrowing. When active, bounds + mask + dimensions
+ * are guaranteed non-null. Replaces the previous shape that allowed
+ * `active: true; mask: null` as a representable bug.
+ */
+export type SelectionData =
+  | {
+      readonly active: false;
+      readonly bounds: null;
+      readonly mask: null;
+      readonly maskWidth: 0;
+      readonly maskHeight: 0;
+    }
+  | {
+      readonly active: true;
+      readonly bounds: Rect;
+      readonly mask: Uint8ClampedArray;
+      readonly maskWidth: number;
+      readonly maskHeight: number;
+    };
+
+export const EMPTY_SELECTION: SelectionData = {
+  active: false,
+  bounds: null,
+  mask: null,
+  maskWidth: 0,
+  maskHeight: 0,
+};
 
 export interface CropInfo {
   x: number;


### PR DESCRIPTION
## Summary

The previous `SelectionData` shape allowed `active: true; mask: null` as a representable bug — the three-clause check `sel.active && sel.bounds !== null && sel.mask !== null` appeared at `clipboard-slice.ts:62,100,150` (and elsewhere) for exactly this reason.

Replace with a TypeScript discriminated union keyed on `active`. The illegal combo is structurally unrepresentable.

Closes #449.

## Fix

```ts
export type SelectionData =
  | {
      readonly active: false;
      readonly bounds: null;
      readonly mask: null;
      readonly maskWidth: 0;
      readonly maskHeight: 0;
    }
  | {
      readonly active: true;
      readonly bounds: Rect;
      readonly mask: Uint8ClampedArray;
      readonly maskWidth: number;
      readonly maskHeight: number;
    };

export const EMPTY_SELECTION: SelectionData = { … };
```

## Why no caller churn

When TS sees `if (sel.active) { … }`, the union narrows automatically: inside the branch, `sel.bounds` and `sel.mask` are non-null. The 53 existing readers that did `sel.active && sel.bounds && sel.mask` keep typechecking — the inner null-checks become redundant but TS-narrowing still happily reduces them to the active variant.

Critically, this gives the rest of the codebase a structural guarantee with zero migration cost. Future code can drop the three-clause incantation for a single `sel.active` check; existing code keeps working.

## Side cleanup

`selection-slice.ts` was open-coding the inactive literal in two places (initial state + `clearSelection`). Both now reference the new `EMPTY_SELECTION` constant.

## Test plan

- [x] `npm run typecheck` — passes after the shape change, no other files needed updating (the discriminated union is structurally compatible with what each existing branch the old type allowed)
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass

## Follow-ups not in scope

The audit notes "The 53 existing readers continue to typecheck unchanged. A subsequent cleanup pass could drop the redundant `&& sel.bounds && sel.mask` predicates now that TS does the narrowing — but each such delete is a separate, mechanical change and shouldn't gate this PR."

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_