### PR TITLE
fix(thumbnails): bump pixel version after dodge/sponge strokes

### DIFF
--- a/src/app/interactions/pending-stroke.ts
+++ b/src/app/interactions/pending-stroke.ts
@@ -64,6 +64,7 @@ export function finalizePendingStrokeGlobal(): void {
     pendingByKind.delete('dodge');
     if (engine) {
       endDodgeBurnStroke(engine, dodgeLayer);
+      clearJsPixelData(dodgeLayer);
     }
   }
 
@@ -72,6 +73,7 @@ export function finalizePendingStrokeGlobal(): void {
     pendingByKind.delete('sponge');
     if (engine) {
       endSpongeStroke(engine, spongeLayer);
+      clearJsPixelData(spongeLayer);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds missing `clearJsPixelData()` calls for dodge/burn and sponge strokes in `finalizePendingStrokeGlobal()`
- The refactor in d794dd4d moved pending stroke tracking to a Map but missed adding version bumps for these two stroke kinds
- Without the bump, `LayerThumbnail` never re-reads the GPU texture after dodge/sponge strokes complete

## Root Cause
The brush stroke path correctly calls `clearJsPixelData(brushLayer)` which bumps `pixelDataManager.versionOf(layerId)`, triggering React to re-render the thumbnail. The dodge and sponge paths were missing this call.

## Test plan
- [x] Typecheck passes
- [ ] Open image, paint with Dodge/Burn tool — verify layer thumbnail updates
- [ ] Open image, paint with Sponge tool — verify layer thumbnail updates
- [ ] Verify brush tool thumbnails still update (regression check)

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)