### PR TITLE
fix(viewport): reset zoom to fit canvas on new document

### DIFF
--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -233,6 +233,7 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);
     }
     useUIStore.getState().clearGuides();
+    get().fitToView();
   },
 
   openImageAsDocument: (imageData, name) => {


### PR DESCRIPTION
## Summary
- `createDocument` was the only document-loading path that didn't call `fitToView()`, so creating a new file while one was already open kept the previous document's zoom and pan instead of fitting to the new canvas size.
- Added `get().fitToView()` at the end of `createDocument` in `document-slice.ts`, matching the pattern used by Open, PSD import, DNG import, and project load.

## Test plan
- [ ] Open a large canvas (e.g. 4000x4000), zoom in
- [ ] File → New, create a small canvas (e.g. 500x500)
- [ ] Verify the viewport resets to fit the new canvas size
- [ ] Repeat in reverse (small → large) and confirm zoom adjusts

🤖 Generated with [Claude Code](https://claude.com/claude-code)