### PR TITLE
docs(CLAUDE.md): reconcile project map with reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,13 @@
 Read SPEC.md for the full product specification.
 
 ## Additional Guides
-e2e/GUIDE.md - Read this before writing any e2e tests.
-MEMORY.md - good for storing small facts about the code base.
+- `AGENTS.md` — contributor workflow for AI-assisted PRs (process,
+  commit style, what's wanted).
+- `e2e/GUIDE.md` — read this before writing any e2e tests.
+- `MEMORY.md` — small facts about the codebase worth remembering.
+- `docs/pixel-data-debt.md` — authoritative tracker for places where
+  pixel buffers still live on the JS side, with the migration plan
+  for each.
 
 ## Language & Types
 
@@ -35,7 +40,10 @@ src/
       brush.test.ts     # Unit tests for the logic
       BrushOptions.tsx   # Options bar UI for this tool
       BrushOptions.module.css
-  engine/           # Legacy JS engine utilities (color-space detection, etc.)
+  engine/           # JS engine utilities that remain CPU-side: color-space
+                    # detection, PixelBuffer / PixelDataManager, bitmap cache,
+                    # canvas-ops (wide-gamut ImageData plumbing). Shrinks
+                    # as features migrate into engine-wasm/.
   engine-wasm/      # WASM bridge layer (see Rust/WASM Engine section below)
     engine-state.ts   # Engine lifecycle: create, destroy, get current engine
     engine-sync.ts    # Syncs Zustand state → WASM engine each frame
@@ -46,7 +54,11 @@ src/
   history/          # Undo/redo system
   selection/        # Selection model and operations
   filters/          # Filter implementations (blur, sharpen, noise, etc.)
-  adjustments/      # Image adjustment implementations
+                    # Adjustment node definitions also live here (see
+                    # adjustment-node-utils.ts and the per-type LUT
+                    # builders in curves.ts / levels.ts). The Adjustments
+                    # UI lives at panels/AdjustmentsPanel/ — there is no
+                    # separate src/adjustments/ directory.
   icons/            # Custom SVG icon components (Lucide style)
   styles/           # Global CSS: tokens.css, reset.css, fonts.css
   types/            # Shared TypeScript type definitions
@@ -195,7 +207,10 @@ Each tool follows this pattern:
 3. `src/tools/<name>/<Name>Options.tsx` — React component for the tool's options bar. Reads/writes tool settings via Zustand.
 4. `src/tools/<name>/<Name>Options.module.css` — styles for the options bar.
 
-Tool logic modules must not import React, DOM APIs, or any rendering code.
+Tool logic modules must not import React, DOM APIs, or any rendering
+code. A small set of pre-rule files still violate this (path/path.ts,
+path/boolean-ops.ts, text/render-text-on-path.ts, brush/preset-io.ts)
+and are tracked for cleanup — new code must not extend the list.
 
 ## Components
 
@@ -217,7 +232,9 @@ Tool logic modules must not import React, DOM APIs, or any rendering code.
 - **E2E tests**: Playwright. Located in `e2e/` directory.
 - **Storybook**: Storybook 8+. Stories co-located with components.
 - Tool logic must have unit tests. Test the math, not the rendering.
-- Every new component needs a Storybook story before it's considered complete.
+- New components should ship with a Storybook story. A handful of legacy
+  components (BrushModal, CanvasSizeModal, ModalHost, etc.) predate this
+  rule and are tracked for backfill — see the GitHub issue for the list.
 - IMPORTANT: e2e tests should always test the UI, not manipulate the zustand stores directly. When we make UI changes, we update the test for the new UI. This is critical to making sure the UI works as the user would experience it.
 
 ## Commands


### PR DESCRIPTION
## Summary

Multiple claims in `CLAUDE.md` were stale or false. The doc misled contributors (including AI agents working in the repo) by describing directories and rules that don't match the codebase.

Closes #472.

## Fixes

| Claim | Reality | Fix |
|---|---|---|
| `src/adjustments/` directory | Doesn't exist | Replaced with a sentence pointing to where adjustment code actually lives (`filters/` for math, `panels/AdjustmentsPanel/` for UI) |
| `src/engine/` is "Legacy JS engine utilities" | Both pejorative and inaccurate — five truly-legacy files were already deleted in #480; what remains is current infra (PixelBuffer, color-space, bitmap-cache, canvas-ops) | Refreshed to name what actually lives there |
| "Every new component needs a Storybook story" | True for new code but ~12 legacy components predate the rule | Softened with a pointer to the tracked backfill issue |
| "Tool logic modules must not import React, DOM APIs, or any rendering code" | True except for 4 files (`path/path.ts`, `path/boolean-ops.ts`, `text/render-text-on-path.ts`, `brush/preset-io.ts`) | Acknowledged with a tracked-cleanup note (resolved by #465) |
| "Additional Guides" section was missing AGENTS.md and docs/pixel-data-debt.md | Both are canonical references for contributors | Added |

## Test plan

- [x] Manual diff review — every claim that remains in the doc is true against the current repo state.

## CI note

Docs-only PR; no code touched. Lint still red until #474 lands (pre-existing pixel-debt baseline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_