### PR TITLE
fix(brush): highlight subbrush tip selection for round brushes

### DIFF
--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -397,8 +397,8 @@ export function BrushModal() {
                     {presets.map((preset) => (
                       <button
                         key={preset.id}
-                        className={`${styles.presetItem}${sub.tip !== null && sub.tip === preset.tip ? ` ${styles.presetItemActive}` : ''}`}
-                        onClick={() => updateSubBrush(idx, { tip: preset.tip })}
+                        className={`${styles.presetItem}${sub.tipPresetId === preset.id ? ` ${styles.presetItemActive}` : ''}`}
+                        onClick={() => updateSubBrush(idx, { tip: preset.tip, tipPresetId: preset.id })}
                         aria-label={`Sub-brush tip: ${preset.name}`}
                         title={preset.name}
                       >

--- a/src/tools/brush/preset-io.ts
+++ b/src/tools/brush/preset-io.ts
@@ -10,6 +10,7 @@ interface SerializedTip {
 
 interface SerializedSubBrush {
   tip: SerializedTip | null;
+  tipPresetId?: string;
   sizeRatio: number;
   hardness: number;
   opacityRatio: number;
@@ -63,7 +64,7 @@ function tipFromJson(s: SerializedTip): BrushTipData {
 }
 
 function subBrushToJson(sub: SubBrush): SerializedSubBrush {
-  return {
+  const s: SerializedSubBrush = {
     tip: sub.tip ? tipToJson(sub.tip) : null,
     sizeRatio: sub.sizeRatio,
     hardness: sub.hardness,
@@ -73,10 +74,12 @@ function subBrushToJson(sub: SubBrush): SerializedSubBrush {
     angleJitter: sub.angleJitter,
     opacityJitter: sub.opacityJitter,
   };
+  if (sub.tipPresetId) s.tipPresetId = sub.tipPresetId;
+  return s;
 }
 
 function subBrushFromJson(s: SerializedSubBrush): SubBrush {
-  return {
+  const sub: SubBrush = {
     tip: s.tip ? tipFromJson(s.tip) : null,
     sizeRatio: s.sizeRatio,
     hardness: s.hardness,
@@ -86,6 +89,8 @@ function subBrushFromJson(s: SerializedSubBrush): SubBrush {
     angleJitter: s.angleJitter,
     opacityJitter: s.opacityJitter,
   };
+  if (s.tipPresetId) return { ...sub, tipPresetId: s.tipPresetId };
+  return sub;
 }
 
 let nextImportId = 1;

--- a/src/types/brush.ts
+++ b/src/types/brush.ts
@@ -24,6 +24,7 @@ export type BrushTextureBlendMode = 'multiply' | 'subtract' | 'overlay';
 /** Additional nozzle that fires alongside the primary brush at each dab position. */
 export interface SubBrush {
   readonly tip: BrushTipData | null;
+  readonly tipPresetId?: string;
   readonly sizeRatio: number;
   readonly hardness: number;
   readonly opacityRatio: number;


### PR DESCRIPTION
## Summary
- The first three built-in brushes (Hard Round, Soft Round, Airbrush) use `tip: null` for procedural dabs, meaning the subbrush picker's reference-equality check (`sub.tip === preset.tip`) always failed for them — clicking gave no visual feedback
- Added a `tipPresetId` field to `SubBrush` that tracks the selected preset by its stable string ID, matching the approach the Shape tab already uses
- Updated preset serialization to round-trip the new field

## Test plan
- [ ] Open Brush Modal → Sub-Brushes tab → Add Sub-Brush
- [ ] Click Hard Round, Soft Round, or Airbrush — verify the highlight appears
- [ ] Click a non-round brush (Square, Diamond, etc.) — verify highlight switches
- [ ] Save a preset with a subbrush using a round tip, reload — verify highlight persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)