### PR TITLE
fix(healing): mark healing brush as GPU tool in registry

### DIFF
--- a/src/tools/tool-registry.test.ts
+++ b/src/tools/tool-registry.test.ts
@@ -31,7 +31,7 @@ describe('tool registry', () => {
 
   it('exposes the same GPU set the manual constant used to', () => {
     expect(new Set(GPU_TOOLS)).toEqual(new Set<ToolId>([
-      'brush', 'pencil', 'eraser', 'dodge', 'sponge', 'stamp', 'gradient', 'shape', 'spray',
+      'brush', 'pencil', 'eraser', 'dodge', 'sponge', 'stamp', 'healing', 'gradient', 'shape', 'spray',
     ]))
   });
 
@@ -78,7 +78,7 @@ describe('tool registry', () => {
   });
 
   it('most paint tools also render on the GPU', () => {
-    const exceptions = new Set<ToolId>(['healing']);
+    const exceptions = new Set<ToolId>([]);
     for (const id of PAINT_TOOLS) {
       if (exceptions.has(id)) continue;
       expect(GPU_TOOLS.has(id)).toBe(true);

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -171,6 +171,7 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
     shortcut: 'h',
     optionsComponent: HealingOptions,
     isPaint: true,
+    isGpu: true,
     handler: {
       down: (ctx) => handleHealingDown(ctx),
       move: (ctx, state) => handleHealingMove(state, ctx.layerPos, ctx.stampOffsetRef),


### PR DESCRIPTION
## Summary
- Adds missing `isGpu: true` flag to the healing brush tool descriptor in `tool-registry.ts`
- The healing brush uses GPU-based WASM functions (`applyHealingDab`, `applyHealingDabBatch`) but wasn't flagged as a GPU tool
- Without this flag, `useCanvasInteraction` routes healing through the CPU paint path which doesn't initialize GPU stroke state properly — making the tool appear to do nothing
- Updated test expectations to include healing in the GPU tools set

## Root Cause
The clone stamp tool (which has an identical architecture — GPU dabs via WASM) was correctly marked `isGpu: true`, but healing was not. This was likely an oversight when the healing brush was first added.

## Test plan
- [x] Typecheck passes
- [x] `tool-registry.test.ts` passes with updated GPU set
- [ ] Open an image, cmd+click to set healing reference point, then paint — verify healing works
- [ ] Verify clone stamp still works (regression check)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)