### PR TITLE
fix(document-slice): use result.removedLayerIds for bitmap-cache cleanup (main typecheck is red)

### DIFF
--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -281,13 +281,13 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     // points to a group, every text descendant is gone too.
     cleanupRemovedTextLayers(s.document, result.removedLayerIds ?? []);
 
-    // Close any cached ImageBitmap for the removed layer (and descendants
-    // when it's a group) so the bitmaps actually get GC'd.
-    invalidateBitmapCache(id);
-    if (removedLayer && removedLayer.type === 'group') {
-      for (const descId of getDescendantIdsUtil(s.document.layers, id)) {
-        invalidateBitmapCache(descId);
-      }
+    // Close any cached ImageBitmap for every layer that's about to vanish.
+    // Use result.removedLayerIds so the descendant walk for groups is the
+    // same one computeRemoveLayer already did — and so we don't reference
+    // a removedLayer variable that #478 dropped when introducing the
+    // cleanupRemovedTextLayers helper above.
+    for (const descId of result.removedLayerIds ?? [id]) {
+      invalidateBitmapCache(descId);
     }
 
     s.pushHistory('Delete Layer');


### PR DESCRIPTION
## Hotfix — main typecheck is currently broken

```
src/app/store/document-slice.ts(287,9): error TS2304: Cannot find name 'removedLayer'.
src/app/store/document-slice.ts(287,25): error TS2304: Cannot find name 'removedLayer'.
```

## What happened

PR #483 (`fix(bitmap-cache): wire cleanup into the layer-removal path`) added a bitmap-cache cleanup block inside `removeLayer`:

```ts
invalidateBitmapCache(id);
if (removedLayer && removedLayer.type === 'group') {
  for (const descId of getDescendantIdsUtil(s.document.layers, id)) {
    invalidateBitmapCache(descId);
  }
}
```

PR #478 (`fix: clean up text-layer engine state for descendants on group delete`) then dropped the `const removedLayer = s.document.layers.find(...)` lookup, replacing it with the new `cleanupRemovedTextLayers(s.document, result.removedLayerIds ?? [])` helper. The bitmap-cache block survived the merge but its lookup variable did not.

## Fix

Iterate `result.removedLayerIds` instead — that's the same descendant set `computeRemoveLayer` already collects (via `getDescendantIds` for groups). Single loop, no type check, no extra `.find()` lookup. Falls back to `[id]` if `removedLayerIds` is missing.

```diff
- invalidateBitmapCache(id);
- if (removedLayer && removedLayer.type === 'group') {
-   for (const descId of getDescendantIdsUtil(s.document.layers, id)) {
-     invalidateBitmapCache(descId);
-   }
- }
+ for (const descId of result.removedLayerIds ?? [id]) {
+   invalidateBitmapCache(descId);
+ }
```

`removeSelectedLayers` is unaffected — it uses a different `layer` local var, not `removedLayer`.

## Test plan

- [x] `npm run typecheck` — passes (was failing on `main`)
- [x] `npm run test` — 914/914 pass

## Why this unblocks #482

`#482` (zombie CPU dab deletion) needs a clean rebase against `main`, but rebasing onto a non-typechecking base means any local CI run on the rebased branch reports the broken `removedLayer` error too. Land this first, then #482's rebase produces a green branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz8F996yMgTgb3DAcpzHLa)_