### PR TITLE
feat(components): introduce Button primitive and migrate dialog action buttons (#459)

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,0 +1,86 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-ui);
+  line-height: 1.4;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.button:disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.primary:active:not(:disabled) {
+  background: var(--color-accent-active);
+  border-color: var(--color-accent-active);
+}
+
+.secondary {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.secondary:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.secondary:active:not(:disabled) {
+  background: var(--color-bg-active);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+}
+
+.ghost:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.ghost:active:not(:disabled) {
+  background: var(--color-bg-active);
+}
+
+.danger {
+  background: var(--color-error);
+  color: #fff;
+  border-color: var(--color-error);
+}
+
+.danger:hover:not(:disabled) {
+  background: #e53935;
+  border-color: #e53935;
+}
+
+.danger:active:not(:disabled) {
+  background: #c62828;
+  border-color: #c62828;
+}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { variant: 'primary', children: 'Save' },
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary', children: 'Cancel' },
+};
+
+export const Ghost: Story = {
+  args: { variant: 'ghost', children: 'Reset' },
+};
+
+export const Danger: Story = {
+  args: { variant: 'danger', children: 'Delete' },
+};
+
+export const Disabled: Story = {
+  args: { variant: 'primary', children: 'Disabled', disabled: true },
+};

--- a/src/components/Button/Button.test.ts
+++ b/src/components/Button/Button.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { Button } from './Button';
+
+function renderToContainer(el: React.ReactElement): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => { createRoot(container).render(el); });
+  return container;
+}
+
+describe('Button', () => {
+  it('renders children', () => {
+    const c = renderToContainer(createElement(Button, null, 'Click me'));
+    const btn = c.querySelector('button')!;
+    expect(btn.textContent).toBe('Click me');
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    const c = renderToContainer(createElement(Button, { onClick }, 'Go'));
+    act(() => { c.querySelector('button')!.click(); });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('defaults to type="button"', () => {
+    const c = renderToContainer(createElement(Button, null, 'Go'));
+    expect(c.querySelector('button')!.getAttribute('type')).toBe('button');
+  });
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,21 @@
+import styles from './Button.module.css';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+export function Button({ variant = 'secondary', className, children, ...rest }: ButtonProps) {
+  const cls = [
+    styles.button,
+    styles[variant],
+    className,
+  ].filter(Boolean).join(' ');
+
+  return (
+    <button type="button" className={cls} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/ExportDialog/ExportDialog.tsx
+++ b/src/components/ExportDialog/ExportDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useEditorStore } from '../../app/editor-store';
 import { Slider } from '../Slider/Slider';
+import { Button } from '../Button/Button';
 import {
   type ExportFormat,
   type ExportOptions,
@@ -200,12 +201,12 @@ export function ExportDialog({ onExport, onCancel, onPreviewRequest }: ExportDia
         </div>
 
         <div className={styles.footer}>
-          <button className={styles.cancelButton} type="button" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
-          </button>
-          <button className={styles.exportButton} type="button" onClick={handleExport}>
+          </Button>
+          <Button variant="primary" onClick={handleExport}>
             Export
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/ModalHost/ModalHost.tsx
+++ b/src/components/ModalHost/ModalHost.tsx
@@ -9,6 +9,7 @@ import { NewDocumentModal } from '../NewDocumentModal/NewDocumentModal';
 import { ShapeSizeModal } from '../ShapeSizeModal/ShapeSizeModal';
 import { BrushModal } from '../BrushModal/BrushModal';
 import { StrokePathModal } from '../StrokePathModal/StrokePathModal';
+import { Button } from '../Button/Button';
 import styles from './ModalHost.module.css';
 
 /**
@@ -135,13 +136,9 @@ function AdjustmentLayerInfoModal({ onClose }: { onClose: () => void }) {
           reorder, and toggle adjustments from there.
         </p>
         <div className={styles.infoDialogActions}>
-          <button
-            type="button"
-            onClick={onClose}
-            className={styles.confirmButton}
-          >
+          <Button variant="primary" onClick={onClose}>
             Got it
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/ShapeSizeModal/ShapeSizeModal.tsx
+++ b/src/components/ShapeSizeModal/ShapeSizeModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { Button } from '../Button/Button';
 import styles from './ShapeSizeModal.module.css';
 
 interface ShapeSizeModalProps {
@@ -66,8 +67,8 @@ export function ShapeSizeModal({ onConfirm, onCancel }: ShapeSizeModalProps) {
           </div>
         </div>
         <div className={styles.footer}>
-          <button className={styles.cancelButton} onClick={onCancel}>Cancel</button>
-          <button className={styles.confirmButton} onClick={handleConfirm}>Create</button>
+          <Button variant="secondary" onClick={onCancel}>Cancel</Button>
+          <Button variant="primary" onClick={handleConfirm}>Create</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **#459 — Button primitive**: Add `src/components/Button/` with four variants (primary, secondary, ghost, danger), CSS module using design tokens, Storybook story, and unit test. Migrate action buttons in ModalHost, ShapeSizeModal, and ExportDialog from raw `<button>` to `<Button>`. Further panel/menu migrations to follow in separate PRs.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 897 unit tests pass (3 new)
- [ ] Button renders correctly in all variants (check Storybook)
- [ ] ModalHost "Got it" button, ShapeSizeModal Cancel/Create, ExportDialog Cancel/Export all render and function

🤖 Generated with [Claude Code](https://claude.com/claude-code)