### PR TITLE
docs(features): note Edit menu's Fill with Pattern entry

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -494,6 +494,7 @@ All 14 adjustment types now have first-class UI controls and are fully GPU-accel
 
 ### Fill from Menu
 - **Fill…** (Edit menu, `⇧F5`): opens a small modal that fills the current selection (or the entire layer if no selection) on the active layer with foreground color, background color, black, white, 50% gray, or a chosen pattern. Honors the selection mask and layer opacity.
+- **Fill with Pattern…** (Edit menu): opens the Pattern Fill dialog directly (same dialog as the Filter-menu entry — see Filters → Render → Pattern Fill for scale / offset / selection-mask behavior).
 - **Define Pattern** (Edit menu): captures the active layer's pixels as a reusable pattern (used by Fill… and the Pattern Fill filter)
 - **Define Brush…** / **Define Color Brush…** (Edit menu): captures the marquee selection as a new alpha or color brush tip (see Brush → Brush from Selection)
 


### PR DESCRIPTION
## Summary
- Scheduled-task audit of FEATURES.md vs recent commits and the menu definitions found one small gap: the Edit menu's **Fill with Pattern…** item (see [edit-menu.ts:50](src/app/MenuBar/menus/edit-menu.ts#L50)) was not surfaced under the **Fill from Menu** section. Pattern Fill itself is fully documented under Filters → Render, but the second entry point from Edit wasn't listed alongside Fill… / Define Pattern / Define Brush.

## Audit notes
Cross-checked FEATURES.md against the last two days of commits on `main` and the full menu/shortcut/tool source tree:
- Recent commits (#549 menu-shortcuts sweep, #550 internal refactor, #554 brush-modal accuracy) — all user-facing changes from #549 and #554 are already reflected in FEATURES.md; #550 is internal refactor with no user-facing surface.
- All tool subdirectories (brush, pencil, eraser, smudge, sponge, spray, dodge, stamp, healing, gradient, fill, eyedropper, move, crop, shape, path, text, marquee, lasso, magnetic-lasso, wand, quick-select, transform, liquify, smooth-line) are documented with their parameter ranges and modifier behaviors.
- Modifier-key behaviors (Cmd/Meta+drag aspect-lock on shape/marquee, Cmd+15°-snap on gradient/transform, Alt-drag duplicate on Move, Cmd+click anchor toggle on Path, Shift+click straight-line on all painting tools, Cmd+click symmetry-center reposition, Hold-to-smooth pause on Brush) all match the source.
- All menu items (File / Edit / Image / Layer / Select / Filter / View / Path) are covered except the one entry added here.

## Test plan
- [ ] Render FEATURES.md and confirm the new bullet sits naturally between Fill… and Define Pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)