### PR TITLE
fix(engine-sync): restore group adjustments on pass-through groups (regression from #492)

### DIFF
--- a/src/engine-wasm/engine-sync.test.ts
+++ b/src/engine-wasm/engine-sync.test.ts
@@ -196,7 +196,14 @@ describe('syncGroupAdjustments — group mask registration', () => {
     expect(vi.mocked(bridge.setGroupAdjustments)).toHaveBeenCalledOnce();
   });
 
-  it('does not register a pass-through group even when it has adjustments', () => {
+  it('registers a pass-through group when it has adjustments (regression: PR #492)', () => {
+    // createGroupLayer defaults blendMode to 'pass-through' (layer-model.ts:79),
+    // so the Project root group is pass-through by default. If
+    // syncGroupAdjustments skips pass-through groups, curves / levels /
+    // exposure on the Project group silently no-op — which is exactly what
+    // shipped briefly in #492. Lock the correct contract in place: the
+    // group MUST register so the engine knows which child ids to apply the
+    // adjustments to during compositing.
     const engine = makeFakeEngine();
     const raster = createRasterLayer({ name: 'Layer 1', width: 100, height: 100 });
     const group = {
@@ -206,7 +213,7 @@ describe('syncGroupAdjustments — group mask registration', () => {
       adjustments: [{ id: 'exp-1', type: 'exposure' as const, enabled: true, exposure: 1.5 }],
     };
     sync.syncGroupAdjustments(engine, [raster, group]);
-    expect(vi.mocked(bridge.setGroupAdjustments)).not.toHaveBeenCalled();
+    expect(vi.mocked(bridge.setGroupAdjustments)).toHaveBeenCalledOnce();
   });
 
   it('does not register a pass-through group with no adjustments and no mask', () => {

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -395,11 +395,14 @@ export function syncGroupAdjustments(engine: Engine, layers: readonly Layer[]): 
     );
     const hasMask = group.mask != null && group.mask.enabled;
     if (!hasAdjustments && !hasMask) continue;
-    // Pass-through groups composite their children directly with no group
-    // texture, so there's no layer to register adjustments against. The
-    // adjustments are effectively no-ops here; skipping prevents
-    // setGroupAdjustments from creating a phantom compositing target.
-    if (group.blendMode === 'pass-through') continue;
+    // Pass-through groups register here too. Pass-through controls how the
+    // group's pre-composited result blends with what's BELOW it — it does
+    // NOT determine whether the group's own children get their adjustments
+    // applied. The Rust side stores { adjustments, child_ids } and applies
+    // them during compositing regardless of the parent group's blend mode.
+    // The default Project root group is pass-through (layer-model.ts:79),
+    // so skipping this call silently drops curves/levels/exposure on every
+    // default document. Don't.
     setGroupAdjustments(
       engine,
       group.id,


### PR DESCRIPTION
## Summary

**Hotfix.** PR #492 (already merged) added a `blendMode === 'pass-through' → continue` skip in `syncGroupAdjustments`, taking the failing unit test at face value. The skip is wrong — curves / levels / exposure on the **Project root group** silently no-op as soon as it lands, because `createGroupLayer` defaults `blendMode` to `'pass-through'` (`layer-model.ts:79`).

## Root cause

Pass-through controls how the group's pre-composited result blends with **what's below it**. It does NOT control whether the group's children get their adjustments applied. The Rust side (`api/adjustment.rs:285-319` → `set_group_adjustments`) stores `{ adjustments, child_ids }` in a HashMap and the compositor applies them during the child-render pass regardless of the parent's blend mode. The engine **needs** the call for pass-through groups too.

## Fix

```diff
 const hasMask = group.mask != null && group.mask.enabled;
 if (!hasAdjustments && !hasMask) continue;
-// Pass-through groups composite their children directly with no group
-// texture, so there's no layer to register adjustments against. The
-// adjustments are effectively no-ops here; skipping prevents
-// setGroupAdjustments from creating a phantom compositing target.
-if (group.blendMode === 'pass-through') continue;
+// Pass-through groups register here too. Pass-through controls how the
+// group's pre-composited result blends with what's BELOW it — it does
+// NOT determine whether the group's own children get their adjustments
+// applied. The Rust side stores { adjustments, child_ids } and applies
+// them during compositing regardless of the parent group's blend mode.
+// The default Project root group is pass-through (layer-model.ts:79),
+// so skipping this call silently drops curves/levels/exposure on every
+// default document. Don't.
 setGroupAdjustments(
```

Test at `engine-sync.test.ts:199` updated to assert the **correct** contract — pass-through group with adjustments DOES register. Test name now references "regression: PR #492" so the history is discoverable from grep.

The sibling test at line 220 (*"does not register a pass-through group with no adjustments and no mask"*) remains correct — the early-bail at line 397 (`!hasAdjustments && !hasMask` → continue) handles that genuine no-op case.

## Verification

- **Pre-fix repro**: open a default document, apply curves on the Project group → no visible change. (The bug you reported.)
- **Post-fix**: same flow → curves apply visibly to the composite.

## Test plan

- [x] `npx vitest run src/engine-wasm/engine-sync.test.ts` — 15/15 pass
- [x] `npm run test` — 962/962 pass
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors, pixel-debt OK

## Why a fresh PR instead of a revert

The hotfix is two small targeted edits — the bad skip removed, the test updated to lock in the correct contract — vs. a revert that would also revert the test fix (the test was wrong; a revert would put the failing test back). Net result: this PR ships less change than a revert would.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_