### PR TITLE
fix(layers): prevent reordering layers above the root group

### DIFF
--- a/src/app/store/actions/move-layer.test.ts
+++ b/src/app/store/actions/move-layer.test.ts
@@ -262,6 +262,23 @@ describe('group block contiguity invariant', () => {
     }
   });
 
+  it('never places a single layer above the root group', () => {
+    const doc = makeGroupDoc();
+    // layerOrder: [BG(0), L1(1), L2(2), L3(3), L4(4), G1(5), Root(6)]
+    // Try moving BG (index 0) to index 6 (where Root is) and beyond
+    const result = computeMoveLayer(doc, 0, 0, 6)!;
+    const order = namesByOrder(result.document!);
+    expect(order[order.length - 1]).toBe('Root');
+  });
+
+  it('never places a group block above the root group', () => {
+    const doc = makeGroupDoc();
+    // Try moving G1 (index 5) to index 7 (beyond Root)
+    const result = computeMoveLayer(doc, 0, 5, 7)!;
+    const order = namesByOrder(result.document!);
+    expect(order[order.length - 1]).toBe('Root');
+  });
+
   it('holds after successive moves', () => {
     let doc = makeGroupDoc();
     // Move L1 into G1, then move it back out, then move BG around

--- a/src/app/store/actions/move-layer.ts
+++ b/src/app/store/actions/move-layer.ts
@@ -16,6 +16,8 @@ export function computeMoveLayer(
   const movedLayer = layerMap.get(movedId);
   if (!movedLayer) return undefined;
 
+  const rootGroupId = doc.rootGroupId;
+
   if (isGroupLayer(movedLayer)) {
     const descendantIds = new Set(getDescendantIds(doc.layers, movedId));
     const blockIds = new Set([movedId, ...descendantIds]);
@@ -59,6 +61,13 @@ export function computeMoveLayer(
       }
     }
 
+    if (rootGroupId) {
+      const rootIdx = restEntries.indexOf(rootGroupId);
+      if (rootIdx !== -1 && insertAt > rootIdx) {
+        insertAt = rootIdx;
+      }
+    }
+
     restEntries.splice(insertAt, 0, ...blockEntries);
     const newLayers = restEntries.map((id) => layerMap.get(id)!);
 
@@ -68,9 +77,16 @@ export function computeMoveLayer(
     };
   }
 
-  // Single item move
+  // Single item move — clamp so nothing goes above the root group
   order.splice(fromIndex, 1);
-  order.splice(toIndex, 0, movedId);
+  let clampedTo = toIndex;
+  if (rootGroupId) {
+    const rootIdx = order.indexOf(rootGroupId);
+    if (rootIdx !== -1 && clampedTo > rootIdx) {
+      clampedTo = rootIdx;
+    }
+  }
+  order.splice(clampedTo, 0, movedId);
 
   // After the flat reorder, check if the layer's neighbor has a different
   // parent group. If so, re-parent the moved layer to match its new neighbor.


### PR DESCRIPTION
## Summary
- Clamps the move destination in `computeMoveLayer` so layers can never be placed above the root group in `layerOrder`
- Applies to both single-item moves and group-block moves
- The root group must always be the topmost (last) item in the visual stack
- Added two new unit tests verifying the constraint for single layers and group blocks

## Root Cause
`computeMoveLayer` lacked the root-group boundary check that already exists in `getInsertionOrderIndex` (used for new layer insertion). When a user dragged a layer to the very bottom of the visible list (top of z-order), it could be placed above the root group.

## Test plan
- [x] Typecheck passes
- [x] All 17 move-layer unit tests pass (including 2 new ones)
- [ ] Drag a layer to the bottom of the layers panel — verify it stays inside the Project group

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)