### PR TITLE
perf(history): metadata undo + RLE compression for undo snapshots

### DIFF
--- a/e2e/memory-retouch-session.spec.ts
+++ b/e2e/memory-retouch-session.spec.ts
@@ -1,0 +1,508 @@
+import { test, expect, type Page } from './fixtures';
+import {
+  waitForStore,
+  addLayer,
+  setActiveLayer,
+  addAdjustment,
+  closeEffectsPanel,
+  getRootGroupId,
+  docToScreen,
+} from './helpers';
+
+/**
+ * Memory profiling test — simulates a photo retouching session on a large
+ * image (4000×6000) and checks that memory stays within reasonable bounds.
+ *
+ * Reproduces the scenario: open large photo → apply levels/curves/hue-sat →
+ * add gradient layer with transparency → duplicate background into a group
+ * with group adjustments.
+ *
+ * Run:
+ *   npx playwright test e2e/memory-retouch-session.spec.ts --project=chromium
+ *   npx playwright test e2e/memory-retouch-session.spec.ts --project=chromium --headed  # real GPU
+ */
+
+function formatMB(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+interface UndoBreakdown {
+  entryIndex: number;
+  label: string;
+  layerCount: number;
+  totalBytes: number;
+  uniqueBlobs: number;
+  blobSizes: number[];
+}
+
+interface SnapshotResult {
+  label: string;
+  heapUsed: number;
+  perfUsed: number;
+  perfTotal: number;
+  wasmMem: number;
+  gpuTextureBytes: number;
+  undoBytes: number;
+  undoUniqueBytes: number;
+  undoEntries: number;
+  undoBreakdown: UndoBreakdown[];
+  layerCount: number;
+  densePixelTotal: number;
+  layerDetails: Array<{ name: string; w: number; h: number; denseBytes: number }>;
+}
+
+async function memorySnapshot(page: Page, label: string): Promise<SnapshotResult> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.collectGarbage');
+  await cdp.send('HeapProfiler.collectGarbage');
+  await new Promise(r => setTimeout(r, 200));
+  await cdp.send('HeapProfiler.collectGarbage');
+
+  const heap = await cdp.send('Runtime.getHeapUsage') as { usedSize: number; totalSize: number };
+
+  const perfMemory = await page.evaluate(() => {
+    const perf = performance as unknown as {
+      memory?: { usedJSHeapSize: number; totalJSHeapSize: number };
+    };
+    return perf.memory
+      ? { usedJSHeapSize: perf.memory.usedJSHeapSize, totalJSHeapSize: perf.memory.totalJSHeapSize }
+      : null;
+  });
+
+  const wasmMem = await page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>;
+    if (w.__wasmMemory) {
+      return (w.__wasmMemory as WebAssembly.Memory).buffer.byteLength;
+    }
+    return 0;
+  });
+
+  const storeInfo = await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => {
+        document: {
+          width: number;
+          height: number;
+          layers: Array<{ id: string; name: string; width?: number; height?: number }>;
+        };
+        undoStack: Array<{
+          label?: string;
+          gpuSnapshots?: Map<string, Uint8Array>;
+          layerPixelData?: Map<string, ImageData>;
+        }>;
+        redoStack: Array<{
+          gpuSnapshots?: Map<string, Uint8Array>;
+        }>;
+      };
+    };
+    const pixelData = (window as unknown as Record<string, unknown>).__pixelData as {
+      get: (id: string) => ImageData | undefined;
+    };
+    const state = store.getState();
+
+    // Track unique blobs across all undo/redo entries by identity
+    const seenBlobs = new Set<Uint8Array>();
+    let totalUndoBytes = 0;
+    let uniqueUndoBytes = 0;
+
+    const undoBreakdown: Array<{
+      entryIndex: number;
+      label: string;
+      layerCount: number;
+      totalBytes: number;
+      uniqueBlobs: number;
+      blobSizes: number[];
+    }> = [];
+
+    const allStacks = [
+      ...state.undoStack.map((e, i) => ({ entry: e, index: i, stack: 'undo' as const })),
+      ...state.redoStack.map((e, i) => ({ entry: e, index: i, stack: 'redo' as const })),
+    ];
+
+    for (const { entry, index, stack } of allStacks) {
+      if (!entry.gpuSnapshots) continue;
+      let entryBytes = 0;
+      let entryUniqueCount = 0;
+      const blobSizes: number[] = [];
+      for (const blob of entry.gpuSnapshots.values()) {
+        entryBytes += blob.byteLength;
+        blobSizes.push(blob.byteLength);
+        if (!seenBlobs.has(blob)) {
+          seenBlobs.add(blob);
+          uniqueUndoBytes += blob.byteLength;
+          entryUniqueCount++;
+        }
+      }
+      totalUndoBytes += entryBytes;
+      if (stack === 'undo') {
+        undoBreakdown.push({
+          entryIndex: index,
+          label: entry.label ?? '?',
+          layerCount: entry.gpuSnapshots.size,
+          totalBytes: entryBytes,
+          uniqueBlobs: entryUniqueCount,
+          blobSizes,
+        });
+      }
+    }
+
+    let gpuLayerBytes = 0;
+    const layerDetails: Array<{ name: string; w: number; h: number; denseBytes: number }> = [];
+    let densePixelTotal = 0;
+    for (const l of state.document.layers) {
+      const w = l.width ?? 0;
+      const h = l.height ?? 0;
+      gpuLayerBytes += w * h * 4;
+      const dense = pixelData.get(l.id);
+      const denseBytes = dense?.data.byteLength ?? 0;
+      densePixelTotal += denseBytes;
+      layerDetails.push({ name: l.name, w, h, denseBytes });
+    }
+
+    const docW = state.document.width ?? 0;
+    const docH = state.document.height ?? 0;
+    const systemTexBytes = docW * docH * 4 * 3;
+
+    return {
+      layerCount: state.document.layers.length,
+      undoEntries: state.undoStack.length,
+      redoEntries: state.redoStack.length,
+      totalUndoBytes,
+      uniqueUndoBytes,
+      undoBreakdown,
+      gpuTextureBytes: gpuLayerBytes + systemTexBytes,
+      layerDetails,
+      densePixelTotal,
+    };
+  });
+
+  await cdp.detach();
+
+  const perfUsed = perfMemory?.usedJSHeapSize ?? heap.usedSize;
+  const perfTotal = perfMemory?.totalJSHeapSize ?? heap.totalSize;
+
+  console.log(`\n=== ${label} ===`);
+  console.log(`  JS Heap (CDP):     ${formatMB(heap.usedSize)}`);
+  console.log(`  JS Heap (perf):    ${formatMB(perfUsed)}`);
+  console.log(`  WASM memory:       ${formatMB(wasmMem)}`);
+  console.log(`  Undo/redo:         ${storeInfo.undoEntries}+${storeInfo.redoEntries} entries`);
+  console.log(`  Undo total bytes:  ${formatMB(storeInfo.totalUndoBytes)} (counting shared blobs per-entry)`);
+  console.log(`  Undo UNIQUE bytes: ${formatMB(storeInfo.uniqueUndoBytes)} (actual memory footprint)`);
+  console.log(`  GPU textures:      ${formatMB(storeInfo.gpuTextureBytes)}`);
+  console.log(`  Dense pixel data:  ${formatMB(storeInfo.densePixelTotal)}`);
+  console.log(`  Layers:`);
+  for (const l of storeInfo.layerDetails) {
+    const denseTag = l.denseBytes > 0 ? ` DENSE=${formatMB(l.denseBytes)}` : '';
+    console.log(`    ${l.name.padEnd(20)} ${l.w}x${l.h} gpu=${formatMB(l.w * l.h * 4)}${denseTag}`);
+  }
+  if (storeInfo.undoBreakdown.length > 0) {
+    console.log(`  Undo entries:`);
+    for (const e of storeInfo.undoBreakdown) {
+      const blobStr = e.blobSizes.map(b => formatMB(b)).join(', ');
+      console.log(`    [${e.entryIndex}] "${e.label}" ${e.layerCount} layers, ${formatMB(e.totalBytes)} (${e.uniqueBlobs} new) [${blobStr}]`);
+    }
+  }
+
+  return {
+    label,
+    heapUsed: heap.usedSize,
+    perfUsed,
+    perfTotal,
+    wasmMem,
+    gpuTextureBytes: storeInfo.gpuTextureBytes,
+    undoBytes: storeInfo.totalUndoBytes,
+    undoUniqueBytes: storeInfo.uniqueUndoBytes,
+    undoEntries: storeInfo.undoEntries,
+    undoBreakdown: storeInfo.undoBreakdown,
+    layerCount: storeInfo.layerCount,
+    densePixelTotal: storeInfo.densePixelTotal,
+    layerDetails: storeInfo.layerDetails,
+  };
+}
+
+test.describe('Memory: retouching session', () => {
+  test('memory stays bounded during a realistic photo retouching workflow', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'CDP heap profiling requires Chromium');
+    test.setTimeout(300_000);
+
+    await page.goto('/');
+    await waitForStore(page);
+
+    // ------------------------------------------------------------------
+    // PHASE 0: Open the large photo (4000×6000)
+    // ------------------------------------------------------------------
+    await page.evaluate(async () => {
+      const response = await fetch('/sample.jpg');
+      const blob = await response.blob();
+      const mod = await import('/src/app/paste-or-open.ts');
+      await mod.pasteOrOpenBlob(blob, 'sample', true);
+    });
+
+    await page.waitForFunction(
+      () => {
+        const store = (window as unknown as Record<string, unknown>).__editorStore as {
+          getState: () => { documentReady: boolean; document: { width: number } };
+        } | undefined;
+        if (!store) return false;
+        const s = store.getState();
+        return s.documentReady && s.document.width > 0;
+      },
+      { timeout: 30000 },
+    );
+    await page.waitForTimeout(2000);
+
+    const docSize = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { width: number; height: number } };
+      };
+      const d = store.getState().document;
+      return { w: d.width, h: d.height };
+    });
+    const oneLayerRGBA8 = docSize.w * docSize.h * 4;
+    const oneLayerU16 = docSize.w * docSize.h * 4 * 2;
+    console.log(`\nDocument: ${docSize.w}x${docSize.h}`);
+    console.log(`One layer RGBA8: ${formatMB(oneLayerRGBA8)}, RGBA u16: ${formatMB(oneLayerU16)}`);
+
+    const s0 = await memorySnapshot(page, 'PHASE 0: Document opened');
+
+    // ------------------------------------------------------------------
+    // PHASE 1: Image adjustments — levels, curves, hue/saturation
+    // ------------------------------------------------------------------
+    const rootGroupId = await getRootGroupId(page);
+
+    await addAdjustment(page, rootGroupId, 'levels');
+    await page.waitForTimeout(500);
+    await closeEffectsPanel(page);
+
+    await addAdjustment(page, rootGroupId, 'curves');
+    await page.waitForTimeout(500);
+    await closeEffectsPanel(page);
+
+    await addAdjustment(page, rootGroupId, 'hue-saturation', {
+      hue: 10,
+      saturation: 15,
+      lightness: 5,
+    });
+    await page.waitForTimeout(500);
+    await closeEffectsPanel(page);
+    await page.waitForTimeout(1000);
+
+    const s1 = await memorySnapshot(page, 'PHASE 1: After levels + curves + hue-sat');
+
+    // ------------------------------------------------------------------
+    // PHASE 2: Add a new layer with a semi-transparent gradient
+    // ------------------------------------------------------------------
+    const gradientLayerId = await addLayer(page);
+    await setActiveLayer(page, gradientLayerId);
+
+    await page.locator('[data-tool-id="gradient"]').click();
+    await page.waitForTimeout(200);
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => {
+          setGradientType: (t: string) => void;
+          setGradientStops: (s: Array<{ position: number; color: { r: number; g: number; b: number; a: number } }>) => void;
+        };
+      };
+      const s = store.getState();
+      s.setGradientType('linear');
+      s.setGradientStops([
+        { position: 0, color: { r: 255, g: 200, b: 50, a: 1 } },
+        { position: 0.5, color: { r: 200, g: 100, b: 150, a: 0.5 } },
+        { position: 1, color: { r: 50, g: 100, b: 200, a: 0 } },
+      ]);
+    });
+
+    const gradStart = await docToScreen(page, 0, 0);
+    const gradEnd = await docToScreen(page, docSize.w, docSize.h);
+    await page.mouse.move(gradStart.x, gradStart.y);
+    await page.mouse.down();
+    await page.mouse.move(gradEnd.x, gradEnd.y, { steps: 20 });
+    await page.mouse.up();
+    await page.waitForTimeout(1000);
+
+    await page.keyboard.press('v');
+    await page.waitForTimeout(500);
+
+    const s2 = await memorySnapshot(page, 'PHASE 2: After gradient layer');
+
+    // ------------------------------------------------------------------
+    // PHASE 3: Duplicate the background layer
+    // ------------------------------------------------------------------
+    const bgId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; name: string }> };
+        };
+      };
+      const bg = store.getState().document.layers.find(l => l.name === 'Background');
+      return bg?.id ?? '';
+    });
+    expect(bgId).not.toBe('');
+
+    await setActiveLayer(page, bgId);
+    await page.locator('[aria-label="Duplicate Layer"]').click();
+    await page.waitForTimeout(2000);
+
+    const s3 = await memorySnapshot(page, 'PHASE 3: After duplicating background');
+
+    // ------------------------------------------------------------------
+    // PHASE 4: Create a group and move the duplicate into it
+    // ------------------------------------------------------------------
+    const dupId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { activeLayerId: string } };
+      };
+      return store.getState().document.activeLayerId;
+    });
+
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { addGroup: (name?: string) => void };
+      };
+      store.getState().addGroup('Retouching');
+    });
+    await page.waitForTimeout(500);
+
+    const groupId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { layers: Array<{ id: string; name: string; type: string }> };
+        };
+      };
+      return store.getState().document.layers.find(l => l.name === 'Retouching')?.id ?? '';
+    });
+    expect(groupId).not.toBe('');
+
+    await page.evaluate(
+      ({ layerId, groupId }) => {
+        const store = (window as unknown as Record<string, unknown>).__editorStore as {
+          getState: () => { moveLayerToGroup: (id: string, gid: string) => void };
+        };
+        store.getState().moveLayerToGroup(layerId, groupId);
+      },
+      { layerId: dupId, groupId },
+    );
+    await page.waitForTimeout(1000);
+
+    const s4 = await memorySnapshot(page, 'PHASE 4: After group with duplicate');
+
+    // ------------------------------------------------------------------
+    // PHASE 5: Add group adjustments (exposure, contrast, hue-sat)
+    // ------------------------------------------------------------------
+    await addAdjustment(page, groupId, 'exposure', { exposure: 15 });
+    await page.waitForTimeout(300);
+    await closeEffectsPanel(page);
+
+    await addAdjustment(page, groupId, 'contrast', { contrast: 20 });
+    await page.waitForTimeout(300);
+    await closeEffectsPanel(page);
+
+    await addAdjustment(page, groupId, 'hue-saturation', {
+      hue: -5,
+      saturation: 25,
+    });
+    await page.waitForTimeout(300);
+    await closeEffectsPanel(page);
+    await page.waitForTimeout(1000);
+
+    const s5 = await memorySnapshot(page, 'PHASE 5: After group adjustments');
+
+    // ------------------------------------------------------------------
+    // PHASE 6: Undo/redo cycles
+    // ------------------------------------------------------------------
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Control+z');
+      await page.waitForTimeout(300);
+    }
+    await page.waitForTimeout(1000);
+
+    const s6 = await memorySnapshot(page, 'PHASE 6: After 5 undos');
+
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Control+Shift+z');
+      await page.waitForTimeout(300);
+    }
+    await page.waitForTimeout(1000);
+
+    const s7 = await memorySnapshot(page, 'PHASE 7: After 5 redos');
+
+    // ------------------------------------------------------------------
+    // SUMMARY
+    // ------------------------------------------------------------------
+    const snapshots = [s0, s1, s2, s3, s4, s5, s6, s7];
+    console.log('\n\n========================================');
+    console.log('       MEMORY SUMMARY');
+    console.log('========================================');
+    console.log(`One layer RGBA8: ${formatMB(oneLayerRGBA8)}, u16: ${formatMB(oneLayerU16)}`);
+    console.log('');
+    console.log(
+      'Phase'.padEnd(48)
+      + 'Heap'.padEnd(12)
+      + 'GPU'.padEnd(12)
+      + 'Undo(ref)'.padEnd(14)
+      + 'Undo(uniq)'.padEnd(14)
+      + 'Dense'.padEnd(12)
+      + '#Undo'.padEnd(8),
+    );
+    console.log('-'.repeat(110));
+    for (const s of snapshots) {
+      console.log(
+        s.label.padEnd(48)
+        + formatMB(s.perfUsed).padEnd(12)
+        + formatMB(s.gpuTextureBytes).padEnd(12)
+        + formatMB(s.undoBytes).padEnd(14)
+        + formatMB(s.undoUniqueBytes).padEnd(14)
+        + formatMB(s.densePixelTotal).padEnd(12)
+        + String(s.undoEntries).padEnd(8),
+      );
+    }
+
+    const peak = (field: keyof SnapshotResult) =>
+      Math.max(...snapshots.map(s => s[field] as number));
+
+    console.log('');
+    console.log(`Peak JS heap:          ${formatMB(peak('perfUsed'))}`);
+    console.log(`Peak undo (unique):    ${formatMB(peak('undoUniqueBytes'))}`);
+    console.log(`Peak undo (ref-count): ${formatMB(peak('undoBytes'))}`);
+    console.log(`Peak GPU textures:     ${formatMB(peak('gpuTextureBytes'))}`);
+    console.log(`Peak dense pixel data: ${formatMB(peak('densePixelTotal'))}`);
+    console.log(`Heap growth:           ${formatMB(s7.perfUsed - s0.perfUsed)}`);
+
+    // Check snapshot blob sizes — are they u8 or u16?
+    const lastEntry = s5.undoBreakdown[s5.undoBreakdown.length - 1];
+    if (lastEntry) {
+      const maxBlob = Math.max(...lastEntry.blobSizes);
+      const isU16 = maxBlob > oneLayerRGBA8 * 1.5;
+      console.log(`\nLargest undo blob: ${formatMB(maxBlob)}`);
+      console.log(`Snapshot format:   ${isU16 ? 'u16 (2 bytes/channel) — DOUBLE SIZED' : 'u8 (1 byte/channel)'}`);
+      if (isU16) {
+        console.log(`  → Each full-frame layer snapshot costs ${formatMB(oneLayerU16)} instead of ${formatMB(oneLayerRGBA8)}`);
+        console.log(`  → Switching to u8 snapshots would halve undo memory`);
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // ASSERTIONS
+    // ------------------------------------------------------------------
+
+    // Undo unique bytes (actual memory) should stay under 1.5 GB.
+    // With 3 raster layers × ~183 MB u16 = 549 MB for one full snapshot,
+    // plus a few incremental entries, 1.5 GB is generous but catches
+    // the 6 GB balloon.
+    const peakUndoUnique = peak('undoUniqueBytes');
+    expect(peakUndoUnique).toBeLessThan(1.5 * 1024 * 1024 * 1024);
+
+    // JS heap should stay under 2 GB total
+    expect(peak('perfUsed')).toBeLessThan(2 * 1024 * 1024 * 1024);
+
+    // Dense pixel data (JS-side ImageData) should be freed after GPU upload.
+    // A lingering 183 MB dense buffer means a layer wasn't cleaned up.
+    // Allow up to 2 full layers of dense data transiently.
+    expect(peak('densePixelTotal')).toBeLessThan(oneLayerRGBA8 * 3);
+
+    // Undo entry count should stay bounded (max 50 per history-slice.ts)
+    expect(peak('undoEntries')).toBeLessThanOrEqual(50);
+  });
+});

--- a/engine-rs/crates/lopsy-core/src/compress.rs
+++ b/engine-rs/crates/lopsy-core/src/compress.rs
@@ -103,6 +103,90 @@ pub fn rle_decompress(data: &[u8], expected_len: usize) -> Vec<u8> {
     out
 }
 
+// ---------------------------------------------------------------------------
+// u16 variant — same RLE scheme but each "pixel" is 4 × u16 = 8 bytes
+// ---------------------------------------------------------------------------
+
+const PIXEL_U16: usize = 8; // 4 channels × 2 bytes
+
+pub fn rle_compress_u16(data: &[u8]) -> Vec<u8> {
+    assert!(data.len() % PIXEL_U16 == 0, "Data length must be a multiple of 8 (RGBA u16)");
+    let pixel_count = data.len() / PIXEL_U16;
+    if pixel_count == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(data.len() + data.len() / 128 + 16);
+    let mut i = 0;
+
+    while i < pixel_count {
+        let pixel = &data[i * PIXEL_U16..(i + 1) * PIXEL_U16];
+        let mut run_len = 1;
+        while i + run_len < pixel_count
+            && run_len < MAX_RUN
+            && data[(i + run_len) * PIXEL_U16..(i + run_len + 1) * PIXEL_U16] == *pixel
+        {
+            run_len += 1;
+        }
+
+        if run_len >= 2 {
+            out.push(0x80 | (run_len as u8 - 1));
+            out.extend_from_slice(pixel);
+            i += run_len;
+        } else {
+            let start = i;
+            let mut lit_len = 0;
+            while i + lit_len < pixel_count && lit_len < MAX_RUN {
+                let p = &data[(i + lit_len) * PIXEL_U16..(i + lit_len + 1) * PIXEL_U16];
+                let mut ahead = 1;
+                while i + lit_len + ahead < pixel_count
+                    && ahead < 2
+                    && data[(i + lit_len + ahead) * PIXEL_U16..(i + lit_len + ahead + 1) * PIXEL_U16] == *p
+                {
+                    ahead += 1;
+                }
+                if ahead >= 2 && lit_len > 0 {
+                    break;
+                }
+                lit_len += 1;
+            }
+            out.push(lit_len as u8 - 1);
+            out.extend_from_slice(&data[start * PIXEL_U16..(start + lit_len) * PIXEL_U16]);
+            i += lit_len;
+        }
+    }
+
+    out
+}
+
+pub fn rle_decompress_u16(data: &[u8], expected_len: usize) -> Vec<u8> {
+    assert!(expected_len % PIXEL_U16 == 0, "Expected length must be a multiple of 8 (RGBA u16)");
+    let mut out = Vec::with_capacity(expected_len);
+    let mut pos = 0;
+
+    while pos < data.len() {
+        let tag = data[pos];
+        pos += 1;
+
+        if tag & 0x80 != 0 {
+            let count = (tag & 0x7F) as usize + 1;
+            let pixel = &data[pos..pos + PIXEL_U16];
+            pos += PIXEL_U16;
+            for _ in 0..count {
+                out.extend_from_slice(pixel);
+            }
+        } else {
+            let count = tag as usize + 1;
+            let bytes = count * PIXEL_U16;
+            out.extend_from_slice(&data[pos..pos + bytes]);
+            pos += bytes;
+        }
+    }
+
+    assert_eq!(out.len(), expected_len, "Decompressed size mismatch");
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,6 +322,86 @@ mod tests {
         let ratio = data.len() as f64 / compressed.len() as f64;
         assert!(ratio > 5.0, "Expected 5x+ compression on typical layer, got {ratio:.1}x");
         let decompressed = rle_decompress(&compressed, data.len());
+        assert_eq!(decompressed, data);
+    }
+
+    // ---------------------------------------------------------------
+    // u16 variant tests
+    // ---------------------------------------------------------------
+
+    fn make_u16_pixel(r: u16, g: u16, b: u16, a: u16) -> [u8; 8] {
+        let mut p = [0u8; 8];
+        p[0..2].copy_from_slice(&r.to_le_bytes());
+        p[2..4].copy_from_slice(&g.to_le_bytes());
+        p[4..6].copy_from_slice(&b.to_le_bytes());
+        p[6..8].copy_from_slice(&a.to_le_bytes());
+        p
+    }
+
+    #[test]
+    fn u16_roundtrip_empty() {
+        let data: Vec<u8> = Vec::new();
+        let compressed = rle_compress_u16(&data);
+        assert!(compressed.is_empty());
+        let decompressed = rle_decompress_u16(&compressed, 0);
+        assert!(decompressed.is_empty());
+    }
+
+    #[test]
+    fn u16_roundtrip_all_transparent() {
+        let pixel = make_u16_pixel(0, 0, 0, 0);
+        let data: Vec<u8> = pixel.iter().copied().cycle().take(1000 * 8).collect();
+        let compressed = rle_compress_u16(&data);
+        assert!(compressed.len() < data.len() / 5);
+        let decompressed = rle_decompress_u16(&compressed, data.len());
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn u16_roundtrip_alternating() {
+        let red = make_u16_pixel(65535, 0, 0, 65535);
+        let blue = make_u16_pixel(0, 0, 65535, 65535);
+        let mut data = Vec::with_capacity(200 * 8);
+        for i in 0..200 {
+            data.extend_from_slice(if i % 2 == 0 { &red } else { &blue });
+        }
+        let compressed = rle_compress_u16(&data);
+        let decompressed = rle_decompress_u16(&compressed, data.len());
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn u16_roundtrip_mixed() {
+        let mut data = Vec::new();
+        let transparent = make_u16_pixel(0, 0, 0, 0);
+        let white = make_u16_pixel(65535, 65535, 65535, 65535);
+        for _ in 0..50 { data.extend_from_slice(&transparent); }
+        for i in 0..10u16 {
+            data.extend_from_slice(&make_u16_pixel(i * 6553, 32768, 50000, 65535));
+        }
+        for _ in 0..100 { data.extend_from_slice(&white); }
+        let compressed = rle_compress_u16(&data);
+        let decompressed = rle_decompress_u16(&compressed, data.len());
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn u16_compression_ratio_sparse_layer() {
+        let width = 200;
+        let height = 200;
+        let transparent = make_u16_pixel(0, 0, 0, 0);
+        let mut data: Vec<u8> = transparent.iter().copied().cycle().take(width * height * 8).collect();
+        for y in 80..120 {
+            for x in 80..120 {
+                let idx = (y * width + x) * 8;
+                let p = make_u16_pixel((x * 300) as u16, (y * 200) as u16, 32768, 65535);
+                data[idx..idx + 8].copy_from_slice(&p);
+            }
+        }
+        let compressed = rle_compress_u16(&data);
+        let ratio = data.len() as f64 / compressed.len() as f64;
+        assert!(ratio > 5.0, "Expected 5x+ compression on sparse u16 layer, got {ratio:.1}x");
+        let decompressed = rle_decompress_u16(&compressed, data.len());
         assert_eq!(decompressed, data);
     }
 }

--- a/engine-rs/crates/lopsy-wasm/src/api/layer.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/layer.rs
@@ -618,18 +618,22 @@ pub fn read_layer_pixels_compressed_u16(engine: &Engine, layer_id: &str) -> Vec<
         return Vec::new();
     }
 
-    // 24-byte header (same layout as u8 variant) + u16 pixel data as LE bytes
-    let pixel_bytes = cropped.len() * 2;
-    let mut result = Vec::with_capacity(24 + pixel_bytes);
+    // Convert cropped u16 values to LE bytes for compression
+    let raw_bytes: Vec<u8> = cropped.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let rle = lopsy_core::compress::rle_compress_u16(&raw_bytes);
+
+    // 28-byte header + uncompressed_size (u32 LE) + RLE data
+    let uncompressed_size = raw_bytes.len() as u32;
+    let mut result = Vec::with_capacity(28 + rle.len());
     result.extend_from_slice(&rect.x.to_le_bytes());
     result.extend_from_slice(&rect.y.to_le_bytes());
     result.extend_from_slice(&(rect.width as i32).to_le_bytes());
     result.extend_from_slice(&(rect.height as i32).to_le_bytes());
     result.extend_from_slice(&(w as i32).to_le_bytes());
     result.extend_from_slice(&(h as i32).to_le_bytes());
-    for &val in &cropped {
-        result.extend_from_slice(&val.to_le_bytes());
-    }
+    result.extend_from_slice(&1i32.to_le_bytes()); // flags: 1 = RLE compressed
+    result.extend_from_slice(&uncompressed_size.to_le_bytes());
+    result.extend_from_slice(&rle);
     result
 }
 
@@ -650,15 +654,30 @@ pub fn upload_layer_pixels_compressed_u16(engine: &mut Engine, layer_id: &str, c
         return Err(JsError::new("Invalid dimensions in compressed header"));
     }
 
-    let pixel_bytes = &compressed[24..];
     let expected_u16_count = (crop_w as usize) * (crop_h as usize) * 4;
-    let expected_byte_len = expected_u16_count * 2;
-    if pixel_bytes.len() < expected_byte_len {
-        return Err(JsError::new("Snapshot pixel data shorter than header dimensions"));
-    }
+    let expected_raw_len = expected_u16_count * 2;
 
-    // Decode LE u16 values
-    let cropped: Vec<u16> = pixel_bytes[..expected_byte_len]
+    // Detect format: 24-byte header + raw data (old) vs 28-byte header + RLE (new).
+    // Old format: data.len() == 24 + expected_raw_len
+    // New format: header[24..28] == flags, header[28..32] == uncompressed_size, then RLE
+    let cropped_bytes: Vec<u8> = if compressed.len() == 24 + expected_raw_len {
+        // Old format: raw u16 bytes after 24-byte header
+        compressed[24..24 + expected_raw_len].to_vec()
+    } else if compressed.len() >= 32 {
+        let flags = i32::from_le_bytes([compressed[24], compressed[25], compressed[26], compressed[27]]);
+        if flags == 1 {
+            let uncompressed_size = u32::from_le_bytes([compressed[28], compressed[29], compressed[30], compressed[31]]) as usize;
+            lopsy_core::compress::rle_decompress_u16(&compressed[32..], uncompressed_size)
+        } else {
+            // flags == 0 means raw, data starts at offset 32
+            compressed[32..].to_vec()
+        }
+    } else {
+        return Err(JsError::new("Snapshot data too short for any known format"));
+    };
+
+    // Decode LE u16 values from the (decompressed) byte stream
+    let cropped: Vec<u16> = cropped_bytes
         .chunks_exact(2)
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .collect();

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -251,7 +251,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeAddLayer(s.document);
     if (!result) return;
-    s.pushHistory('Add Layer');
+    s.pushHistoryMetadata('Add Layer');
     set(result);
   },
 
@@ -259,7 +259,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeAddTextLayer(s.document, layer);
     if (!result) return;
-    s.pushHistory('Add Text Layer');
+    s.pushHistoryMetadata('Add Text Layer');
     set(result);
   },
 
@@ -304,7 +304,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
 
   toggleLayerVisibility: (id) => {
     const s = get();
-    s.pushHistory('Toggle Visibility');
+    s.pushHistoryMetadata('Toggle Visibility');
     set(computeToggleVisibility(s.document, id));
   },
 
@@ -473,7 +473,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeMoveLayer(s.document, s.renderVersion, fromIndex, toIndex);
     if (!result) return;
-    s.pushHistory('Reorder Layer');
+    s.pushHistoryMetadata('Reorder Layer');
     set(result);
   },
 
@@ -617,7 +617,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
   updateLayerEffects: (id: string, effects, skipHistory?: boolean) => {
     finalizePendingStrokeGlobal();
     const s = get();
-    if (!skipHistory) s.pushHistory('Edit Effect');
+    if (!skipHistory) s.pushHistoryMetadata('Edit Effect');
     set(computeUpdateEffects(s.document, s.renderVersion, id, effects));
   },
 
@@ -625,7 +625,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeAddLayerMask(s.document, s.renderVersion, id);
     if (!result) return;
-    s.pushHistory('Add Mask');
+    s.pushHistoryMetadata('Add Mask');
     set(result);
   },
 
@@ -633,7 +633,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeRemoveLayerMask(s.document, s.renderVersion, id);
     if (!result) return;
-    s.pushHistory('Remove Mask');
+    s.pushHistoryMetadata('Remove Mask');
     set(result);
   },
 
@@ -641,7 +641,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     const s = get();
     const result = computeToggleMask(s.document, s.renderVersion, id);
     if (!result) return;
-    s.pushHistory('Toggle Mask');
+    s.pushHistoryMetadata('Toggle Mask');
     set(result);
   },
 
@@ -840,7 +840,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       ...filteredOrder.slice(insertAt),
     ];
 
-    s.pushHistory('Group Layers');
+    s.pushHistoryMetadata('Group Layers');
     set({
       document: {
         ...doc,

--- a/src/app/store/history-slice.ts
+++ b/src/app/store/history-slice.ts
@@ -14,6 +14,7 @@ export interface HistorySlice {
   undo: () => void;
   redo: () => void;
   pushHistory: (label?: string) => void;
+  pushHistoryMetadata: (label: string) => void;
   markClean: () => void;
 }
 
@@ -252,6 +253,23 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
       undoStack: [...state.undoStack.slice(-49), snapshot],
       redoStack: [],
       dirtyLayerIds: new Set(),
+      isDirty: true,
+      renderVersion: state.renderVersion + 1,
+    });
+  },
+
+  pushHistoryMetadata: (label: string) => {
+    const state = get();
+    lastRestoredSnapshot = null;
+
+    const snapshot: HistorySnapshot = {
+      kind: 'metadata',
+      document: state.document,
+      label,
+    };
+    set({
+      undoStack: [...state.undoStack.slice(-49), snapshot],
+      redoStack: [],
       isDirty: true,
       renderVersion: state.renderVersion + 1,
     });

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -173,6 +173,7 @@ export interface EditorState {
   undo: () => void;
   redo: () => void;
   pushHistory: (label?: string) => void;
+  pushHistoryMetadata: (label: string) => void;
   markClean: () => void;
 }
 

--- a/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
+++ b/src/panels/LayerEffectsPanel/LayerEffectsPanel.tsx
@@ -73,7 +73,7 @@ export function LayerEffectsPanel({ dragProps }: LayerEffectsPanelProps) {
   const update = useCallback(
     (partial: Partial<LayerEffects>, label?: string) => {
       if (!activeLayerId || !effects) return;
-      useEditorStore.getState().pushHistory(label ?? `Edit ${effectLabel(selectedEffect)}`);
+      useEditorStore.getState().pushHistoryMetadata(label ?? `Edit ${effectLabel(selectedEffect)}`);
       updateLayerEffects(activeLayerId, { ...effects, ...partial }, true);
     },
     [activeLayerId, effects, updateLayerEffects, selectedEffect],
@@ -82,7 +82,7 @@ export function LayerEffectsPanel({ dragProps }: LayerEffectsPanelProps) {
   // Push one undo entry at the START of a slider drag so undo restores
   // the pre-drag state (not the post-drag state).
   const beginEffectsDrag = useCallback(() => {
-    useEditorStore.getState().pushHistory(`Edit ${effectLabel(selectedEffect)}`);
+    useEditorStore.getState().pushHistoryMetadata(`Edit ${effectLabel(selectedEffect)}`);
   }, [selectedEffect]);
 
   const handleToggle = useCallback(
@@ -98,7 +98,7 @@ export function LayerEffectsPanel({ dragProps }: LayerEffectsPanelProps) {
   const handleBlendModeChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       if (!activeLayerId) return;
-      useEditorStore.getState().pushHistory('Change Blend Mode');
+      useEditorStore.getState().pushHistoryMetadata('Change Blend Mode');
       updateLayerBlendMode(activeLayerId, e.target.value as BlendMode);
     },
     [activeLayerId, updateLayerBlendMode],

--- a/src/panels/LayerPanel/LayerRow.tsx
+++ b/src/panels/LayerPanel/LayerRow.tsx
@@ -224,7 +224,7 @@ export function LayerRow({
             max={100}
             value={Math.round(layer.opacity * 100)}
             aria-label={`${layer.name} opacity`}
-            onPointerDown={() => useEditorStore.getState().pushHistory('Change Opacity')}
+            onPointerDown={() => useEditorStore.getState().pushHistoryMetadata('Change Opacity')}
             onChange={(e) => onUpdateOpacity(layer.id, Number(e.target.value) / 100)}
           />
         </div>


### PR DESCRIPTION
## Summary

- **Metadata-only undo** for 11 operations that don't change pixels (toggle visibility, edit effects, change opacity/blend mode, add/remove layer/mask/group, reorder). These now store zero GPU snapshot data — previously each one read back every layer texture at 183 MB per full-frame layer.
- **RLE compression** for u16 undo snapshot blobs. Adds `rle_compress_u16`/`rle_decompress_u16` to `lopsy-core`, wired into the WASM snapshot read/upload path. Upload auto-detects old (raw) vs new (RLE) format for in-session compat.
- **E2e memory profiling test** (`e2e/memory-retouch-session.spec.ts`) that opens a 4000×6000 JPEG and simulates a retouching session, tracking per-phase memory breakdown (unique undo bytes, GPU textures, dense pixel residue).

## What was happening

Every `pushHistory()` call triggered `snapshotGpuLayers()` — a full GPU readback of every layer. For a 4000×6000 photo at u16 precision, that's 183 MB per layer per undo entry. Toggling layer visibility twice = 2 × 549 MB of GPU readback for a boolean flip.

Heap snapshot analysis of a real session showed 27 undo entries holding 9 unique 183 MB `Uint8Array` blobs (1,648 MB) plus 826 MB WASM memory. The snapshot data was stored as raw u16 bytes with no compression — the "compressed" path only cropped to content bounds.

## Test plan

- [x] 885 unit tests pass (`npm run test`)
- [x] TypeScript clean (`npm run typecheck`)
- [x] 15 Rust compress tests pass (including 5 new u16 tests)
- [x] `e2e/memory-retouch-session.spec.ts` passes — verifies undo memory stays bounded
- [x] `e2e/composition-painting.spec.ts` passes — multi-layer painting with undo/redo
- [x] `e2e/composition-photoediting.spec.ts` passes — filters, text, crop, masks, groups
- [x] `e2e/layer-effects.spec.ts` + `layer-groups.spec.ts` + `layer-mask.spec.ts` — 28 tests pass
- [x] `e2e/brush-system.spec.ts` — 12 tests including undo/redo stroke preservation
- [x] `e2e/external-paste-drop.spec.ts` — paste/drop with undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)