### PR TITLE
fix(layers): rasterize-text position drift + group effects pass-through

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -45,7 +45,7 @@ const ALLOWLIST = {
   'src/app/store/actions/resize-canvas.test.ts': 1,
   'src/app/store/actions/resize-image.test.ts': 1,
   'src/engine-wasm/engine-sync.test.ts': 3,
-  'src/engine-wasm/sync-layers.test.ts': 5,
+  'src/engine-wasm/sync-layers.test.ts': 6,
   'src/engine/pixel-data-manager.test.ts': 2,
   'src/engine/pixel-data.test.ts': 1,
   'src/filters/auto-enhance.test.ts': 1,

--- a/src/app/store/actions/resolve-raster-text-bounds.test.ts
+++ b/src/app/store/actions/resolve-raster-text-bounds.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRasterTextBounds } from './resolve-raster-text-bounds';
+
+describe('resolveRasterTextBounds', () => {
+  it('prefers engine bounds when they are valid', () => {
+    const result = resolveRasterTextBounds([50, 60, 200, 150], 0, 0, 100, 100);
+    expect(result).toEqual({ x: 50, y: 60, width: 200, height: 150 });
+  });
+
+  it('handles Int32Array engine bounds', () => {
+    const bounds = new Int32Array([10, 20, 64, 32]);
+    const result = resolveRasterTextBounds(bounds, 0, 0, 100, 100);
+    expect(result).toEqual({ x: 10, y: 20, width: 64, height: 32 });
+  });
+
+  it('falls back to JS coordinates when engine returns empty', () => {
+    const result = resolveRasterTextBounds([], 25, 35, 100, 80);
+    expect(result).toEqual({ x: 25, y: 35, width: 100, height: 80 });
+  });
+
+  it('falls back to JS coordinates when engine returns null', () => {
+    const result = resolveRasterTextBounds(null, 25, 35, 100, 80);
+    expect(result).toEqual({ x: 25, y: 35, width: 100, height: 80 });
+  });
+
+  it('falls back when engine reports zero-sized bounds', () => {
+    const result = resolveRasterTextBounds([0, 0, 0, 0], 25, 35, 100, 80);
+    expect(result).toEqual({ x: 25, y: 35, width: 100, height: 80 });
+  });
+
+  it('returns null when engine bounds invalid AND fallback dims are zero', () => {
+    expect(resolveRasterTextBounds([], 25, 35, 0, 0)).toBeNull();
+    expect(resolveRasterTextBounds(null, 25, 35, 0, 100)).toBeNull();
+    expect(resolveRasterTextBounds(null, 25, 35, 100, 0)).toBeNull();
+  });
+
+  it('returns null when engine bounds have wrong length', () => {
+    const result = resolveRasterTextBounds([1, 2, 3], 0, 0, 0, 0);
+    expect(result).toBeNull();
+  });
+
+  it('engine bounds with negative origin (texture shifted outside canvas) are preserved', () => {
+    const result = resolveRasterTextBounds([-10, -20, 200, 200], 0, 0, 100, 100);
+    expect(result).toEqual({ x: -10, y: -20, width: 200, height: 200 });
+  });
+});

--- a/src/app/store/actions/resolve-raster-text-bounds.ts
+++ b/src/app/store/actions/resolve-raster-text-bounds.ts
@@ -1,0 +1,35 @@
+export interface RasterTextBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Pick the authoritative bounds for converting a text layer to a raster
+ *  layer. After GPU operations such as `ensure_layer_full_size` (fill,
+ *  gradient, brush…) the engine-side x/y/width/height can diverge from
+ *  the JS-tracked values. When the engine reports valid bounds, those
+ *  win; otherwise we fall back to the JS-tracked position combined with
+ *  the texture dimensions. */
+export function resolveRasterTextBounds(
+  engineBounds: readonly number[] | Int32Array | null | undefined,
+  fallbackX: number,
+  fallbackY: number,
+  fallbackWidth: number,
+  fallbackHeight: number,
+): RasterTextBounds | null {
+  if (engineBounds && engineBounds.length === 4) {
+    const w = engineBounds[2] ?? 0;
+    const h = engineBounds[3] ?? 0;
+    if (w > 0 && h > 0) {
+      return {
+        x: engineBounds[0] ?? 0,
+        y: engineBounds[1] ?? 0,
+        width: w,
+        height: h,
+      };
+    }
+  }
+  if (fallbackWidth <= 0 || fallbackHeight <= 0) return null;
+  return { x: fallbackX, y: fallbackY, width: fallbackWidth, height: fallbackHeight };
+}

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -9,7 +9,7 @@ import { sparseToImageData } from '../../engine/canvas-ops';
 import { readLayerAsImageData } from '../../engine-wasm/gpu-pixel-access';
 import { getEngine, clearEngine } from '../../engine-wasm/engine-state';
 import { flushLayerSync } from '../../engine-wasm/engine-sync';
-import { uploadLayerPixels, getLayerTextureDimensions, removeTextLayerState } from '../../engine-wasm/wasm-bridge';
+import { uploadLayerPixels, getLayerTextureDimensions, getLayerEngineBounds, removeTextLayerState } from '../../engine-wasm/wasm-bridge';
 import { invalidateBitmapCache } from '../../engine/bitmap-cache';
 import { pixelDataManager } from '../../engine/pixel-data-manager';
 import type { ActionResult, SliceCreator, SparseLayerEntry } from './types';
@@ -27,6 +27,7 @@ import { computeDuplicateLayer } from './actions/duplicate-layer';
 import { computeMergeDown } from './actions/merge-down';
 import { computeFlattenImage } from './actions/flatten-image';
 import { computeRasterizeStyle } from './actions/rasterize-style';
+import { resolveRasterTextBounds } from './actions/resolve-raster-text-bounds';
 import { computeCropCanvas } from './actions/crop-canvas';
 import { computeResizeCanvas } from './actions/resize-canvas';
 import { computeResizeImage } from './actions/resize-image';
@@ -581,9 +582,15 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     if (!engine) return;
 
     const dims = getLayerTextureDimensions(engine, activeId);
-    const w = dims[0] ?? 0;
-    const h = dims[1] ?? 0;
-    if (w === 0 || h === 0) return;
+    const engineBounds = getLayerEngineBounds(engine, activeId);
+    const bounds = resolveRasterTextBounds(
+      engineBounds,
+      layer.x,
+      layer.y,
+      dims[0] ?? 0,
+      dims[1] ?? 0,
+    );
+    if (!bounds) return;
 
     s.pushHistory('Rasterize Layer');
     set({
@@ -599,13 +606,13 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
                 locked: l.locked,
                 opacity: l.opacity,
                 blendMode: l.blendMode,
-                x: l.x,
-                y: l.y,
+                x: bounds.x,
+                y: bounds.y,
                 clipToBelow: l.clipToBelow,
                 effects: l.effects,
                 mask: l.mask,
-                width: w,
-                height: h,
+                width: bounds.width,
+                height: bounds.height,
               }
             : l,
         ),

--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -14,7 +14,7 @@ vi.mock('./wasm-bridge', () => ({
   removeLayerMask: vi.fn(),
 }));
 
-const { layerToDescJson, buildPassThroughOpacityMap, syncLayers } = await import('./sync-layers');
+const { layerToDescJson, buildPassThroughOpacityMap, syncLayers, isPassThroughGroup } = await import('./sync-layers');
 const { DEFAULT_EFFECTS, createGroupLayer } = await import('../layers/layer-model');
 const { buildLayerIndex } = await import('../layers/layer-index');
 const bridge = await import('./wasm-bridge');
@@ -354,6 +354,63 @@ describe('layerToDescJson — pass-through blend mode', () => {
     const child: RasterLayer = { ...baseRasterLayer, opacity: 0.7 };
     const desc = JSON.parse(layerToDescJson(child, true, 1.0));
     expect(desc.opacity).toBeCloseTo(0.7);
+  });
+});
+
+describe('isPassThroughGroup — issue #523', () => {
+  it('reports true for a vanilla pass-through group', () => {
+    expect(isPassThroughGroup(baseGroup)).toBe(true);
+  });
+
+  it('reports false for non-group layers', () => {
+    expect(isPassThroughGroup(baseRasterLayer)).toBe(false);
+  });
+
+  it('reports false for groups with blendMode !== pass-through', () => {
+    expect(isPassThroughGroup({ ...baseGroup, blendMode: 'normal' })).toBe(false);
+    expect(isPassThroughGroup({ ...baseGroup, blendMode: 'multiply' })).toBe(false);
+  });
+
+  it('reports false when adjustments are enabled and present', () => {
+    const adjGroup: GroupLayer = {
+      ...baseGroup,
+      adjustments: [{ id: 'a', type: 'exposure', exposure: 0.5 }] as unknown as GroupLayer['adjustments'],
+      adjustmentsEnabled: true,
+    };
+    expect(isPassThroughGroup(adjGroup)).toBe(false);
+  });
+
+  it('reports true when adjustments array is empty even if adjustmentsEnabled', () => {
+    expect(isPassThroughGroup({ ...baseGroup, adjustmentsEnabled: true, adjustments: [] })).toBe(true);
+  });
+
+  it('reports false when a mask is enabled', () => {
+    const maskedGroup: GroupLayer = {
+      ...baseGroup,
+      mask: { id: 'mask-pt', data: new Uint8ClampedArray(4), width: 2, height: 2, enabled: true },
+    };
+    expect(isPassThroughGroup(maskedGroup)).toBe(false);
+  });
+
+  it('reports false when any layer effect is enabled (drop shadow)', () => {
+    const withShadow: GroupLayer = {
+      ...baseGroup,
+      effects: { ...DEFAULT_EFFECTS, dropShadow: { ...DEFAULT_EFFECTS.dropShadow, enabled: true } },
+    };
+    expect(isPassThroughGroup(withShadow)).toBe(false);
+  });
+
+  it('reports false when stroke or outer glow effect is enabled', () => {
+    const withStroke: GroupLayer = {
+      ...baseGroup,
+      effects: { ...DEFAULT_EFFECTS, stroke: { ...DEFAULT_EFFECTS.stroke, enabled: true } },
+    };
+    const withGlow: GroupLayer = {
+      ...baseGroup,
+      effects: { ...DEFAULT_EFFECTS, outerGlow: { ...DEFAULT_EFFECTS.outerGlow, enabled: true } },
+    };
+    expect(isPassThroughGroup(withStroke)).toBe(false);
+    expect(isPassThroughGroup(withGlow)).toBe(false);
   });
 });
 

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -13,6 +13,7 @@ import type { Layer, GroupLayer } from '../types';
 import { pixelDataManager } from '../engine/pixel-data-manager';
 import { buildLayerIndex, isEffectivelyVisible, type LayerIndex } from '../layers/layer-index';
 import { BLEND_MODE_TO_PASCAL as BLEND_MODE_MAP } from '../types/blend-mode-tables';
+import { hasEnabledEffects } from '../layers/layer-model';
 import {
   addLayer,
   removeLayer,
@@ -40,7 +41,7 @@ export function layerToDescJson(
   passThroughOpacityMultiplier = 1.0,
   /** For pass-through groups: send empty children so the Rust compositor
    *  doesn't route descendants into a group scratch FBO. */
-  isPassThroughGroup = false,
+  isPassThrough = false,
 ): string {
   const effects: Record<string, unknown> = {};
 
@@ -134,10 +135,27 @@ export function layerToDescJson(
     // routes descendants into a group-scratch FBO. The children blend
     // directly onto the parent composite using their own blend modes and
     // the accumulated opacity from this group.
-    desc.children = isPassThroughGroup ? [] : (layer as GroupLayer).children;
+    desc.children = isPassThrough ? [] : (layer as GroupLayer).children;
   }
 
   return JSON.stringify(desc);
+}
+
+/**
+ * A group renders as true pass-through only when nothing about the group
+ * itself needs a composited output to operate on. Adjustments, masks, and
+ * layer effects (drop shadow, glow, stroke, color overlay) all require the
+ * group's children to be pre-composited into a scratch FBO so the effect
+ * can apply to the combined result — otherwise the effect has nothing to
+ * attach to and silently no-ops (issue #523).
+ */
+export function isPassThroughGroup(layer: Layer): boolean {
+  if (layer.type !== 'group' || layer.blendMode !== 'pass-through') return false;
+  const group = layer as GroupLayer;
+  if (group.adjustmentsEnabled && group.adjustments.length > 0) return false;
+  if (group.mask?.enabled) return false;
+  if (hasEnabledEffects(group.effects)) return false;
+  return true;
 }
 
 /**
@@ -229,9 +247,7 @@ export function syncLayers(
   // Add or update layers
   for (const layer of layers) {
     const effectiveVisible = isEffectivelyVisible(index, layer.id);
-    const isPassThrough = layer.type === 'group' && layer.blendMode === 'pass-through' &&
-      !((layer as GroupLayer).adjustmentsEnabled && (layer as GroupLayer).adjustments.length > 0) &&
-      !(layer.mask?.enabled);
+    const isPassThrough = isPassThroughGroup(layer);
     const opacityMultiplier = passThroughOpacity.get(layer.id) ?? 1.0;
 
     // Fast path: if both the layer reference and its effective visibility


### PR DESCRIPTION
## Summary

Two unrelated layer-compositing bugs surfaced by the autofix pass.

### #496 — Rasterize Layer moves text to 0,0 when stepping through undo/redo

`rasterizeTextLayer` (`src/app/store/document-slice.ts`) was reading `layer.x` / `layer.y` from the JS store and `width` / `height` from `getLayerTextureDimensions`. But prior GPU operations that go through `ensure_layer_full_size` (fill, brush, gradient, smudge, sponge, filter…) can expand the layer's texture and shift `desc.x` / `desc.y` on the Rust side without notifying JS. Using the stale JS position with the now-bigger texture placed the rasterized layer at the wrong document coordinates, so the text appeared to jump on the rasterize step in the undo stack.

Same failure mode as the gradient-tool bug fixed in #503.

**Fix:** read `getLayerEngineBounds` and use those `(x, y, w, h)` when valid, falling back to JS coordinates + texture dimensions when the engine has no record of the layer. Pure helper `resolveRasterTextBounds` extracts the priority logic — 8 unit tests cover the cases (engine wins / fallback / mixed validity / negative origin / null + empty inputs).

### #523 — Group effects silently no-op for some child blend modes

`sync-layers.ts` classified a group as **pass-through** (children blend directly onto the parent composite, no group scratch FBO) whenever its blend mode was `pass-through` AND it had no enabled adjustments AND no mask. **Layer effects** (drop shadow, outer/inner glow, stroke, color overlay) were not part of the routing decision.

Result: enabling an effect on a pass-through group had no composited intermediate buffer to attach to. The effect silently no-opped, and whether it appeared at all depended on what child blend modes happened to coexist.

**Fix:** extract the routing decision into a named `isPassThroughGroup` helper and add the effects check alongside the adjustments and mask checks. Renames an internal parameter to remove name-shadowing with the new helper. 8 unit tests cover the new condition matrix.

## Tests

- New `resolve-raster-text-bounds.test.ts` — 8 cases (engine wins / Int32Array / engine empty + fallback / engine null / engine zero-sized / null+zero fallback returns null / wrong-length array / negative origin preserved).
- `sync-layers.test.ts` gains an `isPassThroughGroup` describe — 8 cases (vanilla pass-through / non-group / non-pass-through blend mode / adjustments enabled / empty adjustments still pass-through / mask enabled / drop shadow enabled / stroke + glow enabled).
- Pixel-debt budget for `sync-layers.test.ts` bumped 5 → 6 to allow the new mask test buffer.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors, pixel-debt OK
- [x] `npm run test` — 90 files, 923 tests pass
- [ ] Manual #496: open a 100×100 doc, add text, draw on the text layer (forces `ensure_layer_full_size`), rasterize, step undo/redo — text stays put
- [ ] Manual #523: add a group with a child, enable drop shadow on the group — shadow renders regardless of child blend mode

https://claude.ai/code/session_01HdYCKqd8SM8vspvw7xU5Ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdYCKqd8SM8vspvw7xU5Ra)_