### PR TITLE
refactor: address audit issues #448, #458, #460, #465

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,7 +17,7 @@ import { MenuBar } from './MenuBar/MenuBar';
 import { OptionsBar } from './OptionsBar/OptionsBar';
 import { StatusBar } from './StatusBar/StatusBar';
 import { NewDocumentModal } from '../components/NewDocumentModal/NewDocumentModal';
-import { ModalHost } from '../components/ModalHost/ModalHost';
+import { ModalHost, LoadingOverlay } from '../components/ModalHost/ModalHost';
 import { GuideColorPicker } from '../components/GuideColorPicker/GuideColorPicker';
 import { useUIStore } from './ui-store';
 import { useEditorStore } from './editor-store';
@@ -48,26 +48,6 @@ function CanvasRenderer({ canvasRef, containerRef, overlayCanvasRef }: {
 }) {
   useCanvasRendering(canvasRef, containerRef, overlayCanvasRef);
   return null;
-}
-
-function LoadingOverlay({ message }: { message: string }) {
-  return (
-    <div style={{
-      position: 'fixed', inset: 0,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      background: 'rgba(0, 0, 0, 0.6)', zIndex: 9999,
-    }} role="dialog" aria-label={message}>
-      <div style={{
-        background: 'var(--color-bg-secondary, #1e1e1e)',
-        borderRadius: 'var(--radius-lg, 8px)',
-        padding: '24px 32px',
-        color: 'var(--color-text-primary, #e0e0e0)',
-        fontSize: 'var(--font-size-sm, 13px)',
-      }}>
-        {message}
-      </div>
-    </div>
-  );
 }
 
 export function App() {

--- a/src/app/editor-store.test.ts
+++ b/src/app/editor-store.test.ts
@@ -91,6 +91,9 @@ describe('editor-store history', () => {
 
     // Without a GPU engine, both snapshots use EMPTY_LAYER_SENTINEL blobs,
     // which are the same reference for each layer (structural sharing)
+    expect(snapshot1.kind).toBe('pixels');
+    expect(snapshot2.kind).toBe('pixels');
+    if (snapshot1.kind !== 'pixels' || snapshot2.kind !== 'pixels') return;
     for (const layerId of state.document.layerOrder) {
       const blob1 = snapshot1.gpuSnapshots.get(layerId);
       const blob2 = snapshot2.gpuSnapshots.get(layerId);

--- a/src/app/store/actions/_helpers/layer-transform.ts
+++ b/src/app/store/actions/_helpers/layer-transform.ts
@@ -1,0 +1,34 @@
+import type { Layer } from '../../../../types';
+import { getEngine } from '../../../../engine-wasm/engine-state';
+
+type Engine = NonNullable<ReturnType<typeof getEngine>>;
+
+interface LayerTransformHandlers {
+  onText: (layer: Layer) => Layer;
+  onRaster: (layer: Layer, engine: Engine | null) => Layer;
+}
+
+/**
+ * Iterates document layers and dispatches by type. Text and raster
+ * layers are handled by the provided callbacks; groups and other
+ * non-raster types pass through unchanged.
+ */
+export function mapLayersForTransform(
+  layers: readonly Layer[],
+  handlers: LayerTransformHandlers,
+): Layer[] {
+  const engine = getEngine();
+  const result: Layer[] = [];
+
+  for (const layer of layers) {
+    if (layer.type === 'text') {
+      result.push(handlers.onText(layer));
+    } else if (layer.type === 'raster') {
+      result.push(handlers.onRaster(layer, engine));
+    } else {
+      result.push(layer);
+    }
+  }
+
+  return result;
+}

--- a/src/app/store/actions/crop-canvas.ts
+++ b/src/app/store/actions/crop-canvas.ts
@@ -1,7 +1,7 @@
 import type { DocumentState, Layer, Rect } from '../../../types';
 import type { ActionResult } from '../types';
-import { getEngine } from '../../../engine-wasm/engine-state';
 import { cropLayerTexture } from '../../../engine-wasm/wasm-bridge';
+import { mapLayersForTransform } from './_helpers/layer-transform';
 
 export function computeCropCanvas(
   doc: DocumentState,
@@ -21,40 +21,22 @@ export function computeCropCanvas(
   const ch = y2 - y1;
   if (cw <= 0 || ch <= 0) return undefined;
 
-  const engine = getEngine();
-  const newLayers: Layer[] = [];
-
-  for (const layer of doc.layers) {
-    if (layer.type === 'text') {
-      // Text layers: adjust position relative to crop rect — engine re-renders
-      newLayers.push({
-        ...layer,
-        x: Math.round(layer.x - cx),
-        y: Math.round(layer.y - cy),
-      } as Layer);
-      continue;
-    }
-
-    if (layer.type !== 'raster') {
-      newLayers.push(layer);
-      continue;
-    }
-
-    // GPU-side crop
-    if (engine) {
-      cropLayerTexture(engine, layer.id, layer.x, layer.y, cx, cy, cw, ch);
-    }
-
-    newLayers.push({ ...layer, x: 0, y: 0, width: cw, height: ch } as Layer);
-  }
+  const newLayers = mapLayersForTransform(doc.layers, {
+    onText: (layer) => ({
+      ...layer,
+      x: Math.round(layer.x - cx),
+      y: Math.round(layer.y - cy),
+    }) as Layer,
+    onRaster: (layer, engine) => {
+      if (engine) {
+        cropLayerTexture(engine, layer.id, layer.x, layer.y, cx, cy, cw, ch);
+      }
+      return { ...layer, x: 0, y: 0, width: cw, height: ch } as Layer;
+    },
+  });
 
   return {
-    document: {
-      ...doc,
-      width: cw,
-      height: ch,
-      layers: newLayers,
-    },
+    document: { ...doc, width: cw, height: ch, layers: newLayers },
     layerPixelData: new Map(),
     renderVersion: renderVersion + 1,
   };

--- a/src/app/store/actions/flatten-image.ts
+++ b/src/app/store/actions/flatten-image.ts
@@ -5,6 +5,7 @@ import { createRasterLayer, createGroupLayer } from '../../../layers/layer-model
 import { createDefaultAdjustments } from '../../../filters/adjustment-node-utils';
 import { getEngine } from '../../../engine-wasm/engine-state';
 import { compositeForExport, uploadLayerPixels, addLayer } from '../../../engine-wasm/wasm-bridge';
+import { layerToDescJson } from '../../../engine-wasm/sync-layers';
 
 export function computeFlattenImage(
   doc: DocumentState,
@@ -23,23 +24,7 @@ export function computeFlattenImage(
     // Register the new layer with the engine BEFORE uploading pixels.
     // This ensures addLayer sees that no texture exists yet and creates a placeholder,
     // then uploadLayerPixels replaces it with the correct-size texture.
-    const descJson = JSON.stringify({
-      id: flatLayer.id,
-      name: flatLayer.name,
-      layer_type: 'Raster',
-      visible: true,
-      locked: false,
-      opacity: 1.0,
-      blend_mode: 'Normal',
-      x: 0,
-      y: 0,
-      width,
-      height,
-      clip_to_below: false,
-      effects: {},
-      mask: null,
-    });
-    addLayer(engine, descJson);
+    addLayer(engine, layerToDescJson(flatLayer, true));
 
     if (composited && composited.length > 0) {
       uploadLayerPixels(engine, flatLayer.id, composited, width, height, 0, 0);

--- a/src/app/store/actions/merge-down.ts
+++ b/src/app/store/actions/merge-down.ts
@@ -2,9 +2,9 @@ import type { DocumentState } from '../../../types';
 import type { ActionResult } from '../types';
 import { getEngine } from '../../../engine-wasm/engine-state';
 import { mergeLayers, rasterizeLayerEffects, updateLayer, uploadLayerPixels } from '../../../engine-wasm/wasm-bridge';
+import { layerToDescJson } from '../../../engine-wasm/sync-layers';
 import { DEFAULT_EFFECTS, hasEnabledEffects } from '../../../layers/layer-model';
 import { removeFromParentGroup } from '../../../layers/group-utils';
-import { BLEND_MODE_TO_PASCAL } from '../../../types/blend-mode-tables';
 
 export function computeMergeDown(
   doc: DocumentState,
@@ -27,22 +27,8 @@ export function computeMergeDown(
       const rasterized = rasterizeLayerEffects(engine, activeId);
       if (rasterized && rasterized.length > 0) {
         uploadLayerPixels(engine, activeId, rasterized, doc.width, doc.height, 0, 0);
-        updateLayer(engine, JSON.stringify({
-          id: topLayer.id,
-          name: topLayer.name,
-          layer_type: topLayer.type === 'group' ? 'Group' : 'Raster',
-          visible: topLayer.visible,
-          locked: topLayer.locked,
-          opacity: topLayer.opacity,
-          blend_mode: BLEND_MODE_TO_PASCAL[topLayer.blendMode] ?? 'Normal',
-          x: 0,
-          y: 0,
-          width: doc.width,
-          height: doc.height,
-          clip_to_below: topLayer.clipToBelow,
-          effects: {},
-          mask: null,
-        }));
+        const cleared = { ...topLayer, x: 0, y: 0, width: doc.width, height: doc.height, effects: DEFAULT_EFFECTS, mask: null };
+        updateLayer(engine, layerToDescJson(cleared, topLayer.visible));
       }
     }
 
@@ -50,22 +36,8 @@ export function computeMergeDown(
       const rasterized = rasterizeLayerEffects(engine, belowId);
       if (rasterized && rasterized.length > 0) {
         uploadLayerPixels(engine, belowId, rasterized, doc.width, doc.height, 0, 0);
-        updateLayer(engine, JSON.stringify({
-          id: bottomLayer.id,
-          name: bottomLayer.name,
-          layer_type: bottomLayer.type === 'group' ? 'Group' : 'Raster',
-          visible: bottomLayer.visible,
-          locked: bottomLayer.locked,
-          opacity: bottomLayer.opacity,
-          blend_mode: BLEND_MODE_TO_PASCAL[bottomLayer.blendMode] ?? 'Normal',
-          x: 0,
-          y: 0,
-          width: doc.width,
-          height: doc.height,
-          clip_to_below: bottomLayer.clipToBelow,
-          effects: {},
-          mask: null,
-        }));
+        const cleared = { ...bottomLayer, x: 0, y: 0, width: doc.width, height: doc.height, effects: DEFAULT_EFFECTS, mask: null };
+        updateLayer(engine, layerToDescJson(cleared, bottomLayer.visible));
       }
     }
 

--- a/src/app/store/actions/resize-canvas.ts
+++ b/src/app/store/actions/resize-canvas.ts
@@ -1,7 +1,7 @@
 import type { DocumentState, Layer } from '../../../types';
 import type { ActionResult } from '../types';
-import { getEngine } from '../../../engine-wasm/engine-state';
 import { resizeCanvasTexture } from '../../../engine-wasm/wasm-bridge';
+import { mapLayersForTransform } from './_helpers/layer-transform';
 
 export function computeResizeCanvas(
   doc: DocumentState,
@@ -17,44 +17,26 @@ export function computeResizeCanvas(
   const offsetX = Math.round((newWidth - oldW) * anchorX);
   const offsetY = Math.round((newHeight - oldH) * anchorY);
 
-  const engine = getEngine();
-  const newLayers: Layer[] = [];
-
-  for (const layer of doc.layers) {
-    if (layer.type === 'text') {
-      // Text layers: adjust position by the canvas offset — engine re-renders
-      newLayers.push({
-        ...layer,
-        x: Math.round(layer.x + offsetX),
-        y: Math.round(layer.y + offsetY),
-      } as Layer);
-      continue;
-    }
-
-    if (layer.type !== 'raster') {
-      newLayers.push(layer);
-      continue;
-    }
-
-    // GPU-side canvas resize: reposition pixels within new canvas
-    if (engine) {
-      resizeCanvasTexture(
-        engine, layer.id,
-        layer.x, layer.y, oldW, oldH,
-        newWidth, newHeight, offsetX, offsetY,
-      );
-    }
-
-    newLayers.push({ ...layer, x: 0, y: 0, width: newWidth, height: newHeight } as Layer);
-  }
+  const newLayers = mapLayersForTransform(doc.layers, {
+    onText: (layer) => ({
+      ...layer,
+      x: Math.round(layer.x + offsetX),
+      y: Math.round(layer.y + offsetY),
+    }) as Layer,
+    onRaster: (layer, engine) => {
+      if (engine) {
+        resizeCanvasTexture(
+          engine, layer.id,
+          layer.x, layer.y, oldW, oldH,
+          newWidth, newHeight, offsetX, offsetY,
+        );
+      }
+      return { ...layer, x: 0, y: 0, width: newWidth, height: newHeight } as Layer;
+    },
+  });
 
   return {
-    document: {
-      ...doc,
-      width: newWidth,
-      height: newHeight,
-      layers: newLayers,
-    },
+    document: { ...doc, width: newWidth, height: newHeight, layers: newLayers },
     layerPixelData: new Map(),
     renderVersion: renderVersion + 1,
   };

--- a/src/app/store/actions/resize-image.ts
+++ b/src/app/store/actions/resize-image.ts
@@ -1,7 +1,7 @@
 import type { DocumentState, Layer } from '../../../types';
 import type { ActionResult } from '../types';
-import { getEngine } from '../../../engine-wasm/engine-state';
 import { scaleLayerTexture } from '../../../engine-wasm/wasm-bridge';
+import { mapLayersForTransform } from './_helpers/layer-transform';
 
 export function computeResizeImage(
   doc: DocumentState,
@@ -10,51 +10,31 @@ export function computeResizeImage(
   newWidth: number,
   newHeight: number,
 ): ActionResult {
-  const oldW = doc.width;
-  const oldH = doc.height;
-  const scaleX = newWidth / oldW;
-  const scaleY = newHeight / oldH;
+  const scaleX = newWidth / doc.width;
+  const scaleY = newHeight / doc.height;
 
-  const engine = getEngine();
-  const newLayers: Layer[] = [];
-
-  for (const layer of doc.layers) {
-    if (layer.type === 'text') {
-      // Text layers: scale position only — engine re-renders at new coordinates
-      newLayers.push({
-        ...layer,
-        x: Math.round(layer.x * scaleX),
-        y: Math.round(layer.y * scaleY),
-      } as Layer);
-      continue;
-    }
-
-    if (layer.type !== 'raster') {
-      newLayers.push(layer);
-      continue;
-    }
-
-    // GPU-side scale
-    if (engine) {
-      scaleLayerTexture(engine, layer.id, newWidth, newHeight);
-    }
-
-    newLayers.push({
+  const newLayers = mapLayersForTransform(doc.layers, {
+    onText: (layer) => ({
       ...layer,
       x: Math.round(layer.x * scaleX),
       y: Math.round(layer.y * scaleY),
-      width: newWidth,
-      height: newHeight,
-    } as Layer);
-  }
+    }) as Layer,
+    onRaster: (layer, engine) => {
+      if (engine) {
+        scaleLayerTexture(engine, layer.id, newWidth, newHeight);
+      }
+      return {
+        ...layer,
+        x: Math.round(layer.x * scaleX),
+        y: Math.round(layer.y * scaleY),
+        width: newWidth,
+        height: newHeight,
+      } as Layer;
+    },
+  });
 
   return {
-    document: {
-      ...doc,
-      width: newWidth,
-      height: newHeight,
-      layers: newLayers,
-    },
+    document: { ...doc, width: newWidth, height: newHeight, layers: newLayers },
     layerPixelData: new Map(),
     renderVersion: renderVersion + 1,
   };

--- a/src/app/store/history-slice.ts
+++ b/src/app/store/history-slice.ts
@@ -48,7 +48,7 @@ function snapshotGpuLayers(
     // layer x/y without touching dirtyLayerIds, so a position mismatch
     // means the blob's texture dimensions no longer match the current GPU
     // state and must be re-read.
-    if (!dirtyIds.has(layerId) && previous?.gpuSnapshots.has(layerId)) {
+    if (!dirtyIds.has(layerId) && previous?.kind === 'pixels' && previous.gpuSnapshots.has(layerId)) {
       const curLayer = layers.find((l) => l.id === layerId);
       const prevLayer = previous.document.layers.find((l) => l.id === layerId);
       const posMatch = curLayer && prevLayer && curLayer.x === prevLayer.x && curLayer.y === prevLayer.y;
@@ -87,7 +87,7 @@ function snapshotGpuLayers(
  * Empty sentinels clear the layer's texture to transparent.
  */
 function restoreGpuFromSnapshot(snapshot: HistorySnapshot): void {
-  if (snapshot.metadataOnly) return;
+  if (snapshot.kind === 'metadata') return;
 
   const engine = getEngine();
   for (const [layerId, blob] of snapshot.gpuSnapshots) {
@@ -116,30 +116,20 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
     if (!previous) return;
 
     let currentSnapshot: HistorySnapshot;
-    if (previous.metadataOnly) {
+    if (previous.kind === 'metadata') {
       currentSnapshot = {
+        kind: 'metadata',
         document: state.document,
-        gpuSnapshots: new Map(),
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: previous.label,
-        metadataOnly: true,
       };
-    } else if (lastRestoredSnapshot) {
-      // GPU state matches the last restored snapshot — reuse blobs directly
+    } else if (lastRestoredSnapshot && lastRestoredSnapshot.kind === 'pixels') {
       currentSnapshot = {
+        kind: 'pixels',
         document: state.document,
         gpuSnapshots: lastRestoredSnapshot.gpuSnapshots,
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: previous.label,
-        metadataOnly: false,
       };
     } else {
-      // First undo from user-edited state — only read dirty layers from GPU,
-      // reuse clean-layer blobs from the snapshot we're restoring to
       const gpuSnapshots = snapshotGpuLayers(
         state.document.layers,
         state.document.layerOrder,
@@ -147,13 +137,10 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         previous,
       );
       currentSnapshot = {
+        kind: 'pixels',
         document: state.document,
         gpuSnapshots,
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: previous.label,
-        metadataOnly: false,
       };
     }
 
@@ -187,25 +174,18 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
     if (!next) return;
 
     let currentSnapshot: HistorySnapshot;
-    if (next.metadataOnly) {
+    if (next.kind === 'metadata') {
       currentSnapshot = {
+        kind: 'metadata',
         document: state.document,
-        gpuSnapshots: new Map(),
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: next.label,
-        metadataOnly: true,
       };
-    } else if (lastRestoredSnapshot) {
+    } else if (lastRestoredSnapshot && lastRestoredSnapshot.kind === 'pixels') {
       currentSnapshot = {
+        kind: 'pixels',
         document: state.document,
         gpuSnapshots: lastRestoredSnapshot.gpuSnapshots,
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: next.label,
-        metadataOnly: false,
       };
     } else {
       const gpuSnapshots = snapshotGpuLayers(
@@ -215,13 +195,10 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         next,
       );
       currentSnapshot = {
+        kind: 'pixels',
         document: state.document,
         gpuSnapshots,
-        layerPixelData: new Map(),
-        layerCropInfo: new Map(),
-        sparseLayerData: new Map(),
         label: next.label,
-        metadataOnly: false,
       };
     }
 
@@ -266,13 +243,10 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
     const gpuSnapshots = snapshotGpuLayers(state.document.layers, state.document.layerOrder, state.dirtyLayerIds, prevSnapshot);
 
     const snapshot: HistorySnapshot = {
+      kind: 'pixels',
       document: state.document,
       gpuSnapshots,
-      layerPixelData: new Map(),
-      layerCropInfo: new Map(),
-      sparseLayerData: new Map(),
       label,
-      metadataOnly: false,
     };
     set({
       undoStack: [...state.undoStack.slice(-49), snapshot],

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -35,32 +35,27 @@ export const EMPTY_SELECTION: SelectionData = {
   maskHeight: 0,
 };
 
-export interface CropInfo {
-  x: number;
-  y: number;
-  fullWidth: number;
-  fullHeight: number;
-}
-
 export interface SparseLayerEntry {
   readonly offsetX: number;
   readonly offsetY: number;
   readonly sparse: import('../../engine/canvas-ops').SparsePixelData;
 }
 
-export interface HistorySnapshot {
-  document: DocumentState;
-  /** Compressed GPU pixel snapshots per layer (RLE-encoded RGBA blobs). */
-  gpuSnapshots: Map<string, Uint8Array>;
-  /** Legacy CPU pixel data — kept for backward compat during transition. */
-  layerPixelData: Map<string, ImageData>;
-  layerCropInfo: Map<string, CropInfo>;
-  sparseLayerData: Map<string, SparseLayerEntry>;
-  label: string;
-  /** When true, only document metadata changed (effects, opacity, etc.) —
-   *  pixel data maps are empty and should not replace current pixel state. */
-  metadataOnly: boolean;
-}
+/**
+ * Discriminated union for undo/redo snapshots.
+ *
+ * - `metadata`: only document metadata changed (effects, opacity, etc.) —
+ *   no pixel data was captured. Zero Maps allocated.
+ * - `pixels`: full snapshot including compressed GPU pixel blobs.
+ */
+export type HistorySnapshot =
+  | { readonly kind: 'metadata'; document: DocumentState; label: string }
+  | {
+      readonly kind: 'pixels';
+      document: DocumentState;
+      label: string;
+      gpuSnapshots: Map<string, Uint8Array>;
+    };
 
 export interface ClipboardData {
   width: number;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -434,7 +434,7 @@ export function useCanvasInteraction(
           // instead of calling undo(), which would pop the stack.
           const undoStack = useEditorStore.getState().undoStack;
           const preStrokeEntry = undoStack[undoStack.length - 2];
-          if (!preStrokeEntry) return;
+          if (!preStrokeEntry || preStrokeEntry.kind !== 'pixels') return;
           const preStrokeBlob = preStrokeEntry.gpuSnapshots.get(layerId);
           if (preStrokeBlob && preStrokeBlob.length > 0) {
             uploadCompressed(layerId, preStrokeBlob);

--- a/src/components/BrushModal/BrushExportModal.tsx
+++ b/src/components/BrushModal/BrushExportModal.tsx
@@ -31,7 +31,7 @@ export function BrushExportModal({ onClose }: BrushExportModalProps) {
 
   const handleExport = useCallback(() => {
     if (selected.size > 0) {
-      exportPresets(selected);
+      exportPresets(presets.filter((p) => selected.has(p.id)));
       onClose();
     }
   }, [selected, onClose]);

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -115,7 +115,7 @@ export function BrushModal() {
           try {
             const parsed = JSON.parse(reader.result as string) as { presets: unknown[] };
             if (Array.isArray(parsed.presets)) {
-              importPresetsFromFile(file);
+              importPresetsFromFile(file, (p) => useToolSettingsStore.getState().addPresets(p));
             }
           } catch { /* not valid JSON, ignore */ }
         };

--- a/src/components/ModalHost/ModalHost.module.css
+++ b/src/components/ModalHost/ModalHost.module.css
@@ -1,0 +1,56 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: var(--z-modal, 9999);
+}
+
+.infoDialog {
+  background: var(--color-bg-secondary, #1e1e1e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: var(--radius-lg, 8px);
+  padding: 24px 28px;
+  max-width: 420px;
+  color: var(--color-text-primary, #e0e0e0);
+  font-size: var(--font-size-sm, 13px);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.infoDialogHeading {
+  margin: 0;
+  font-size: var(--font-size-lg, 16px);
+}
+
+.infoDialogBody {
+  margin: 0;
+  color: var(--color-text-secondary, #aaa);
+}
+
+.infoDialogActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.confirmButton {
+  background: var(--color-accent, #4a9eff);
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  padding: 6px 20px;
+  color: #fff;
+  font-size: var(--font-size-sm, 13px);
+  cursor: pointer;
+}
+
+.loadingContent {
+  background: var(--color-bg-secondary, #1e1e1e);
+  border-radius: var(--radius-lg, 8px);
+  padding: 24px 32px;
+  color: var(--color-text-primary, #e0e0e0);
+  font-size: var(--font-size-sm, 13px);
+}

--- a/src/components/ModalHost/ModalHost.tsx
+++ b/src/components/ModalHost/ModalHost.tsx
@@ -9,6 +9,7 @@ import { NewDocumentModal } from '../NewDocumentModal/NewDocumentModal';
 import { ShapeSizeModal } from '../ShapeSizeModal/ShapeSizeModal';
 import { BrushModal } from '../BrushModal/BrushModal';
 import { StrokePathModal } from '../StrokePathModal/StrokePathModal';
+import styles from './ModalHost.module.css';
 
 /**
  * Renders whichever modal is currently open in the ui-store slot. Also
@@ -115,53 +116,29 @@ export function ModalHost() {
 function AdjustmentLayerInfoModal({ onClose }: { onClose: () => void }) {
   return (
     <div
-      style={{
-        position: 'fixed', inset: 0,
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        background: 'rgba(0, 0, 0, 0.6)', zIndex: 9999,
-      }}
+      className={styles.overlay}
       role="dialog"
       aria-label="Adjustment layers"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div style={{
-        background: 'var(--color-bg-secondary, #1e1e1e)',
-        border: '1px solid var(--color-border, #333)',
-        borderRadius: 'var(--radius-lg, 8px)',
-        padding: '24px 28px',
-        maxWidth: 420,
-        color: 'var(--color-text-primary, #e0e0e0)',
-        fontSize: 'var(--font-size-sm, 13px)',
-        lineHeight: 1.6,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-      }}>
-        <h2 style={{ margin: 0, fontSize: 'var(--font-size-lg, 16px)' }}>
+      <div className={styles.infoDialog}>
+        <h2 className={styles.infoDialogHeading}>
           Group Adjustments
         </h2>
-        <p style={{ margin: 0, color: 'var(--color-text-secondary, #aaa)' }}>
+        <p className={styles.infoDialogBody}>
           Lopsy uses <strong>group adjustments</strong> instead of separate adjustment layers.
           Adjustments like Levels, Curves, Exposure, and Hue/Saturation live directly on
           the Project group and apply non-destructively to all layers within it.
         </p>
-        <p style={{ margin: 0, color: 'var(--color-text-secondary, #aaa)' }}>
+        <p className={styles.infoDialogBody}>
           The Group Adjustments panel is now open on the right. You can add, remove,
           reorder, and toggle adjustments from there.
         </p>
-        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <div className={styles.infoDialogActions}>
           <button
             type="button"
             onClick={onClose}
-            style={{
-              background: 'var(--color-accent, #4a9eff)',
-              border: 'none',
-              borderRadius: 'var(--radius-sm, 4px)',
-              padding: '6px 20px',
-              color: '#fff',
-              fontSize: 'var(--font-size-sm, 13px)',
-              cursor: 'pointer',
-            }}
+            className={styles.confirmButton}
           >
             Got it
           </button>
@@ -171,20 +148,10 @@ function AdjustmentLayerInfoModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function LoadingOverlay({ message }: { message: string }) {
+export function LoadingOverlay({ message }: { message: string }) {
   return (
-    <div style={{
-      position: 'fixed', inset: 0,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      background: 'rgba(0, 0, 0, 0.6)', zIndex: 9999,
-    }} role="dialog" aria-label={message}>
-      <div style={{
-        background: 'var(--color-bg-secondary, #1e1e1e)',
-        borderRadius: 'var(--radius-lg, 8px)',
-        padding: '24px 32px',
-        color: 'var(--color-text-primary, #e0e0e0)',
-        fontSize: 'var(--font-size-sm, 13px)',
-      }}>
+    <div className={styles.overlay} role="dialog" aria-label={message}>
+      <div className={styles.loadingContent}>
         {message}
       </div>
     </div>

--- a/src/tools/brush/preset-io.ts
+++ b/src/tools/brush/preset-io.ts
@@ -1,5 +1,4 @@
 import type { BrushPreset, BrushTipData, SubBrush } from '../../types/brush';
-import { useToolSettingsStore } from '../../app/tool-settings-store';
 
 interface SerializedTip {
   width: number;
@@ -90,12 +89,9 @@ function subBrushFromJson(s: SerializedSubBrush): SubBrush {
 
 let nextImportId = 1;
 
-export function exportPresets(ids?: Set<string>): void {
-  const state = useToolSettingsStore.getState();
-  const customs = ids
-    ? state.presets.filter((p) => ids.has(p.id))
-    : state.presets.filter((p) => p.isCustom);
-  if (customs.length === 0) return;
+export function exportPresets(presets: readonly BrushPreset[]): void {
+  if (presets.length === 0) return;
+  const customs = presets;
 
   const serialized: SerializedPreset[] = customs.map((p) => ({
     name: p.name,
@@ -129,7 +125,10 @@ export function exportPresets(ids?: Set<string>): void {
   URL.revokeObjectURL(url);
 }
 
-export async function importPresetsFromFile(file: File): Promise<number> {
+export async function importPresetsFromFile(
+  file: File,
+  onAddPresets: (presets: BrushPreset[]) => void,
+): Promise<number> {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onload = () => {
@@ -158,7 +157,7 @@ export async function importPresetsFromFile(file: File): Promise<number> {
           taper: s.taper,
           subBrushes: s.subBrushes?.map(subBrushFromJson),
         }));
-        useToolSettingsStore.getState().addPresets(presets);
+        onAddPresets(presets);
         resolve(presets.length);
       } catch {
         resolve(0);

--- a/src/tools/healing/healing-interaction.ts
+++ b/src/tools/healing/healing-interaction.ts
@@ -1,4 +1,3 @@
-import type { MutableRefObject } from 'react';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 import type { Point } from '../../types';
@@ -77,7 +76,7 @@ export function handleHealingDown(ctx: InteractionContext): InteractionState | u
 export function handleHealingMove(
   state: InteractionState,
   layerLocalPos: Point,
-  stampOffsetRef: MutableRefObject<Point | null>,
+  stampOffsetRef: { current: Point | null },
 ): void {
   if (!state.lastPoint || !stampOffsetRef.current || !state.layerId) return;
 

--- a/src/tools/stamp/stamp-interaction.ts
+++ b/src/tools/stamp/stamp-interaction.ts
@@ -1,4 +1,3 @@
-import type { MutableRefObject } from 'react';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 import type { Point } from '../../types';
@@ -65,7 +64,7 @@ export function handleStampDown(ctx: InteractionContext): InteractionState | und
 export function handleStampMove(
   state: InteractionState,
   layerLocalPos: Point,
-  stampOffsetRef: MutableRefObject<Point | null>,
+  stampOffsetRef: { current: Point | null },
 ): void {
   if (!state.lastPoint || !stampOffsetRef.current) return;
 


### PR DESCRIPTION
## Summary

Addresses four audit issues from the codebase review:

- **#448 — HistorySnapshot tagged union**: Replace the flat `HistorySnapshot` interface with a `kind: 'metadata' | 'pixels'` discriminated union. Delete always-empty legacy CPU fields (`layerPixelData`, `layerCropInfo`, `sparseLayerData`) and the unused `CropInfo` interface. Metadata-only snapshots now allocate zero Maps.

- **#458 — Action helpers**: Extract `mapLayersForTransform` helper from the near-clone resize-canvas/crop-canvas/resize-image pattern. Replace open-coded `JSON.stringify` descriptor payloads in merge-down and flatten-image with calls to the canonical `layerToDescJson` from sync-layers.ts.

- **#460 — Inline styles in ModalHost/App**: Move all static inline styles from `AdjustmentLayerInfoModal` and `LoadingOverlay` into `ModalHost.module.css`. Consolidate the duplicate `LoadingOverlay` from App.tsx into a single exported component.

- **#465 — DOM/React in tool logic**: Decouple `preset-io.ts` from `useToolSettingsStore` (accepts data/callbacks instead). Remove `MutableRefObject` React imports from stamp and healing interaction files.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 872 unit tests pass
- [ ] Visual check: modals (loading overlay, adjustment info) render correctly
- [ ] Undo/redo still works correctly (tagged union change)
- [ ] Canvas resize, crop, image resize behave unchanged
- [ ] Brush preset import/export still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)