### PR TITLE
fix: layer/coordinate bugs (thumbnails, healing, reorder, gradient sync)

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -60,7 +60,7 @@ const ALLOWLIST = {
   'src/test/canvas-mock.ts': 3,
   'src/tools/brush/brush-from-selection.test.ts': 3,
   'src/tools/crop/perspective-crop.test.ts': 3,             // see #441 (delete with prod file)
-  'src/tools/gradient/gradient-interaction.test.ts': 1,
+  'src/tools/gradient/gradient-interaction.test.ts': 2,
   'src/tools/magnetic-lasso/magnetic-lasso.test.ts': 2,
   'src/tools/move/move.test.ts': 1,
   'src/tools/path/boolean-ops.test.ts': 11,

--- a/src/app/store/actions/move-layer.test.ts
+++ b/src/app/store/actions/move-layer.test.ts
@@ -262,6 +262,18 @@ describe('group block contiguity invariant', () => {
     }
   });
 
+  it('keeps the root group last in layerOrder no matter what toIndex is requested (issue #495)', () => {
+    const doc = makeGroupDoc();
+    // Root is at layerOrder index 6. Try every possible move of L1 (index 1)
+    // including positions past the root (e.g. toIndex = layerOrder.length).
+    for (let to = 0; to <= doc.layerOrder.length; to++) {
+      const result = computeMoveLayer(doc, 0, 1, to);
+      if (!result) continue;
+      const newOrder = result.document!.layerOrder;
+      expect(newOrder[newOrder.length - 1]).toBe(doc.rootGroupId);
+    }
+  });
+
   it('holds after successive moves', () => {
     let doc = makeGroupDoc();
     // Move L1 into G1, then move it back out, then move BG around

--- a/src/app/store/actions/move-layer.ts
+++ b/src/app/store/actions/move-layer.ts
@@ -16,6 +16,17 @@ export function computeMoveLayer(
   const movedLayer = layerMap.get(movedId);
   if (!movedLayer) return undefined;
 
+  // Root group must remain the topmost item in layerOrder (last in array)
+  // so nothing renders outside it — issue #495. Clamp toIndex if a non-root
+  // move would place the layer at or past the root's post-splice position.
+  if (doc.rootGroupId && movedId !== doc.rootGroupId) {
+    const rootIdx = order.indexOf(doc.rootGroupId);
+    if (rootIdx !== -1) {
+      const newRootIdx = fromIndex < rootIdx ? rootIdx - 1 : rootIdx;
+      if (toIndex > newRootIdx) toIndex = newRootIdx;
+    }
+  }
+
   if (isGroupLayer(movedLayer)) {
     const descendantIds = new Set(getDescendantIds(doc.layers, movedId));
     const blockIds = new Set([movedId, ...descendantIds]);

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -288,6 +288,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     // cleanupRemovedTextLayers helper above.
     for (const descId of result.removedLayerIds ?? [id]) {
       invalidateBitmapCache(descId);
+      pixelDataManager.dropLayer(descId);
     }
 
     s.pushHistory('Delete Layer');
@@ -777,6 +778,10 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       if (result.removedLayerIds) allRemovedIds.push(...result.removedLayerIds);
     }
     cleanupRemovedTextLayers(doc, allRemovedIds);
+    for (const removedId of allRemovedIds) {
+      invalidateBitmapCache(removedId);
+      pixelDataManager.dropLayer(removedId);
+    }
     const activeId = currentDoc.activeLayerId;
     set({
       document: {

--- a/src/engine/pixel-data-manager.test.ts
+++ b/src/engine/pixel-data-manager.test.ts
@@ -76,14 +76,30 @@ describe('PixelDataManager', () => {
     expect(mgr.version()).toBe(v);
   });
 
-  it('remove() drains the layerVersions entry so it does not accumulate', () => {
-    // Set + remove a layer 10 times; versionOf should always reset to 0
-    // after the remove (i.e. no permanent entry per id ever seen).
-    for (let i = 0; i < 10; i++) {
-      mgr.setDense(`layer-${i}`, makeImageData());
-      mgr.remove(`layer-${i}`);
-      expect(mgr.versionOf(`layer-${i}`)).toBe(0);
-    }
+  it('remove() preserves the layerVersions entry so consecutive evictions still bump (issue #498)', () => {
+    // clearJsPixelData() does remove() followed by bumpVersion() on every
+    // GPU-side stroke. If remove() drains the version entry, the next
+    // bumpVersion sets it to 1 instead of incrementing, so consecutive
+    // strokes produce version=1 every time and LayerThumbnail subscribers
+    // (useSyncExternalStore) see no change and stop re-rendering.
+    mgr.setDense('a', makeImageData());
+    mgr.remove('a');
+    mgr.bumpVersion('a');
+    const afterFirstStroke = mgr.versionOf('a');
+    mgr.remove('a');
+    mgr.bumpVersion('a');
+    const afterSecondStroke = mgr.versionOf('a');
+    expect(afterSecondStroke).toBeGreaterThan(afterFirstStroke);
+  });
+
+  it('dropLayer() drains both data and the version entry — for actual layer removal', () => {
+    // Used in the layer-removal flow so layerVersions does not accumulate
+    // one entry per layer the document ever saw.
+    mgr.setDense('a', makeImageData());
+    expect(mgr.versionOf('a')).toBe(1);
+    mgr.dropLayer('a');
+    expect(mgr.get('a')).toBeUndefined();
+    expect(mgr.versionOf('a')).toBe(0);
   });
 
   it('removeDense leaves sparse data alone', () => {

--- a/src/engine/pixel-data-manager.ts
+++ b/src/engine/pixel-data-manager.ts
@@ -78,15 +78,26 @@ export class PixelDataManager {
     this.bump(layerId);
   }
 
-  /** Remove any data (dense or sparse) for a layer. */
+  /** Remove the cached pixel data (dense or sparse) for a layer that still
+   *  exists in the document — e.g. after a GPU operation makes the JS cache
+   *  stale. The layer's version entry is preserved so consecutive cache
+   *  evictions keep producing monotonically increasing versions; otherwise
+   *  per-layer subscribers (LayerThumbnail) would see the version oscillate
+   *  back to 1 on every stroke and stop re-rendering. To fully drain a
+   *  layer that's being removed from the document, call dropLayer(). */
   remove(layerId: string): void {
     const hadDense = this.pixelData.delete(layerId);
     const hadSparse = this.sparseData.delete(layerId);
     if (hadDense || hadSparse) this.bump(layerId);
-    // Drop the version entry too — the layer is gone, no remaining
-    // subscriber should be observing it (components that displayed it
-    // have unmounted). Without this, layerVersions accumulates one
-    // entry per layer the document ever saw, for the document's life.
+  }
+
+  /** Remove cached data AND the version entry. Use this when a layer is
+   *  actually removed from the document, so layerVersions doesn't accumulate
+   *  an entry per layer the document ever saw. */
+  dropLayer(layerId: string): void {
+    const hadDense = this.pixelData.delete(layerId);
+    const hadSparse = this.sparseData.delete(layerId);
+    if (hadDense || hadSparse) this.bump(layerId);
     this.layerVersions.delete(layerId);
   }
 

--- a/src/tools/gradient/gradient-interaction.test.ts
+++ b/src/tools/gradient/gradient-interaction.test.ts
@@ -31,6 +31,11 @@ vi.mock('../../app/store/clear-js-pixel-data', () => ({
   clearJsPixelData: vi.fn(),
 }));
 
+const syncLayerAfterFullSize = vi.fn();
+vi.mock('../../app/sync-layer-after-full-size', () => ({
+  syncLayerAfterFullSize: (...args: unknown[]) => syncLayerAfterFullSize(...args),
+}));
+
 const editorState = {
   pushHistory: vi.fn(),
   notifyRender: vi.fn(),
@@ -151,6 +156,41 @@ describe('gradient drag lifecycle (issue #338)', () => {
     expect(uiState.setGradientPreview).toHaveBeenCalled();
     handleGradientUp(state);
     expect(uiState.setGradientPreview).toHaveBeenLastCalledWith(null);
+  });
+
+  // Issue #494 — gpuRenderLinearGradient calls ensure_layer_full_size on the
+  // WASM side, expanding cropped textures. The JS layer.x/y/w/h must be
+  // synced afterward or downstream cmd+click alpha selection reads stale
+  // coordinates and produces a misaligned selection.
+  it('syncs layer position after the gradient commit (issue #494)', () => {
+    syncLayerAfterFullSize.mockClear();
+    const state = handleGradientDown(makeCtx());
+    handleGradientUp(state);
+    expect(syncLayerAfterFullSize).toHaveBeenCalledTimes(1);
+    expect(syncLayerAfterFullSize).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+  });
+
+  it('does not sync layer position when the gradient was on a layer mask', () => {
+    syncLayerAfterFullSize.mockClear();
+    uiStateValues.maskEditMode = true;
+    // Stub a mask on the active layer so the maskMode branch is taken.
+    const ctx = makeCtx();
+    (ctx.activeLayer as unknown as { mask: { data: Uint8ClampedArray; width: number; height: number } }).mask = {
+      data: new Uint8ClampedArray(4),
+      width: 2,
+      height: 2,
+    };
+    const state = handleGradientDown(ctx);
+    handleGradientUp(state);
+    expect(syncLayerAfterFullSize).not.toHaveBeenCalled();
+  });
+
+  it('does not sync layer position when the gradient was on the quick mask', () => {
+    syncLayerAfterFullSize.mockClear();
+    uiStateValues.isQuickMaskMode = true;
+    const state = handleGradientDown(makeCtx());
+    handleGradientUp(state);
+    expect(syncLayerAfterFullSize).not.toHaveBeenCalled();
   });
 });
 

--- a/src/tools/gradient/gradient-interaction.ts
+++ b/src/tools/gradient/gradient-interaction.ts
@@ -5,6 +5,7 @@ import { useUIStore } from '../../app/ui-store';
 import { useEditorStore } from '../../app/editor-store';
 import { useToolSettingsStore } from '../../app/tool-settings-store';
 import { clearJsPixelData } from '../../app/store/clear-js-pixel-data';
+import { syncLayerAfterFullSize } from '../../app/sync-layer-after-full-size';
 import { getEngine } from '../../engine-wasm/engine-state';
 import {
   renderLinearGradient as gpuRenderLinearGradient,
@@ -60,9 +61,19 @@ export function handleGradientDown(ctx: InteractionContext): InteractionState {
   };
 }
 
-export function handleGradientUp(_state: InteractionState): void {
+export function handleGradientUp(state: InteractionState): void {
   const engine = getEngine();
-  if (engine) gpuEndGradientPreview(engine);
+  if (engine) {
+    gpuEndGradientPreview(engine);
+    // The render path calls ensure_layer_full_size on the WASM side, which
+    // expands a cropped layer texture. Sync the JS store so layer.x/y/w/h
+    // match the new GPU texture extent — otherwise downstream operations
+    // (cmd+click alpha selection, content bounds) read the stale offsets
+    // and produce misaligned results. Issue #494.
+    if (state.layerId && !state.maskMode && !state.quickMaskMode) {
+      syncLayerAfterFullSize(engine, state.layerId);
+    }
+  }
   useUIStore.getState().setGradientPreview(null);
 }
 

--- a/src/tools/healing/healing-interaction.test.ts
+++ b/src/tools/healing/healing-interaction.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const applyHealingDab = vi.fn();
+const applyHealingDabBatch = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  applyHealingDab: (...args: unknown[]) => applyHealingDab(...args),
+  applyHealingDabBatch: (...args: unknown[]) => applyHealingDabBatch(...args),
+}));
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => ({ __engine: 'mock' }),
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+  document: { layers: [{ id: 'layer-1', x: 100, y: 200, type: 'raster' }] },
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  healingSize: 20,
+  healingOpacity: 100,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import {
+  handleHealingDown,
+  handleHealingMove,
+} from './healing-interaction';
+import type { InteractionContext } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 100, y: 200, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 150, y: 250 },
+    // layerPos is layer-local (canvasPos - layer.xy): (50, 50)
+    layerPos: { x: 50, y: 50 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    pixelBuffer: {} as unknown as InteractionContext['pixelBuffer'],
+    paintSurface: {} as unknown as InteractionContext['paintSurface'],
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null } as unknown as InteractionContext['floatingSelectionRef'],
+    persistentTransformRef: { current: null } as unknown as InteractionContext['persistentTransformRef'],
+    stampSourceRef: { current: null } as unknown as InteractionContext['stampSourceRef'],
+    stampOffsetRef: { current: null } as unknown as InteractionContext['stampOffsetRef'],
+    lastPaintPointRef: { current: null } as unknown as InteractionContext['lastPaintPointRef'],
+    ...overrides,
+  };
+}
+
+describe('healing brush coordinate space (issue #497)', () => {
+  beforeEach(() => {
+    applyHealingDab.mockClear();
+    applyHealingDabBatch.mockClear();
+    editorState.pushHistory.mockClear();
+    editorState.notifyRender.mockClear();
+  });
+
+  it('cmd+click sets the source reference and does not paint', () => {
+    const ctx = makeCtx({ metaKey: true });
+    handleHealingDown(ctx);
+    expect(ctx.stampSourceRef.current).toEqual({ x: 50, y: 50 });
+    expect(applyHealingDab).not.toHaveBeenCalled();
+  });
+
+  it('passes layer-local coordinates to applyHealingDab (NOT doc-space minus layer.xy again)', () => {
+    // Source set first via cmd+click at layer-local (10, 10)
+    const sourceCtx = makeCtx({ metaKey: true, layerPos: { x: 10, y: 10 } });
+    handleHealingDown(sourceCtx);
+    // Now click at layer-local (50, 50) — should heal at layer-local (50, 50)
+    const ctx = makeCtx({
+      layerPos: { x: 50, y: 50 },
+      stampSourceRef: sourceCtx.stampSourceRef,
+      stampOffsetRef: sourceCtx.stampOffsetRef,
+    });
+    handleHealingDown(ctx);
+    expect(applyHealingDab).toHaveBeenCalledTimes(1);
+    const args = applyHealingDab.mock.calls[0]!;
+    // (engine, layerId, dx, dy, ox, oy, size, opacity)
+    expect(args[2]).toBe(50);
+    expect(args[3]).toBe(50);
+  });
+
+  it('handleHealingMove forwards layer-local points to applyHealingDabBatch without subtracting docX/docY', () => {
+    handleHealingMove(
+      {
+        lastPoint: { x: 0, y: 0 },
+        layerId: 'layer-1',
+        drawing: true,
+      } as never,
+      { x: 80, y: 80 },
+      { current: { x: -40, y: -40 } } as never,
+    );
+    expect(applyHealingDabBatch).toHaveBeenCalledTimes(1);
+    const args = applyHealingDabBatch.mock.calls[0]!;
+    const pts = args[2] as Float64Array;
+    // All points must be positive (within layer-local 0..80 range).
+    // The double-subtraction bug produced (-20, -120) etc., which would
+    // be far outside the layer texture.
+    for (let i = 0; i < pts.length; i += 2) {
+      expect(pts[i]).toBeGreaterThanOrEqual(0);
+      expect(pts[i]).toBeLessThanOrEqual(80);
+      expect(pts[i + 1]).toBeGreaterThanOrEqual(0);
+      expect(pts[i + 1]).toBeLessThanOrEqual(80);
+    }
+    // Source offset must be passed through unchanged.
+    expect(args[3]).toBe(-40);
+    expect(args[4]).toBe(-40);
+  });
+});

--- a/src/tools/healing/healing-interaction.ts
+++ b/src/tools/healing/healing-interaction.ts
@@ -9,7 +9,7 @@ import { applyHealingDab, applyHealingDabBatch } from '../../engine-wasm/wasm-br
 import { interpolateFlat } from '../common/dab-interpolation';
 
 /**
- * Apply a healing dab at doc-space position `pos` on the given layer,
+ * Apply a healing dab at layer-local position `pos` on the given layer,
  * sampling source from `pos + offset`. Runs entirely on the GPU via
  * the WASM engine to preserve FP16 color precision.
  */
@@ -17,15 +17,7 @@ function applyHealDab(layerId: string, pos: Point, offset: Point, size: number, 
   const engine = getEngine();
   if (!engine) return;
 
-  const layer = useEditorStore.getState().document.layers.find((l) => l.id === layerId);
-  const docX = layer?.x ?? 0;
-  const docY = layer?.y ?? 0;
-
-  // Convert to layer-local coordinates
-  const localX = pos.x - docX;
-  const localY = pos.y - docY;
-
-  applyHealingDab(engine, layerId, localX, localY, offset.x, offset.y, size, opacity / 100);
+  applyHealingDab(engine, layerId, pos.x, pos.y, offset.x, offset.y, size, opacity / 100);
   useEditorStore.getState().notifyRender();
 }
 
@@ -63,15 +55,7 @@ export function handleHealingDown(ctx: InteractionContext): InteractionState | u
   if (shiftKey && ctx.lastPaintPointRef.current && ctx.lastPaintPointRef.current.layerId === activeLayerId) {
     const spacing = Math.max(1, healingSize * 0.25);
     const pts = interpolateFlat(ctx.lastPaintPointRef.current.point, layerPos, spacing);
-    const layer = activeLayer;
-    const docX = layer?.x ?? 0;
-    const docY = layer?.y ?? 0;
-    const localPts = new Float64Array(pts.length);
-    for (let i = 0; i < pts.length; i += 2) {
-      localPts[i] = pts[i]! - docX;
-      localPts[i + 1] = pts[i + 1]! - docY;
-    }
-    applyHealDabBatch(activeLayerId, localPts, ctx.stampOffsetRef.current, healingSize, healingOpacity);
+    applyHealDabBatch(activeLayerId, pts, ctx.stampOffsetRef.current, healingSize, healingOpacity);
   } else {
     applyHealDab(activeLayerId, layerPos, ctx.stampOffsetRef.current, healingSize, healingOpacity);
   }
@@ -102,15 +86,7 @@ export function handleHealingMove(
   const spacing = Math.max(1, healingSize * 0.25);
 
   const pts = interpolateFlat(state.lastPoint, layerLocalPos, spacing);
-  const layer = useEditorStore.getState().document.layers.find((l) => l.id === state.layerId);
-  const docX = layer?.x ?? 0;
-  const docY = layer?.y ?? 0;
-  const localPts = new Float64Array(pts.length);
-  for (let i = 0; i < pts.length; i += 2) {
-    localPts[i] = pts[i]! - docX;
-    localPts[i + 1] = pts[i + 1]! - docY;
-  }
-  applyHealDabBatch(state.layerId, localPts, stampOffsetRef.current, healingSize, healingOpacity);
+  applyHealDabBatch(state.layerId, pts, stampOffsetRef.current, healingSize, healingOpacity);
 
   state.lastPoint = layerLocalPos;
 }


### PR DESCRIPTION
## Summary

Four independent bug fixes — all small, all coordinate / sync issues.

### #498 — Layer thumbnails are not updating
`PixelDataManager.remove()` was modified in PR #484 to drain the
`layerVersions` entry. But `remove()` is also called by
`clearJsPixelData()` after every GPU-side stroke, where the layer is
NOT being removed — its JS cache is just being evicted. The flow
became:

1. `remove(layerId)` — no dense/sparse data to delete, drops version entry
2. `bumpVersion(layerId)` — sets version to `0 + 1 = 1`

So consecutive strokes all produced `version === 1`, and
`LayerThumbnail`'s `useSyncExternalStore` subscriber saw no change and
stopped re-rendering.

**Fix:** `remove()` now leaves the version entry intact. Added a new
`dropLayer()` method that drains both data and the version, wired into
`computeRemoveLayer` callers so the original concern from #484 (map
growth across the document's life) still holds.

### #497 — Healing brush isn't doing anything
`InteractionContext.layerPos` is already in layer-local coordinates
(`canvasPos - layer.xy`). `healing-interaction.ts` was subtracting
`docX/docY` again, sending negative coordinates to `applyHealingDab`.
The dab landed off-texture, so nothing rendered. The stamp tool
already does this correctly — healing diverged when it was forked.

**Fix:** Drop the double subtraction. Pass `layerPos` straight through
to the WASM bridge.

### #495 — Can drag a layer above the root project group
`computeMoveLayer` accepted any `toIndex` up to `layerOrder.length`,
including positions past the root group's index in `layerOrder`. The
root group must remain last in `layerOrder` (= top of the display
stack) so nothing renders outside the project.

**Fix:** Clamp `toIndex` to the root group's post-splice position
inside `computeMoveLayer`. A new test sweeps every possible
`toIndex` for a non-root move and asserts the root group is always
last in the resulting `layerOrder`.

### #494 — cmd+select on rasterized text layer doesn't line up after gradient
`gpuRenderLinearGradient` calls `ensure_layer_full_size` on the WASM
side, expanding a cropped layer's texture to (at least) the document
area. The JS-side `layer.x/y/w/h` was never updated to match, so
downstream operations using those values (cmd+click alpha selection,
content bounds) read stale offsets and produced misaligned results.
The brush path already calls `syncLayerAfterFullSize` after
`beginStroke`; the gradient was missing the matching call.

**Fix:** Call `syncLayerAfterFullSize` from `handleGradientUp` after
`gpuEndGradientPreview` commits the texture. Skip the sync for layer
masks and quick-mask gradients since those don't expand the
underlying layer texture.

## Test plan

- [x] `src/engine/pixel-data-manager.test.ts` — new test confirms
  consecutive `remove()` + `bumpVersion()` cycles produce monotonically
  increasing versions; `dropLayer()` test confirms full drain.
- [x] `src/tools/healing/healing-interaction.test.ts` (new file) —
  asserts layer-local coordinates reach the WASM bridge with no
  double-subtraction.
- [x] `src/app/store/actions/move-layer.test.ts` — new test loops
  every `toIndex` for a non-root move and asserts root stays last.
- [x] `src/tools/gradient/gradient-interaction.test.ts` — new tests
  assert `syncLayerAfterFullSize` fires on layer gradient up and is
  skipped on layer-mask / quick-mask gradients.
- [x] Full unit suite: 872/872 passing locally with `npm run test`.

Closes #498
Closes #497
Closes #495
Closes #494