### PR TITLE
perf(engine-rs): reduce peak WASM memory during GPU snapshot readback

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/api/layer.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/layer.rs
@@ -600,10 +600,6 @@ pub fn upload_layer_pixels_compressed(engine: &mut Engine, layer_id: &str, compr
 
 #[wasm_bindgen(js_name = "readLayerPixelsCompressedU16")]
 pub fn read_layer_pixels_compressed_u16(engine: &Engine, layer_id: &str) -> Vec<u8> {
-    let pixels = match layer_manager::read_pixels_u16(&engine.inner, layer_id) {
-        Ok(p) => p,
-        Err(_) => return Vec::new(),
-    };
     let tex = match engine.inner.layer_textures.get(layer_id) {
         Some(&t) => t,
         None => return Vec::new(),
@@ -613,18 +609,31 @@ pub fn read_layer_pixels_compressed_u16(engine: &Engine, layer_id: &str) -> Vec<
         return Vec::new();
     }
 
-    let (cropped, rect) = lopsy_core::pixel_buffer::crop_to_content_bounds_u16(&pixels, w, h);
-    if cropped.is_empty() {
-        return Vec::new();
-    }
+    // Crop and convert to LE bytes in one pass, dropping the full-size
+    // Vec<u16> before building the byte buffer. This keeps peak WASM
+    // allocation at ~2× the cropped layer size instead of ~4×.
+    let (raw_bytes, rect) = {
+        let pixels = match layer_manager::read_pixels_u16(&engine.inner, layer_id) {
+            Ok(p) => p,
+            Err(_) => return Vec::new(),
+        };
+        let (cropped, rect) = lopsy_core::pixel_buffer::crop_to_content_bounds_u16(&pixels, w, h);
+        drop(pixels);
+        if cropped.is_empty() {
+            return Vec::new();
+        }
+        let mut bytes = Vec::with_capacity(cropped.len() * 2);
+        for &val in &cropped {
+            bytes.extend_from_slice(&val.to_le_bytes());
+        }
+        (bytes, rect)
+    };
 
-    // Convert cropped u16 values to LE bytes for compression
-    let raw_bytes: Vec<u8> = cropped.iter().flat_map(|v| v.to_le_bytes()).collect();
-    let rle = lopsy_core::compress::rle_compress_u16(&raw_bytes);
-
-    // 28-byte header + uncompressed_size (u32 LE) + RLE data
     let uncompressed_size = raw_bytes.len() as u32;
-    let mut result = Vec::with_capacity(28 + rle.len());
+    let rle = lopsy_core::compress::rle_compress_u16(&raw_bytes);
+    drop(raw_bytes);
+
+    let mut result = Vec::with_capacity(32 + rle.len());
     result.extend_from_slice(&rect.x.to_le_bytes());
     result.extend_from_slice(&rect.y.to_le_bytes());
     result.extend_from_slice(&(rect.width as i32).to_le_bytes());

--- a/engine-rs/crates/lopsy-wasm/src/gpu/texture_pool.rs
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/texture_pool.rs
@@ -415,6 +415,7 @@ impl TexturePool {
         let count = (w * h * 4) as usize;
 
         if self.use_float {
+            // Read GPU → JS Float32Array (lives on the JS heap, not WASM).
             let f32_buf = js_sys::Float32Array::new_with_length(count as u32);
             gl.read_pixels_with_opt_array_buffer_view(
                 x, y,
@@ -423,12 +424,22 @@ impl TexturePool {
                 WebGl2RenderingContext::FLOAT,
                 Some(&f32_buf),
             ).map_err(|e| format!("readPixels float failed: {:?}", e))?;
-            let mut f32_data = vec![0f32; count];
-            f32_buf.copy_to(&mut f32_data);
-            let pixels: Vec<u16> = f32_data
-                .iter()
-                .map(|&v| (v.clamp(0.0, 1.0) * 65535.0 + 0.5) as u16)
-                .collect();
+            // Convert f32→u16 in chunks to avoid a full-size f32 copy in WASM.
+            // This keeps peak WASM allocation at Vec<u16> (2 bytes/sample)
+            // instead of Vec<f32> + Vec<u16> (6 bytes/sample).
+            let mut pixels = vec![0u16; count];
+            const CHUNK: usize = 65536;
+            let mut f32_chunk = vec![0f32; CHUNK];
+            let mut offset = 0;
+            while offset < count {
+                let len = CHUNK.min(count - offset);
+                let view = f32_buf.subarray(offset as u32, (offset + len) as u32);
+                view.copy_to(&mut f32_chunk[..len]);
+                for i in 0..len {
+                    pixels[offset + i] = (f32_chunk[i].clamp(0.0, 1.0) * 65535.0 + 0.5) as u16;
+                }
+                offset += len;
+            }
             Ok(pixels)
         } else {
             let mut u8_pixels = vec![0u8; count];


### PR DESCRIPTION
## Summary

- Fix `read_rgba_u16` to convert f32→u16 in 64K-sample chunks via JS `Float32Array.subarray()` views instead of copying the entire GPU readback into a WASM `Vec<f32>`. Eliminates **384 MB** of peak WASM allocation per layer readback on a 4000×6000 image.
- Fix `read_layer_pixels_compressed_u16` to eagerly `drop()` the full-size `Vec<u16>` before building the byte buffer, and drop the byte buffer before building the RLE result. Reduces peak from ~4× to ~2× cropped layer size.

## What was happening

WASM linear memory grows in 64KB pages to accommodate peak allocations and **never shrinks**. The old readback path for a 4000×6000 layer allocated `Vec<f32>` (384 MB) + `Vec<u16>` (192 MB) = 576 MB inside `read_rgba_u16`. Combined with crop + byte conversion + RLE in the caller, peak WASM memory reached ~1,360 MB — and stayed there permanently even after resizing to 2000×3000.

Heap snapshot from a session (open 4000×6000 → resize to 2000×3000 → duplicate layer) showed the `WebAssembly.Memory` backing store at **1,361 MB** — the single largest allocation in a 1.6 GB heap.

## Test plan

- [x] `e2e/memory-retouch-session.spec.ts` passes
- [x] `e2e/brush-system.spec.ts` — 12 tests including undo/redo stroke preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)