### PR TITLE
refactor(interactions): move _usedGpuStroke into CanvasGesture variant (#444)

### DIFF
--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  gestureUsedGpuStroke,
+  GESTURE_IDLE,
+  type CanvasGesture,
+} from './interaction-types';
+
+describe('gestureUsedGpuStroke', () => {
+  it('returns false for idle gesture', () => {
+    expect(gestureUsedGpuStroke(GESTURE_IDLE)).toBe(false);
+  });
+
+  it('returns true for tool gesture with usedGpuStroke=true', () => {
+    const g: CanvasGesture = { kind: 'tool', usedGpuStroke: true };
+    expect(gestureUsedGpuStroke(g)).toBe(true);
+  });
+
+  it('returns false for tool gesture with usedGpuStroke=false', () => {
+    const g: CanvasGesture = { kind: 'tool', usedGpuStroke: false };
+    expect(gestureUsedGpuStroke(g)).toBe(false);
+  });
+
+  it('returns false for non-tool gestures regardless of context', () => {
+    const gestures: CanvasGesture[] = [
+      { kind: 'idle' },
+      { kind: 'liquify' },
+      { kind: 'tiltShift' },
+      { kind: 'meshWarp' },
+      { kind: 'transform' },
+    ];
+    for (const g of gestures) {
+      expect(gestureUsedGpuStroke(g)).toBe(false);
+    }
+  });
+});

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -12,11 +12,22 @@ import type { PixelBuffer, MaskedPixelBuffer } from '../../engine/pixel-data';
  */
 export type CanvasGesture =
   | { kind: 'idle' }
-  | { kind: 'tool' }
+  | { kind: 'tool'; usedGpuStroke: boolean }
   | { kind: 'liquify' }
   | { kind: 'tiltShift' }
   | { kind: 'meshWarp' }
   | { kind: 'transform' };
+
+/**
+ * True when the active tool gesture is a paint stroke that started on
+ * the GPU path (brush/pencil/eraser with engine available, outside
+ * mask/quick-mask modes). Replaces the legacy `_usedGpuStroke?` flag
+ * on InteractionState. Lives on the gesture variant so it can't be
+ * set unless we're actually inside a `tool` gesture.
+ */
+export function gestureUsedGpuStroke(gesture: CanvasGesture): boolean {
+  return gesture.kind === 'tool' && gesture.usedGpuStroke;
+}
 
 export const GESTURE_IDLE: CanvasGesture = { kind: 'idle' };
 
@@ -39,7 +50,6 @@ export interface InteractionState {
   originalSelectionMask: Uint8ClampedArray | null;
   originalSelectionMaskWidth: number;
   originalSelectionMaskHeight: number;
-  _usedGpuStroke?: boolean;
   strokeDistance?: number;
   spacingRemainder?: number;
   symmetryCenter?: Point;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -26,6 +26,7 @@ import type {
   InteractionState, InteractionContext,
   FloatingSelection, PersistentTransform, LastPaintPoint,
 } from './interactions/interaction-types';
+import { gestureUsedGpuStroke } from './interactions/interaction-types';
 import { handleTransformDown } from './interactions/transform-handlers';
 import {
   handleMeshWarpDown,
@@ -330,8 +331,7 @@ export function useCanvasInteraction(
       const handler = toolHandlers[activeTool];
       const newState = handler?.down?.(ctx);
       if (newState) {
-        newState.gesture = { kind: 'tool' };
-        newState._usedGpuStroke = !!useGpuStroke;
+        newState.gesture = { kind: 'tool', usedGpuStroke: !!useGpuStroke };
         stateRef.current = newState;
       }
     },
@@ -396,7 +396,7 @@ export function useCanvasInteraction(
       // If the cursor stays still (no new mousemove) for HOLD_TIMEOUT_MS, smooth.
       if (
         state.tool === 'brush'
-        && state._usedGpuStroke
+        && gestureUsedGpuStroke(state.gesture)
         && state.strokePoints
         && state.strokePoints.length >= 3
         && state.layerId
@@ -564,7 +564,7 @@ export function useCanvasInteraction(
     // pushHistory falls through to a synchronous readback.
     if (PAINT_TOOLS.has(state.tool) && state.layerId && !state.maskMode) {
       const engine = getEngine();
-      if (engine && state._usedGpuStroke) {
+      if (engine && gestureUsedGpuStroke(state.gesture)) {
         endStroke(engine, state.layerId);
         clearJsPixelData(state.layerId);
         useEditorStore.getState().notifyRender();


### PR DESCRIPTION
## Summary

Incremental progress on #444 — eliminates the `_usedGpuStroke?: boolean` field that the audit issue specifically called out as "the smell that named it" (underscore-prefixed admission that it was a hack, set via direct mutation of a tool-handler's freshly-returned state object).

Per the issue's acceptance criteria:
> `_usedGpuStroke` field deleted; replaced by a required field on the `painting` variant.

This PR does exactly that. The field is now `usedGpuStroke: boolean` on the `{ kind: 'tool', ... }` variant of `CanvasGesture`, where it structurally cannot be set unless the gesture is actually a tool gesture. A typed `gestureUsedGpuStroke(gesture)` helper handles the two read sites in `useCanvasInteraction.ts`.

The other acceptance items (full `CanvasGesture`-replaces-`InteractionState` migration, no-mutation rule, switch-instead-of-if-ladders across all phases) remain in scope on the audit issue.

## Changes

- `src/app/interactions/interaction-types.ts`:
  - `CanvasGesture['tool']` now carries `usedGpuStroke: boolean`.
  - New `gestureUsedGpuStroke(gesture)` helper.
  - Removed `_usedGpuStroke?: boolean` from `InteractionState`.
- `src/app/useCanvasInteraction.ts`:
  - Single write site collapses to one gesture assignment.
  - Two read sites use the new helper.
- New unit test file covering the helper across all `CanvasGesture` variants.

## Test plan

- [x] `npm run typecheck` — clean (pre-existing baseUrl deprecation warning unchanged)
- [x] `npm run test` — 935/935 pass (4 new tests added)
- [x] `npm run lint` — 0 errors

Refs #444.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY3FzBpfCzsweSm68T59q8)_