### PR TITLE
refactor(interactions): no-mutation rule for tool down handlers (#444)

### DIFF
--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   gestureUsedGpuStroke,
+  withToolGesture,
   GESTURE_IDLE,
   INITIAL_INTERACTION_STATE,
   type CanvasGesture,
@@ -118,5 +119,59 @@ describe('PreToolDownGuard signature', () => {
     expect(claimed).not.toBeNull();
     expect(claimed?.layerId).toBe('layer-1');
     expect(claimed?.gesture.kind).toBe('liquify');
+  });
+});
+
+const makeBaseState = (overrides: Partial<InteractionState> = {}): InteractionState => ({
+  drawing: true,
+  gesture: GESTURE_IDLE,
+  lastPoint: null,
+  pixelBuffer: null,
+  originalPixelBuffer: null,
+  layerId: 'layer-1',
+  tool: 'brush',
+  startPoint: null,
+  layerStartX: 0,
+  layerStartY: 0,
+  maskMode: false,
+  originalSelectionMask: null,
+  originalSelectionMaskWidth: 0,
+  originalSelectionMaskHeight: 0,
+  moveOriginalMask: null,
+  moveOriginalBounds: null,
+  ...overrides,
+});
+
+describe('withToolGesture', () => {
+  it('returns a tool gesture with the given usedGpuStroke flag', () => {
+    const input = makeBaseState();
+    const output = withToolGesture(input, true);
+    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: true });
+  });
+
+  it('preserves non-gesture fields from the input', () => {
+    const input = makeBaseState({ layerId: 'abc', tool: 'pencil', drawing: true });
+    const output = withToolGesture(input, false);
+    expect(output.layerId).toBe('abc');
+    expect(output.tool).toBe('pencil');
+    expect(output.drawing).toBe(true);
+    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: false });
+  });
+
+  it('does not mutate the input state (no-mutation invariant from #444)', () => {
+    const input = Object.freeze(makeBaseState({ gesture: GESTURE_IDLE }));
+    const output = withToolGesture(input, true);
+    expect(input.gesture).toBe(GESTURE_IDLE);
+    expect(output).not.toBe(input);
+    expect(output.gesture).not.toBe(input.gesture);
+  });
+
+  it('does not mutate a previously-set tool gesture object', () => {
+    const priorGesture: CanvasGesture = { kind: 'tool', usedGpuStroke: false };
+    const input = makeBaseState({ gesture: priorGesture });
+    const output = withToolGesture(input, true);
+    expect(priorGesture).toEqual({ kind: 'tool', usedGpuStroke: false });
+    expect(output.gesture).not.toBe(priorGesture);
+    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: true });
   });
 });

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -40,6 +40,18 @@ export function gestureUsedGpuStroke(gesture: CanvasGesture): boolean {
   return gesture.kind === 'tool' && gesture.usedGpuStroke;
 }
 
+/**
+ * Construct a tool-gesture InteractionState from a down-handler's
+ * freshly-returned state, without mutating the input. The dispatcher
+ * used to write `newState.gesture = { kind: 'tool', … }` directly on
+ * the returned object — the audit issue (#444) calls out post-return
+ * mutation as the bag-of-flags smell. Returning a new object instead
+ * keeps the no-mutation invariant.
+ */
+export function withToolGesture(state: InteractionState, usedGpuStroke: boolean): InteractionState {
+  return { ...state, gesture: { kind: 'tool', usedGpuStroke } };
+}
+
 export const GESTURE_IDLE: CanvasGesture = { kind: 'idle' };
 
 /**

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -27,7 +27,7 @@ import type {
   FloatingSelection, PersistentTransform, LastPaintPoint,
   PreToolDownGuard,
 } from './interactions/interaction-types';
-import { gestureUsedGpuStroke, INITIAL_INTERACTION_STATE } from './interactions/interaction-types';
+import { gestureUsedGpuStroke, INITIAL_INTERACTION_STATE, withToolGesture } from './interactions/interaction-types';
 import { handleTransformDown } from './interactions/transform-handlers';
 import {
   handleMeshWarpDown,
@@ -303,8 +303,7 @@ export function useCanvasInteraction(
       const handler = toolHandlers[activeTool];
       const newState = handler?.down?.(ctx);
       if (newState) {
-        newState.gesture = { kind: 'tool', usedGpuStroke: !!useGpuStroke };
-        stateRef.current = newState;
+        stateRef.current = withToolGesture(newState, !!useGpuStroke);
       }
     },
     [screenToCanvas, containerRef, buildContext, cancelHoldTimer],


### PR DESCRIPTION
## Summary

Tonight's incremental piece of #444 — paying down the **"no mutation of the gesture object outside the dispatcher"** acceptance criterion for the tool path.

The previous pass (#555) cleaned the transform path; the tool path was the last site mutating a freshly-returned handler state. Line 331 of `useCanvasInteraction.ts` wrote:

```ts
const newState = handler?.down?.(ctx);
if (newState) {
  newState.gesture = { kind: 'tool', usedGpuStroke: !!useGpuStroke };  // ← post-return mutation
  stateRef.current = newState;
}
```

Replaced with a `withToolGesture(state, useGpuStroke)` helper that returns a new state via spread, following the same `interaction-types.ts` helper pattern as `gestureUsedGpuStroke` from #550:

```ts
if (newState) {
  stateRef.current = withToolGesture(newState, !!useGpuStroke);
}
```

Same observable behavior, no mutation of the handler's freshly-returned object. The "no-mutation rule" acceptance criterion for #444 is now met on every path through `handleToolDown`.

## Remaining #444 acceptance criteria (still open)

- [ ] Per-variant migration of the remaining `MutableRefObject` fields on `InteractionContext` (`stampOffsetRef`, `floatingSelectionRef`, `persistentTransformRef`, `lastPaintPointRef`).
- [ ] Down-phase if-ladder (`useCanvasInteraction.ts:179-209`) → single switch. Structurally different from move/up since it constructs gestures rather than dispatching on them — needs its own design pass.

Each remaining item warrants its own focused pass.

## Drive-by

`useCanvasRendering.ts` had a duplicate `import { clearJsPixelData }` introduced by the merge in #551, breaking `tsc --noEmit` and the pre-push hook. Dropped the redundant line in a separate commit so this PR can land cleanly.

## Test plan

- [x] New unit tests in `interaction-types.test.ts` cover `withToolGesture`: produces a tool gesture, preserves non-gesture fields, does not mutate the input (frozen-input test), does not mutate a previously-set gesture object.
- [x] Existing `interaction-types.test.ts` suite (gestureUsedGpuStroke, transform-variant ownership, forbidden-keys) still passes.
- [x] Full unit test suite: 950/950 passing.
- [x] `tsc --noEmit` clean (was failing on main due to the duplicate import).
- [x] `npm run lint` clean (no new warnings).

https://claude.ai/code/session_01RrnPh5BQqgP4umyhNE4knD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrnPh5BQqgP4umyhNE4knD)_