### PR TITLE
feat(emboss): stronger strength progression and labeled type toggle

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/filters/emboss.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/filters/emboss.glsl
@@ -4,7 +4,7 @@ precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_tex;
 uniform float u_angle;    // light direction in radians
-uniform float u_strength; // relief height 0.0 - 1.0
+uniform float u_strength; // relief depth 0.0 - 1.0
 uniform float u_type;     // 0.0 = emboss, 1.0 = pillow emboss
 
 out vec4 fragColor;
@@ -13,39 +13,26 @@ void main() {
     vec2 texel = 1.0 / vec2(textureSize(u_tex, 0));
     vec4 orig = texture(u_tex, v_uv);
 
-    float cosA = cos(u_angle);
-    float sinA = sin(u_angle);
-    vec2 lightDir = vec2(cosA, sinA);
+    vec2 lightDir = vec2(cos(u_angle), sin(u_angle));
 
-    // Sample 3x3 neighborhood luminances
-    float tl = dot(texture(u_tex, v_uv + vec2(-texel.x, -texel.y)).rgb, vec3(0.299, 0.587, 0.114));
-    float tc = dot(texture(u_tex, v_uv + vec2(0.0, -texel.y)).rgb, vec3(0.299, 0.587, 0.114));
-    float tr = dot(texture(u_tex, v_uv + vec2(texel.x, -texel.y)).rgb, vec3(0.299, 0.587, 0.114));
-    float ml = dot(texture(u_tex, v_uv + vec2(-texel.x, 0.0)).rgb, vec3(0.299, 0.587, 0.114));
-    float mr = dot(texture(u_tex, v_uv + vec2(texel.x, 0.0)).rgb, vec3(0.299, 0.587, 0.114));
-    float bl = dot(texture(u_tex, v_uv + vec2(-texel.x, texel.y)).rgb, vec3(0.299, 0.587, 0.114));
-    float bc = dot(texture(u_tex, v_uv + vec2(0.0, texel.y)).rgb, vec3(0.299, 0.587, 0.114));
-    float br = dot(texture(u_tex, v_uv + vec2(texel.x, texel.y)).rgb, vec3(0.299, 0.587, 0.114));
+    // Strength controls the sampling distance — wider offset = wider bevel.
+    // Quadratic curve so the upper half of the slider is more dramatic.
+    float t = u_strength * u_strength;
+    float radius = 1.0 + t * 20.0;
+    vec2 offset = lightDir * texel * radius;
 
-    // Sobel gradients
-    float gx = -tl - 2.0 * ml - bl + tr + 2.0 * mr + br;
-    float gy = -tl - 2.0 * tc - tr + bl + 2.0 * bc + br;
+    // Two-point directional luminance difference along the light vector.
+    // Max magnitude is bounded by the luminance range (0–1) so it won't
+    // clip the way a Sobel kernel does.
+    vec3 lumW = vec3(0.299, 0.587, 0.114);
+    float lumFwd = dot(texture(u_tex, v_uv + offset).rgb, lumW);
+    float lumBwd = dot(texture(u_tex, v_uv - offset).rgb, lumW);
+    float diff = lumFwd - lumBwd;
 
-    // Directional emboss: dot product of gradient with light direction
-    float emboss = dot(vec2(gx, gy), lightDir) * u_strength;
+    // Normal emboss: directional (highlight one side, shadow the other).
+    // Pillow emboss: raised ridges along all edges (highlights both sides).
+    float emboss = (u_type > 0.5 ? abs(diff) : diff) * 0.75;
 
-    if (u_type > 0.5) {
-        // Pillow emboss: fade the relief toward the edges of opaque regions
-        // so the object looks like a raised pillow
-        float center = dot(orig.rgb, vec3(0.299, 0.587, 0.114));
-        float avgSurround = (tl + tc + tr + ml + mr + bl + bc + br) / 8.0;
-        float edgeFade = clamp(abs(center - avgSurround) * 8.0, 0.0, 1.0);
-        emboss *= (1.0 - edgeFade * 0.6);
-    }
-
-    // Blend emboss highlight/shadow onto original color
-    vec3 result = orig.rgb + vec3(emboss);
-    result = clamp(result, 0.0, 1.0);
-
+    vec3 result = clamp(orig.rgb + vec3(emboss), 0.0, 1.0);
     fragColor = vec4(result, orig.a);
 }

--- a/src/components/FilterDialog/FilterDialog.module.css
+++ b/src/components/FilterDialog/FilterDialog.module.css
@@ -63,6 +63,39 @@
   font-weight: 500;
 }
 
+.toggleGroup {
+  display: flex;
+  gap: 1px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+
+.toggleOption {
+  flex: 1;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.toggleOption:hover {
+  background: var(--color-bg-hover);
+}
+
+.toggleOptionActive {
+  background: var(--color-accent);
+  color: var(--color-text-on-accent, #fff);
+}
+
+.toggleOptionActive:hover {
+  background: var(--color-accent);
+}
+
 .footer {
   display: flex;
   align-items: center;

--- a/src/components/FilterDialog/FilterDialog.tsx
+++ b/src/components/FilterDialog/FilterDialog.tsx
@@ -15,6 +15,8 @@ interface FilterParam {
   defaultValue: number;
   /** When 'doc', max scales to 1.5x max(docW, docH) capped at 5000, with `max` as the floor. */
   dynamicMax?: 'doc';
+  /** When provided, renders a segmented toggle instead of a slider. */
+  options?: { value: number; label: string }[];
 }
 
 interface FilterDialogProps {
@@ -126,6 +128,26 @@ export function FilterDialog({ title, params, showRegenerate, onApply, onCancel,
         </div>
         <div className={styles.body}>
           {params.map((param) => {
+            if (param.options) {
+              const current = values[param.key] ?? param.defaultValue;
+              return (
+                <div key={param.key} className={styles.paramRow}>
+                  <span className={styles.paramLabel}>{param.label}</span>
+                  <div className={styles.toggleGroup}>
+                    {param.options.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        className={`${styles.toggleOption}${current === opt.value ? ` ${styles.toggleOptionActive}` : ''}`}
+                        onClick={() => handleChange(param.key, opt.value)}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            }
             const max = param.dynamicMax === 'doc'
               ? docScaledMax(docWidth, docHeight, param.max)
               : param.max;

--- a/src/filters/emboss.ts
+++ b/src/filters/emboss.ts
@@ -7,7 +7,7 @@ export const emboss: FilterDefinition = {
   params: [
     { key: 'angle', label: 'Angle', min: 0, max: 360, step: 1, defaultValue: 135 },
     { key: 'strength', label: 'Strength', min: 1, max: 100, step: 1, defaultValue: 50 },
-    { key: 'type', label: 'Type', min: 0, max: 1, step: 1, defaultValue: 0 },
+    { key: 'type', label: 'Type', min: 0, max: 1, step: 1, defaultValue: 0, options: [{ value: 0, label: 'Emboss' }, { value: 1, label: 'Pillow Emboss' }] },
   ],
   applyGpu: (engine, layerId, values) =>
     filterEmboss(


### PR DESCRIPTION
## Summary
- **Strength now controls bevel width** via quadratic-curved sampling radius instead of just amplifying a Sobel gradient that clips early. The full 1–100 slider range produces visibly progressive results.
- **Shader rewritten** from Sobel kernel to two-point directional luminance sampling — bounded output that doesn't saturate at edges.
- **Type toggle** renders as a labeled segmented control ("Emboss" / "Pillow Emboss") instead of a meaningless 0/1 slider. Powered by a new `options` field on `FilterParam`, reusable by other filters.
- **Pillow emboss** now uses `abs(diff)` for raised-ridge highlights on both sides of edges, visually distinct from normal directional emboss.

## Test plan
- [x] Unit tests pass (931/931)
- [x] TypeScript typecheck clean
- [x] Lint clean (0 errors)
- [ ] Open emboss dialog → verify toggle shows "Emboss" / "Pillow Emboss" labels
- [ ] Drag strength from 1 → 100 with preview on — confirm progressive bevel widening
- [ ] Toggle between Emboss and Pillow Emboss — confirm visible difference
- [ ] Test on textured/photographic content for best results

🤖 Generated with [Claude Code](https://claude.com/claude-code)