### PR TITLE
refactor: eliminate module-level mutable singletons in interaction handlers

### DIFF
--- a/src/app/interactions/liquify-handlers.ts
+++ b/src/app/interactions/liquify-handlers.ts
@@ -11,8 +11,15 @@ import { applyDab, encodeDisplacementRegion } from '../../tools/liquify/liquify'
 import { previewLiquifyRegion } from '../MenuBar/liquify-actions';
 import type { Point } from '../../types';
 
-let isPainting = false;
-let lastPaintPoint: Point | null = null;
+/**
+ * Single grouped state object instead of independent let-bindings.
+ * `null` means no active liquify stroke; non-null carries the
+ * last-painted point. The audit flagged the previous
+ * `let isPainting = false; let lastPaintPoint = null;` as exactly
+ * the "module-level mutable globals" smell the discriminated-union
+ * pattern (pointer-mode.ts) was designed to retire.
+ */
+let stroke: { lastPoint: Point } | null = null;
 
 export function isLiquifyActive(): boolean {
   return useUIStore.getState().liquify !== null;
@@ -22,21 +29,20 @@ export function handleLiquifyDown(layerPos: Point): boolean {
   const session = useUIStore.getState().liquify;
   if (!session) return false;
 
-  isPainting = true;
-  lastPaintPoint = layerPos;
+  stroke = { lastPoint: layerPos };
   return true;
 }
 
 export function handleLiquifyMove(layerPos: Point): boolean {
   const session = useUIStore.getState().liquify;
   if (!session) return false;
-  if (!isPainting) return true;
+  if (!stroke) return true;
 
-  const dragDx = lastPaintPoint ? layerPos.x - lastPaintPoint.x : 0;
-  const dragDy = lastPaintPoint ? layerPos.y - lastPaintPoint.y : 0;
+  const dragDx = layerPos.x - stroke.lastPoint.x;
+  const dragDy = layerPos.y - stroke.lastPoint.y;
 
   const dirty = applyDab(session.displacementMap, layerPos.x, layerPos.y, dragDx, dragDy, session.settings);
-  lastPaintPoint = layerPos;
+  stroke = { lastPoint: layerPos };
 
   const sub = encodeDisplacementRegion(session.displacementMap, session.encodedDisplacement, dirty);
   previewLiquifyRegion(sub, dirty.x, dirty.y, dirty.w, dirty.h);
@@ -47,7 +53,6 @@ export function handleLiquifyUp(): boolean {
   const session = useUIStore.getState().liquify;
   if (!session) return false;
 
-  isPainting = false;
-  lastPaintPoint = null;
+  stroke = null;
   return true;
 }

--- a/src/app/interactions/pending-stroke.ts
+++ b/src/app/interactions/pending-stroke.ts
@@ -3,36 +3,43 @@ import { endStroke, endDodgeBurnStroke, endSpongeStroke } from '../../engine-was
 import { clearJsPixelData } from '../store/clear-js-pixel-data';
 import { useEditorStore } from '../editor-store';
 
-let pendingLayerId: string | null = null;
-let pendingDodgeLayerId: string | null = null;
-let pendingSpongeLayerId: string | null = null;
+/**
+ * Pending-stroke registry: tracks which layer (if any) has an in-flight
+ * GPU stroke per stroke kind. Previously a trio of parallel
+ * `let pending...LayerId: string | null` globals; the Map shape makes
+ * adding a new stroke kind a one-line change and keeps the
+ * "all-globals are equally suspect" smell from spreading.
+ */
+type PendingStrokeKind = 'brush' | 'dodge' | 'sponge';
+
+const pendingByKind = new Map<PendingStrokeKind, string>();
 
 export function setPendingStroke(layerId: string): void {
-  pendingLayerId = layerId;
+  pendingByKind.set('brush', layerId);
 }
 
 export function clearPendingStroke(): void {
-  pendingLayerId = null;
+  pendingByKind.delete('brush');
 }
 
 export function hasPendingStroke(): boolean {
-  return pendingLayerId !== null;
+  return pendingByKind.has('brush');
 }
 
 export function setPendingDodgeStroke(layerId: string): void {
-  pendingDodgeLayerId = layerId;
+  pendingByKind.set('dodge', layerId);
 }
 
 export function clearPendingDodgeStroke(): void {
-  pendingDodgeLayerId = null;
+  pendingByKind.delete('dodge');
 }
 
 export function setPendingSpongeStroke(layerId: string): void {
-  pendingSpongeLayerId = layerId;
+  pendingByKind.set('sponge', layerId);
 }
 
 export function clearPendingSpongeStroke(): void {
-  pendingSpongeLayerId = null;
+  pendingByKind.delete('sponge');
 }
 
 /**
@@ -40,31 +47,31 @@ export function clearPendingSpongeStroke(): void {
  * the most recent stroke is committed before taking a snapshot.
  */
 export function finalizePendingStrokeGlobal(): void {
-  if (!pendingLayerId && !pendingDodgeLayerId && !pendingSpongeLayerId) return;
+  if (pendingByKind.size === 0) return;
   const engine = getEngine();
 
-  if (pendingLayerId) {
-    const layerId = pendingLayerId;
-    pendingLayerId = null;
+  const brushLayer = pendingByKind.get('brush');
+  if (brushLayer !== undefined) {
+    pendingByKind.delete('brush');
     if (engine) {
-      endStroke(engine, layerId);
-      clearJsPixelData(layerId);
+      endStroke(engine, brushLayer);
+      clearJsPixelData(brushLayer);
     }
   }
 
-  if (pendingDodgeLayerId) {
-    const layerId = pendingDodgeLayerId;
-    pendingDodgeLayerId = null;
+  const dodgeLayer = pendingByKind.get('dodge');
+  if (dodgeLayer !== undefined) {
+    pendingByKind.delete('dodge');
     if (engine) {
-      endDodgeBurnStroke(engine, layerId);
+      endDodgeBurnStroke(engine, dodgeLayer);
     }
   }
 
-  if (pendingSpongeLayerId) {
-    const layerId = pendingSpongeLayerId;
-    pendingSpongeLayerId = null;
+  const spongeLayer = pendingByKind.get('sponge');
+  if (spongeLayer !== undefined) {
+    pendingByKind.delete('sponge');
     if (engine) {
-      endSpongeStroke(engine, layerId);
+      endSpongeStroke(engine, spongeLayer);
     }
   }
 


### PR DESCRIPTION
## Summary

Two interaction-handler files held mutable state at module top-level — the exact "module-level globals" smell the discriminated-union pattern in `pointer-mode.ts` was designed to retire.

Closes #454.

## Changes

### `src/app/interactions/pending-stroke.ts` — three singletons → one Map

```diff
-let pendingLayerId: string | null = null;
-let pendingDodgeLayerId: string | null = null;
-let pendingSpongeLayerId: string | null = null;
+type PendingStrokeKind = 'brush' | 'dodge' | 'sponge';
+const pendingByKind = new Map<PendingStrokeKind, string>();
```

Every setter / clearer becomes `pendingByKind.set/delete`. Adding a new stroke kind is a one-line type extension + one line per setter pair, not three parallel `let`s plus three pairs of setter/clearer functions. The public API (`setPendingStroke`, `clearPendingDodgeStroke`, etc.) is unchanged — no consumer churns.

### `src/app/interactions/liquify-handlers.ts` — two coordinated globals → one grouped state

```diff
-let isPainting = false;
-let lastPaintPoint: Point | null = null;
+let stroke: { lastPoint: Point } | null = null;
```

Replaces the "isPainting + nullable point" pair with a nullable grouped object. `stroke === null` means "not painting"; non-null carries the last-painted point. The illegal combo (`isPainting: true` with `lastPaintPoint: null`) is now structurally unrepresentable. Still a module global, but half the surface area.

## Not addressed in this PR

The audit flagged three other module-level singletons. Each is tied to the larger `#444` (InteractionState tagged-union) refactor and the natural home for the state is the per-tool gesture variant. Touching them now would either inline ad-hoc state with no real win, or pre-bake the union design:

- `src/tools/brush/brush.ts` — cached stamp + `scatterSpacingRemainder`
- `src/tools/tool-registry.ts` — `shapeFillSeededFromForeground`
- `src/tools/spray/spray-interaction.ts` — `sprayTimer`

These are tracked alongside #444.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — same 1 pre-existing failure as `main`, 961 pass

## CI note

Lint still red until #474 lands (pre-existing pixel-debt baseline). Typecheck and test green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_