### PR TITLE
refactor(interactions): move transform fields onto CanvasGesture variant (#444)

### DIFF
--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -5,6 +5,15 @@ import {
   type CanvasGesture,
   type InteractionState,
 } from './interaction-types';
+import { createTransformState } from '../../tools/transform/transform';
+
+const makeTransformGesture = (): Extract<CanvasGesture, { kind: 'transform' }> => ({
+  kind: 'transform',
+  handle: 'top-left',
+  startState: createTransformState({ x: 0, y: 0, width: 100, height: 100 }),
+  startAngle: 0,
+  selectionOnly: false,
+});
 
 describe('gestureUsedGpuStroke', () => {
   it('returns false for idle gesture', () => {
@@ -27,7 +36,7 @@ describe('gestureUsedGpuStroke', () => {
       { kind: 'liquify' },
       { kind: 'tiltShift' },
       { kind: 'meshWarp' },
-      { kind: 'transform' },
+      makeTransformGesture(),
     ];
     for (const g of gestures) {
       expect(gestureUsedGpuStroke(g)).toBe(false);
@@ -36,14 +45,45 @@ describe('gestureUsedGpuStroke', () => {
 });
 
 describe('InteractionState shape', () => {
-  // Locks in the invariant that the gesture discriminant — not a parallel
-  // set of bag-of-flags booleans — is the single source of truth for which
-  // gesture is active. A regression here means we're re-growing the
-  // bag-of-flags pattern the #444 audit is unwinding.
   it('does not carry redundant per-gesture boolean flags', () => {
     type ForbiddenKeys = 'tiltShiftDragging' | 'meshWarpDragging';
     type Asserts = Exclude<ForbiddenKeys, keyof InteractionState>;
     const exhaustive: Asserts = 'tiltShiftDragging' as const;
     expect(exhaustive).toBe('tiltShiftDragging');
+  });
+});
+
+describe('CanvasGesture transform variant ownership', () => {
+  type ForbiddenKeys =
+    | 'transformHandle'
+    | 'transformStartState'
+    | 'transformStartAngle'
+    | 'selectionOnlyTransform';
+
+  type Leaked = Extract<keyof InteractionState, ForbiddenKeys>;
+
+  const _check: Leaked extends never ? true : false = true;
+
+  it('keeps transform metadata off the shared InteractionState', () => {
+    expect(_check).toBe(true);
+  });
+
+  it('carries handle/startState/startAngle/selectionOnly on the variant', () => {
+    const gesture = makeTransformGesture();
+    expect(gesture.handle).toBe('top-left');
+    expect(gesture.startState.scaleX).toBe(1);
+    expect(gesture.startAngle).toBe(0);
+    expect(gesture.selectionOnly).toBe(false);
+  });
+
+  it('narrows variant data via the discriminant without non-null assertions', () => {
+    const gesture: CanvasGesture = makeTransformGesture();
+    if (gesture.kind !== 'transform') {
+      throw new Error('expected transform gesture');
+    }
+    const handle: string = gesture.handle;
+    const startAngle: number = gesture.startAngle;
+    expect(handle).toBe('top-left');
+    expect(startAngle).toBe(0);
   });
 });

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -6,11 +6,14 @@ import type { PixelBuffer, MaskedPixelBuffer } from '../../engine/pixel-data';
 /**
  * Discriminated union describing which canvas gesture is active.
  * Replaces the previous bag-of-flags pattern where mutually-exclusive
- * states like `tiltShiftDragging` and `meshWarpDragging` could be set
- * independently (and could conceptually both be true at once). The
- * `kind` discriminant is the single source of truth for which gesture
- * is active and lets `switch` dispatch in the move/up handlers with
- * compile-time exhaustiveness checking.
+ * states like `tiltShiftDragging` and `meshWarpDragging` could both
+ * be true. The `kind` discriminant lets `switch` dispatch in the
+ * move/up handlers with compile-time exhaustiveness checking.
+ *
+ * Per-gesture data lives on its variant so the type system guarantees
+ * the data is present whenever the discriminant says so — handlers can
+ * narrow on `kind` and drop the `!` non-null assertions that the old
+ * bag-of-flags shape forced (see transform-handlers.ts).
  */
 export type CanvasGesture =
   | { kind: 'idle' }
@@ -18,7 +21,13 @@ export type CanvasGesture =
   | { kind: 'liquify' }
   | { kind: 'tiltShift' }
   | { kind: 'meshWarp' }
-  | { kind: 'transform' };
+  | {
+      kind: 'transform';
+      handle: TransformHandle;
+      startState: TransformState;
+      startAngle: number;
+      selectionOnly: boolean;
+    };
 
 /**
  * True when the active tool gesture is a paint stroke that started on
@@ -46,9 +55,6 @@ export interface InteractionState {
   layerStartY: number;
   maskMode: boolean;
   quickMaskMode?: boolean;
-  transformHandle: TransformHandle | null;
-  transformStartState: TransformState | null;
-  transformStartAngle: number;
   originalSelectionMask: Uint8ClampedArray | null;
   originalSelectionMaskWidth: number;
   originalSelectionMaskHeight: number;
@@ -80,15 +86,11 @@ export interface InteractionState {
   quickMaskOriginalPixels?: Uint8Array | null;
   quickMaskOriginalWidth?: number;
   quickMaskOriginalHeight?: number;
-  selectionOnlyTransform?: boolean;
 }
 
 export const DEFAULT_TRANSFORM_FIELDS = {
   gesture: GESTURE_IDLE as CanvasGesture,
   maskMode: false,
-  transformHandle: null as TransformHandle | null,
-  transformStartState: null as TransformState | null,
-  transformStartAngle: 0,
   originalSelectionMask: null as Uint8ClampedArray | null,
   originalSelectionMaskWidth: 0,
   originalSelectionMaskHeight: 0,

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -27,7 +27,7 @@ import {
   dropFloat,
 } from '../../engine-wasm/wasm-bridge';
 import { selectLayerAlpha } from '../../panels/LayerPanel/layer-selection';
-import type { InteractionState, InteractionContext } from './interaction-types';
+import type { InteractionState, InteractionContext, CanvasGesture } from './interaction-types';
 import type { Point } from '../../types';
 import {
   createRectSelection,
@@ -153,7 +153,13 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
 
   const newState: InteractionState = {
     drawing: true,
-    gesture: { kind: 'transform' },
+    gesture: {
+      kind: 'transform',
+      handle: hit,
+      startState: { ...currentTransform },
+      startAngle,
+      selectionOnly: false,
+    },
     lastPoint: canvasPos,
     pixelBuffer: null,
     originalPixelBuffer: null,
@@ -163,9 +169,6 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
     layerStartX: 0,
     layerStartY: 0,
     maskMode: false,
-    transformHandle: hit,
-    transformStartState: { ...currentTransform },
-    transformStartAngle: startAngle,
     originalSelectionMask: persistent?.originalMask ?? null,
     originalSelectionMaskWidth: persistent?.maskWidth ?? 0,
     originalSelectionMaskHeight: persistent?.maskHeight ?? 0,
@@ -203,7 +206,13 @@ function handleSelectionTransformDown(
 
   const newState: InteractionState = {
     drawing: true,
-    gesture: { kind: 'transform' },
+    gesture: {
+      kind: 'transform',
+      handle: hit,
+      startState: { ...currentTransform },
+      startAngle: 0,
+      selectionOnly: true,
+    },
     lastPoint: canvasPos,
     pixelBuffer: null,
     originalPixelBuffer: null,
@@ -213,15 +222,11 @@ function handleSelectionTransformDown(
     layerStartX: 0,
     layerStartY: 0,
     maskMode: false,
-    transformHandle: hit,
-    transformStartState: { ...currentTransform },
-    transformStartAngle: 0,
     originalSelectionMask: null,
     originalSelectionMaskWidth: 0,
     originalSelectionMaskHeight: 0,
     moveOriginalMask: null,
     moveOriginalBounds: null,
-    selectionOnlyTransform: true,
   };
 
   uiState.setActiveTransformHandle(hit);
@@ -238,17 +243,17 @@ export function handleTransformMove(
   canvasPos: Point,
   metaKey: boolean,
 ): void {
-  if (!state.transformHandle || !state.transformStartState || !state.startPoint) {
+  if (state.gesture.kind !== 'transform' || !state.startPoint) {
     return;
   }
 
-  if (state.selectionOnlyTransform) {
-    handleSelectionTransformMove(state, canvasPos, metaKey);
+  if (state.gesture.selectionOnly) {
+    handleSelectionTransformMove(state, state.gesture, canvasPos, metaKey);
     return;
   }
 
-  const handle = state.transformHandle;
-  const startState = state.transformStartState;
+  const handle = state.gesture.handle;
+  const startState = state.gesture.startState;
 
   let newTransform: TransformState;
 
@@ -289,7 +294,7 @@ export function handleTransformMove(
     };
   } else {
     const currentAngle = computeRotation(canvasPos, startState);
-    const newRotation = currentAngle - state.transformStartAngle;
+    const newRotation = currentAngle - state.gesture.startAngle;
     const uiState = useUIStore.getState();
     const shouldSnap = metaKey || (uiState.showGrid && uiState.snapToGrid);
     const snappedRotation = shouldSnap
@@ -335,11 +340,12 @@ export function handleTransformMove(
 
 function handleSelectionTransformMove(
   state: InteractionState,
+  gesture: Extract<CanvasGesture, { kind: 'transform' }>,
   canvasPos: Point,
   metaKey: boolean,
 ): void {
-  const handle = state.transformHandle!;
-  const startState = state.transformStartState!;
+  const handle = gesture.handle;
+  const startState = gesture.startState;
 
   const uiSnap = useUIStore.getState();
   const snapEnabled = uiSnap.showGrid && uiSnap.snapToGrid;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -102,9 +102,6 @@ const INITIAL_STATE: InteractionState = {
   layerStartX: 0,
   layerStartY: 0,
   maskMode: false,
-  transformHandle: null,
-  transformStartState: null,
-  transformStartAngle: 0,
   originalSelectionMask: null,
   originalSelectionMaskWidth: 0,
   originalSelectionMaskHeight: 0,
@@ -303,10 +300,12 @@ export function useCanvasInteraction(
         ctx.isStrokeContinuation = true;
       }
 
-      // Transform handle interaction (pre-tool dispatch)
+      // Transform handle interaction (pre-tool dispatch). The handler
+      // already populates `gesture` with the transform variant's required
+      // data (handle, startState, startAngle, selectionOnly), so no
+      // post-assignment mutation is needed here.
       const transformResult = handleTransformDown(ctx);
       if (transformResult) {
-        transformResult.gesture = { kind: 'transform' };
         stateRef.current = transformResult;
         return;
       }
@@ -586,7 +585,7 @@ export function useCanvasInteraction(
     // Finalize transform handle drag: keep the GPU float alive so subsequent
     // grabs can re-transform from the original pixels without degradation.
     // The float is only dropped when the user commits (clearPersistentTransform).
-    if (state.transformHandle) {
+    if (state.gesture.kind === 'transform') {
       useUIStore.getState().setActiveTransformHandle(null);
     }
 


### PR DESCRIPTION
## Summary

Incremental progress on the InteractionState tagged-union refactor (#444). Continues the per-variant migration pattern from PR #550 (`_usedGpuStroke` onto the `tool` variant) and PR #552 (deleting `tiltShiftDragging` / `meshWarpDragging`).

**Acceptance criterion addressed:**
> Reorganize per-tool fields under their variants — `stampOffsetRef`, `floatingSelectionRef`, `persistentTransformRef`, etc. live in the variants where they're meaningful, not as MutableRefObjects on a shared context.

...specifically for the transform gesture's per-gesture fields. `transformHandle`, `transformStartState`, `transformStartAngle`, and `selectionOnlyTransform` move from optional fields on the shared `InteractionState` into a single `{ kind: 'transform'; handle; startState; startAngle; selectionOnly }` variant of `CanvasGesture`.

### Why this is the right shape

The old shape had four optional fields that were only meaningful when the gesture was a transform gesture — exactly the bag-of-flags pattern the audit calls out. The discriminated variant encodes the invariant in the type: the transform fields are present iff `gesture.kind === 'transform'`.

This drops two `state.transformHandle!` / `state.transformStartState!` non-null assertions in `handleSelectionTransformMove` — the audit-issue smell that `!` admits the bag-of-flags shape was forcing.

It also incidentally pays down the no-mutation criterion for the transform path: `handleTransformDown` now returns a fully-populated transform variant directly, instead of returning a placeholder `gesture: { kind: 'transform' }` for `useCanvasInteraction.ts` to overwrite-mutate at line 311. One fewer post-assignment write on a freshly-returned handler state.

### Tests

The existing `gestureUsedGpuStroke` tests remain green (one updated to construct a transform gesture with its required data). A new test locks the invariant:

```ts
type ForbiddenKeys =
  | 'transformHandle'
  | 'transformStartState'
  | 'transformStartAngle'
  | 'selectionOnlyTransform';
type Leaked = Extract<keyof InteractionState, ForbiddenKeys>;
const _check: Leaked extends never ? true : false = true;
```

If any of the moved fields ever re-grow on the shared `InteractionState` — alongside the gesture variant that now owns them — TypeScript flags it at compile time.

All 938 unit tests pass. Typecheck clean. Lint clean (-2 non-null assertion warnings).

### Remaining acceptance criteria (still open)

- [ ] Per-variant migration of the remaining `MutableRefObject` fields on `InteractionContext` (`stampOffsetRef`, `floatingSelectionRef`, `persistentTransformRef`, `lastPaintPointRef`).
- [ ] No-mutation rule for the gesture object outside the dispatcher (transform path now clean; tool path at `useCanvasInteraction.ts:334` still mutates).
- [ ] Down-phase if-ladder (`useCanvasInteraction.ts:179-209`) → single switch. Structurally different from move/up since it constructs gestures rather than dispatching on them; needs its own design pass.

Closes part of #444.

## Test plan

- [x] `npm run test` — 938 / 938 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (2 fewer non-null-assertion warnings vs. main)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpUUdy7EXSKosdc5gWg1kt)_