### PR TITLE
fix(quick-mask): brush respects foreground color (#521)

### DIFF
--- a/e2e/quick-mask.spec.ts
+++ b/e2e/quick-mask.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from './fixtures';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { waitForStore, createDocument, docToScreen } from './helpers';
+import { waitForStore, createDocument, docToScreen, setForegroundColor } from './helpers';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -228,7 +228,10 @@ test.describe('Quick Mask Mode', () => {
     await page.keyboard.press('q');
     await page.waitForTimeout(150);
 
-    // Paint with brush (white = select) over the top-left quadrant (doc 0–100, 0–100)
+    // Paint with brush (white = select) over the top-left quadrant (doc 0–100, 0–100).
+    // Set foreground to white explicitly — brush in quick mask respects color
+    // (white grows selection, black shrinks it).
+    await setForegroundColor(page, 255, 255, 255);
     await page.keyboard.press('b');
     await page.waitForTimeout(50);
 
@@ -278,7 +281,9 @@ test.describe('Quick Mask Mode', () => {
     expect(beforePixel.b).toBeGreaterThan(50);
     expect(beforePixel.a).toBeGreaterThan(20);
 
-    // Paint over the center with brush (white = select)
+    // Paint over the center with brush (white = select). Foreground must be
+    // explicitly white because quick-mask brush respects color (issue #521).
+    await setForegroundColor(page, 255, 255, 255);
     await page.keyboard.press('b');
     await page.waitForTimeout(50);
 
@@ -295,6 +300,69 @@ test.describe('Quick Mask Mode', () => {
     const afterPixel = await sampleCompositedAt(page, 100, 100);
     // Painted area should have lower blue than unpainted area
     expect(afterPixel.b).toBeLessThan(beforePixel.b);
+
+    // Exit
+    await page.keyboard.press('q');
+    await page.waitForTimeout(100);
+  });
+
+  test('Quick Mask brush color controls add/remove of the overlay (issue #521)', async ({ page }) => {
+    await createDocument(page, 200, 200, true);
+    await fitToView(page);
+
+    // Start with a full selection so the overlay is initially absent at the
+    // center — that lets us prove the black brush can ADD overlay back.
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          setSelection: (
+            bounds: { x: number; y: number; width: number; height: number },
+            mask: Uint8ClampedArray,
+            w: number,
+            h: number,
+          ) => void;
+        };
+      };
+      const mask = new Uint8ClampedArray(200 * 200);
+      for (let i = 0; i < mask.length; i++) mask[i] = 255;
+      store.getState().setSelection({ x: 0, y: 0, width: 200, height: 200 }, mask, 200, 200);
+    });
+    await page.waitForTimeout(100);
+
+    // Enter Quick Mask Mode — fully selected → no blue overlay anywhere
+    await page.keyboard.press('q');
+    await page.waitForTimeout(150);
+
+    // Confirm the center is clear (no overlay)
+    const baseline = await sampleCompositedAt(page, 100, 100);
+
+    // Paint over the center with a BLACK brush — this should ADD overlay.
+    await setForegroundColor(page, 0, 0, 0);
+    await page.keyboard.press('b');
+    await page.waitForTimeout(50);
+    const centerScreen = await docToScreen(page, 100, 100);
+    await page.mouse.move(centerScreen.x - 20, centerScreen.y);
+    await page.mouse.down();
+    await page.mouse.move(centerScreen.x + 20, centerScreen.y, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+
+    const afterBlack = await sampleCompositedAt(page, 100, 100);
+    // Black brush should have ADDED blue overlay where it painted.
+    expect(afterBlack.b).toBeGreaterThan(baseline.b + 20);
+
+    // Now paint over the same spot with a WHITE brush — this should REMOVE overlay.
+    await setForegroundColor(page, 255, 255, 255);
+    await page.waitForTimeout(50);
+    await page.mouse.move(centerScreen.x - 20, centerScreen.y);
+    await page.mouse.down();
+    await page.mouse.move(centerScreen.x + 20, centerScreen.y, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+
+    const afterWhite = await sampleCompositedAt(page, 100, 100);
+    // White brush should have erased the overlay back down.
+    expect(afterWhite.b).toBeLessThan(afterBlack.b - 20);
 
     // Exit
     await page.keyboard.press('q');

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -27,6 +27,7 @@ import { getMirroredPoints, mirrorBatchPoints, isSymmetryActive } from '../../to
 import { handleBrushStroke } from '../../tools/brush/brush-stroke';
 import { handlePencilStroke } from '../../tools/pencil/pencil-stroke';
 import { handleEraserStroke } from '../../tools/eraser/eraser-stroke';
+import { getQuickMaskPaintMode } from './quick-mask-paint';
 
 type PaintTool = 'brush' | 'pencil' | 'eraser';
 
@@ -119,7 +120,10 @@ export function handlePaintDown(
       return state;
     }
 
-    const mode = tool === 'eraser' ? 1 : 0; // 0 = brush (add), 1 = eraser (remove)
+    // Quick mask: brush/pencil respect foreground color (black adds the
+    // overlay / shrinks selection, white removes it / grows selection);
+    // eraser always acts as paint-black.
+    const mode = getQuickMaskPaintMode(tool, toolSettings.foregroundColor);
 
     if (tool === 'brush') {
       const size = toolSettings.brushSize;
@@ -648,9 +652,11 @@ function handleMaskPaintMoveUnified(
   if (!state.lastPoint) return;
 
   const isQuickMask = target === 'quickMask';
+  const paintTool: 'brush' | 'pencil' | 'eraser' =
+    state.tool === 'eraser' ? 'eraser' : state.tool === 'pencil' ? 'pencil' : 'brush';
   const mode = isQuickMask
-    ? (state.tool === 'eraser' ? 1 : 0)
-    : (state.tool === 'eraser' ? 0 : 1);
+    ? getQuickMaskPaintMode(paintTool, toolSettings.foregroundColor)
+    : (paintTool === 'eraser' ? 0 : 1);
 
   const emitDabs = (size: number, hardness: number, opacity: number) => {
     const spacing = Math.max(1, size * 0.25);

--- a/src/app/interactions/quick-mask-paint.test.ts
+++ b/src/app/interactions/quick-mask-paint.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { getQuickMaskPaintMode } from './quick-mask-paint';
+import type { Color } from '../../types';
+
+const BLACK: Color = { r: 0, g: 0, b: 0, a: 1 };
+const WHITE: Color = { r: 255, g: 255, b: 255, a: 1 };
+const MID_GRAY: Color = { r: 128, g: 128, b: 128, a: 1 };
+const NEAR_BLACK: Color = { r: 30, g: 30, b: 30, a: 1 };
+const NEAR_WHITE: Color = { r: 230, g: 230, b: 230, a: 1 };
+const SATURATED_RED: Color = { r: 255, g: 0, b: 0, a: 1 };
+const SATURATED_GREEN: Color = { r: 0, g: 255, b: 0, a: 1 };
+const SATURATED_BLUE: Color = { r: 0, g: 0, b: 255, a: 1 };
+
+describe('getQuickMaskPaintMode', () => {
+  it('returns 1 (add overlay / shrink selection) when brush is black', () => {
+    expect(getQuickMaskPaintMode('brush', BLACK)).toBe(1);
+  });
+
+  it('returns 0 (remove overlay / grow selection) when brush is white', () => {
+    expect(getQuickMaskPaintMode('brush', WHITE)).toBe(0);
+  });
+
+  it('treats pencil the same as brush', () => {
+    expect(getQuickMaskPaintMode('pencil', BLACK)).toBe(1);
+    expect(getQuickMaskPaintMode('pencil', WHITE)).toBe(0);
+  });
+
+  it('returns 1 for eraser regardless of color', () => {
+    expect(getQuickMaskPaintMode('eraser', BLACK)).toBe(1);
+    expect(getQuickMaskPaintMode('eraser', WHITE)).toBe(1);
+    expect(getQuickMaskPaintMode('eraser', MID_GRAY)).toBe(1);
+  });
+
+  it('treats near-black brush as dark (mode 1)', () => {
+    expect(getQuickMaskPaintMode('brush', NEAR_BLACK)).toBe(1);
+  });
+
+  it('treats near-white brush as light (mode 0)', () => {
+    expect(getQuickMaskPaintMode('brush', NEAR_WHITE)).toBe(0);
+  });
+
+  it('treats mid-gray brush as light (>= mid threshold)', () => {
+    expect(getQuickMaskPaintMode('brush', MID_GRAY)).toBe(0);
+  });
+
+  it('uses perceptual luminance so saturated red is dark', () => {
+    expect(getQuickMaskPaintMode('brush', SATURATED_RED)).toBe(1);
+  });
+
+  it('uses perceptual luminance so saturated green is light', () => {
+    expect(getQuickMaskPaintMode('brush', SATURATED_GREEN)).toBe(0);
+  });
+
+  it('uses perceptual luminance so saturated blue is dark', () => {
+    expect(getQuickMaskPaintMode('brush', SATURATED_BLUE)).toBe(1);
+  });
+});

--- a/src/app/interactions/quick-mask-paint.ts
+++ b/src/app/interactions/quick-mask-paint.ts
@@ -1,0 +1,27 @@
+import type { Color } from '../../types';
+
+export type QuickMaskPaintTool = 'brush' | 'pencil' | 'eraser';
+
+/**
+ * Quick-mask paint mode values consumed by the GPU shader
+ * (`engine-rs/.../gpu/shaders/brush/quick_mask_dab.glsl`):
+ *   0 = paint white into the mask → grow selection → remove overlay
+ *   1 = paint black into the mask → shrink selection → add overlay
+ *
+ * Brushes and pencils respect the foreground color so that painting black
+ * adds the overlay and painting white removes it — matching the user
+ * expectation for quick-mask editing. Eraser keeps its existing semantics
+ * (always paints black into the mask).
+ */
+export function getQuickMaskPaintMode(
+  tool: QuickMaskPaintTool,
+  color: Color,
+): 0 | 1 {
+  if (tool === 'eraser') return 1;
+  return isLightColor(color) ? 0 : 1;
+}
+
+function isLightColor(color: Color): boolean {
+  const luminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+  return luminance >= 128;
+}


### PR DESCRIPTION
## Summary

Fixes #521. In Quick Mask Mode, both a black brush and a white brush were removing the blue overlay (growing the selection). The brush ignored the foreground color and always painted white into the mask.

- New `getQuickMaskPaintMode(tool, color)` helper picks the mode based on perceptual luminance: dark foreground → paint black into the mask (shrink selection / add overlay); light foreground → paint white (grow selection / remove overlay).
- `paint-handlers.ts` routes both quick-mask call sites (`handlePaintDown` and `handleMaskPaintMoveUnified`) through the helper.
- Eraser keeps its existing semantics (always paints black into the mask).

## Tests

- New unit test `src/app/interactions/quick-mask-paint.test.ts` — 10 cases covering black/white/gray, near-black/near-white, saturated red/green/blue, brush/pencil/eraser.
- Two existing e2e tests in `quick-mask.spec.ts` assumed the default black brush would grow the selection; updated them to set `foreground=white` explicitly before painting.
- New e2e test `Quick Mask brush color controls add/remove of the overlay (issue #521)` exercises the fixed behavior end-to-end.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 89 files, 907 tests pass
- [x] `npm run lint` — 0 errors (warnings unchanged from baseline)
- [ ] Manual: enter quick mask, brush with black foreground → overlay appears; switch to white → overlay erases

https://claude.ai/code/session_01EvkAoJXZXqzUYy745HBVGV