### PR TITLE
refactor(interactions): unify pre-tool down guards (#444)

### DIFF
--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   gestureUsedGpuStroke,
   GESTURE_IDLE,
+  INITIAL_INTERACTION_STATE,
   type CanvasGesture,
   type InteractionState,
+  type PreToolDownGuard,
 } from './interaction-types';
 import { createTransformState } from '../../tools/transform/transform';
 
@@ -85,5 +87,36 @@ describe('CanvasGesture transform variant ownership', () => {
     const startAngle: number = gesture.startAngle;
     expect(handle).toBe('top-left');
     expect(startAngle).toBe(0);
+  });
+});
+
+describe('INITIAL_INTERACTION_STATE', () => {
+  it('starts idle with no drawing', () => {
+    expect(INITIAL_INTERACTION_STATE.drawing).toBe(false);
+    expect(INITIAL_INTERACTION_STATE.gesture.kind).toBe('idle');
+    expect(INITIAL_INTERACTION_STATE.layerId).toBeNull();
+    expect(INITIAL_INTERACTION_STATE.tool).toBeNull();
+  });
+});
+
+describe('PreToolDownGuard signature', () => {
+  it('accepts (canvasPos, activeLayerId) and returns InteractionState | null', () => {
+    const guard: PreToolDownGuard = (canvasPos, activeLayerId) => {
+      if (!activeLayerId) return null;
+      return {
+        ...INITIAL_INTERACTION_STATE,
+        drawing: true,
+        gesture: { kind: 'liquify' },
+        layerId: activeLayerId,
+        startPoint: canvasPos,
+      };
+    };
+
+    expect(guard({ x: 0, y: 0 }, '')).toBeNull();
+
+    const claimed = guard({ x: 5, y: 5 }, 'layer-1');
+    expect(claimed).not.toBeNull();
+    expect(claimed?.layerId).toBe('layer-1');
+    expect(claimed?.gesture.kind).toBe('liquify');
   });
 });

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -42,6 +42,45 @@ export function gestureUsedGpuStroke(gesture: CanvasGesture): boolean {
 
 export const GESTURE_IDLE: CanvasGesture = { kind: 'idle' };
 
+/**
+ * Baseline InteractionState used both for stateRef initialization and as
+ * a template for handlers that need to return a fresh state with a single
+ * gesture variant slotted in. Exported so pre-tool down handlers can
+ * construct their own state — see PRE_TOOL_DOWN_GUARDS in
+ * useCanvasInteraction.ts.
+ */
+export const INITIAL_INTERACTION_STATE: InteractionState = {
+  drawing: false,
+  gesture: GESTURE_IDLE,
+  lastPoint: null,
+  pixelBuffer: null,
+  originalPixelBuffer: null,
+  layerId: null,
+  tool: null,
+  startPoint: null,
+  layerStartX: 0,
+  layerStartY: 0,
+  maskMode: false,
+  originalSelectionMask: null,
+  originalSelectionMaskWidth: 0,
+  originalSelectionMaskHeight: 0,
+  moveOriginalMask: null,
+  moveOriginalBounds: null,
+};
+
+/**
+ * Signature shared by all pre-tool down guards (liquify, tilt-shift,
+ * mesh-warp). Each guard inspects ambient session state, decides whether
+ * to claim the gesture, and either returns a fully-populated
+ * InteractionState (its variant constructed inline) or `null` to fall
+ * through to the next guard. Replaces the priority-encoded if-ladder
+ * that previously lived in useCanvasInteraction.ts (#444).
+ */
+export type PreToolDownGuard = (
+  canvasPos: Point,
+  activeLayerId: string,
+) => InteractionState | null;
+
 export interface InteractionState {
   drawing: boolean;
   gesture: CanvasGesture;

--- a/src/app/interactions/liquify-handlers.ts
+++ b/src/app/interactions/liquify-handlers.ts
@@ -7,9 +7,11 @@
  */
 
 import { useUIStore } from '../ui-store';
+import { useEditorStore } from '../editor-store';
 import { getEngine } from '../../engine-wasm/engine-state';
 import { liquifyApplyDabGpu, liquifyRender } from '../../engine-wasm/wasm-bridge';
 import type { Point } from '../../types';
+import { INITIAL_INTERACTION_STATE, type InteractionState } from './interaction-types';
 
 const LIQUIFY_MODE_MAP: Record<string, number> = {
   push: 0,
@@ -21,16 +23,33 @@ const LIQUIFY_MODE_MAP: Record<string, number> = {
 
 let stroke: { lastPoint: Point } | null = null;
 
-export function isLiquifyActive(): boolean {
-  return useUIStore.getState().liquify !== null;
-}
-
-export function handleLiquifyDown(layerPos: Point): boolean {
+/**
+ * Pre-tool down guard for the liquify gesture. When a liquify session
+ * is active, all pointer-downs are claimed by liquify regardless of
+ * position (the entire canvas is the liquify surface). Returns a fully-
+ * populated InteractionState with the `liquify` gesture variant, or
+ * null if no session is active so the dispatcher falls through to the
+ * next guard.
+ */
+export function handleLiquifyDown(
+  canvasPos: Point,
+  activeLayerId: string,
+): InteractionState | null {
   const session = useUIStore.getState().liquify;
-  if (!session) return false;
+  if (!session) return null;
 
+  const layer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId);
+  const layerPos = layer
+    ? { x: canvasPos.x - layer.x, y: canvasPos.y - layer.y }
+    : canvasPos;
   stroke = { lastPoint: layerPos };
-  return true;
+
+  return {
+    ...INITIAL_INTERACTION_STATE,
+    drawing: true,
+    gesture: { kind: 'liquify' },
+    layerId: activeLayerId,
+  };
 }
 
 export function handleLiquifyMove(layerPos: Point): boolean {

--- a/src/app/interactions/mesh-warp-handlers.ts
+++ b/src/app/interactions/mesh-warp-handlers.ts
@@ -4,23 +4,34 @@ import { hitTestMeshHandle } from '../rendering/render-mesh-warp';
 import { previewMeshWarp } from '../MenuBar/mesh-warp-actions';
 import type { Point } from '../../types';
 import type { MeshWarpGrid } from '../../filters/mesh-warp';
+import { INITIAL_INTERACTION_STATE, type InteractionState } from './interaction-types';
 
 /**
- * Pre-tool dispatch — runs on mousedown when an inline mesh warp session
- * is active. Returns true if a handle was hit (so the regular tool dispatch
- * is skipped). Otherwise returns false and tool routing continues normally.
+ * Pre-tool down guard for the mesh-warp gesture. Hit-tests the mesh
+ * warp handles and, if one is hit, claims the gesture with the
+ * `meshWarp` variant. Returns null otherwise so the dispatcher falls
+ * through to the next guard.
  */
-export function handleMeshWarpDown(canvasPos: Point): boolean {
+export function handleMeshWarpDown(
+  canvasPos: Point,
+  activeLayerId: string,
+): InteractionState | null {
   const ui = useUIStore.getState();
   const session = ui.meshWarp;
-  if (!session) return false;
+  if (!session) return null;
 
   const zoom = useEditorStore.getState().viewport.zoom;
   const idx = hitTestMeshHandle(canvasPos.x, canvasPos.y, session, zoom);
-  if (idx === null) return false;
+  if (idx === null) return null;
 
   ui.setMeshWarpDragging(idx);
-  return true;
+
+  return {
+    ...INITIAL_INTERACTION_STATE,
+    drawing: true,
+    gesture: { kind: 'meshWarp' },
+    layerId: activeLayerId,
+  };
 }
 
 /**

--- a/src/app/interactions/pre-tool-down-guards.test.ts
+++ b/src/app/interactions/pre-tool-down-guards.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../test/canvas-mock';
+
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+const { useUIStore } = await import('../ui-store');
+const { handleLiquifyDown } = await import('./liquify-handlers');
+const { handleTiltShiftDown } = await import('./tilt-shift-handlers');
+const { handleMeshWarpDown } = await import('./mesh-warp-handlers');
+const { useEditorStore } = await import('../editor-store');
+
+function resetSessions(): void {
+  useUIStore.setState({ liquify: null, tiltShift: null, meshWarp: null });
+}
+
+describe('pre-tool down guards', () => {
+  beforeEach(resetSessions);
+
+  describe('handleLiquifyDown', () => {
+    it('returns null when no liquify session is active', () => {
+      expect(handleLiquifyDown({ x: 10, y: 10 }, 'layer-1')).toBeNull();
+    });
+
+    it('returns a liquify-variant state when a session is active', () => {
+      const layerId = useEditorStore.getState().document.activeLayerId ?? 'layer-1';
+      useUIStore.setState({
+        liquify: {
+          layerId,
+          layerWidth: 256,
+          layerHeight: 256,
+          settings: { mode: 'push', brushSize: 64, pressure: 0.5 },
+        },
+      });
+
+      const state = handleLiquifyDown({ x: 25, y: 30 }, layerId);
+
+      expect(state).not.toBeNull();
+      expect(state?.drawing).toBe(true);
+      expect(state?.gesture.kind).toBe('liquify');
+      expect(state?.layerId).toBe(layerId);
+    });
+  });
+
+  describe('handleTiltShiftDown', () => {
+    it('returns null when no tilt-shift session is active', () => {
+      expect(handleTiltShiftDown({ x: 10, y: 10 }, 'layer-1')).toBeNull();
+    });
+  });
+
+  describe('handleMeshWarpDown', () => {
+    it('returns null when no mesh-warp session is active', () => {
+      expect(handleMeshWarpDown({ x: 10, y: 10 }, 'layer-1')).toBeNull();
+    });
+  });
+});

--- a/src/app/interactions/tilt-shift-handlers.ts
+++ b/src/app/interactions/tilt-shift-handlers.ts
@@ -3,6 +3,7 @@ import { useEditorStore } from '../editor-store';
 import { hitTestTiltShift } from '../rendering/render-tilt-shift-overlay';
 import { previewTiltShift } from '../MenuBar/tilt-shift-actions';
 import type { Point } from '../../types';
+import { INITIAL_INTERACTION_STATE, type InteractionState } from './interaction-types';
 
 function getProjected(x: number, y: number, docW: number, docH: number, angleDeg: number): number {
   const angleRad = (angleDeg * Math.PI) / 180;
@@ -13,15 +14,24 @@ function getProjected(x: number, y: number, docW: number, docH: number, angleDeg
   return (u - 0.5) * (-sinA) + (v - 0.5) * cosA + 0.5;
 }
 
-export function handleTiltShiftDown(canvasPos: Point): boolean {
+/**
+ * Pre-tool down guard for the tilt-shift gesture. Hit-tests the
+ * tilt-shift overlay handles and, if one is hit, claims the gesture
+ * with the `tiltShift` variant. Returns null otherwise so the
+ * dispatcher falls through to the next guard.
+ */
+export function handleTiltShiftDown(
+  canvasPos: Point,
+  activeLayerId: string,
+): InteractionState | null {
   const ui = useUIStore.getState();
   const session = ui.tiltShift;
-  if (!session) return false;
+  if (!session) return null;
 
   const doc = useEditorStore.getState().document;
   const zoom = useEditorStore.getState().viewport.zoom;
   const target = hitTestTiltShift(canvasPos.x, canvasPos.y, session, doc.width, doc.height, zoom);
-  if (!target) return false;
+  if (!target) return null;
 
   let anchor = 0;
   if (target === 'line1') {
@@ -31,7 +41,13 @@ export function handleTiltShiftDown(canvasPos: Point): boolean {
   }
 
   ui.setTiltShiftDragging(target, anchor);
-  return true;
+
+  return {
+    ...INITIAL_INTERACTION_STATE,
+    drawing: true,
+    gesture: { kind: 'tiltShift' },
+    layerId: activeLayerId,
+  };
 }
 
 export function handleTiltShiftMove(canvasPos: Point, metaKey: boolean): void {

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -25,8 +25,9 @@ import { syncLayerAfterFullSize } from './sync-layer-after-full-size';
 import type {
   InteractionState, InteractionContext,
   FloatingSelection, PersistentTransform, LastPaintPoint,
+  PreToolDownGuard,
 } from './interactions/interaction-types';
-import { gestureUsedGpuStroke } from './interactions/interaction-types';
+import { gestureUsedGpuStroke, INITIAL_INTERACTION_STATE } from './interactions/interaction-types';
 import { handleTransformDown } from './interactions/transform-handlers';
 import {
   handleMeshWarpDown,
@@ -39,7 +40,6 @@ import {
   handleTiltShiftUp,
 } from './interactions/tilt-shift-handlers';
 import {
-  isLiquifyActive,
   handleLiquifyDown,
   handleLiquifyMove,
   handleLiquifyUp,
@@ -90,30 +90,27 @@ function finalizePendingStroke(ref: React.MutableRefObject<{ layerId: string } |
 // TODO: drop these fields from InteractionContext entirely — nothing reads them.
 const PLACEHOLDER_PIXEL_BUFFER = PixelBuffer.wrapImageData(new ImageData(1, 1));
 
-const INITIAL_STATE: InteractionState = {
-  drawing: false,
-  gesture: { kind: 'idle' },
-  lastPoint: null,
-  pixelBuffer: null,
-  originalPixelBuffer: null,
-  layerId: null,
-  tool: null,
-  startPoint: null,
-  layerStartX: 0,
-  layerStartY: 0,
-  maskMode: false,
-  originalSelectionMask: null,
-  originalSelectionMaskWidth: 0,
-  originalSelectionMaskHeight: 0,
-  moveOriginalMask: null,
-  moveOriginalBounds: null,
-};
+/**
+ * Pre-tool down guards run in priority order on mousedown — the first
+ * one to return a non-null state claims the gesture and the dispatcher
+ * skips regular tool routing. Adding a new pre-tool gesture is now a
+ * one-line registry change (#444).
+ *
+ * Liquify is first because an active liquify session takes the entire
+ * canvas (no hit-test); the other two only claim the gesture when their
+ * overlay handles are actually hit.
+ */
+const PRE_TOOL_DOWN_GUARDS: readonly PreToolDownGuard[] = [
+  handleLiquifyDown,
+  handleTiltShiftDown,
+  handleMeshWarpDown,
+];
 
 export function useCanvasInteraction(
   screenToCanvas: (screenX: number, screenY: number) => Point,
   containerRef: React.RefObject<HTMLDivElement | null>,
 ) {
-  const stateRef = useRef<InteractionState>({ ...INITIAL_STATE });
+  const stateRef = useRef<InteractionState>({ ...INITIAL_INTERACTION_STATE });
   const persistentTransformRef = useRef<PersistentTransform | null>(null);
   const floatingSelectionRef = useRef<FloatingSelection | null>(null);
   const stampSourceRef = useRef<Point | null>(null);
@@ -173,34 +170,12 @@ export function useCanvasInteraction(
         }
       }
 
-      if (isLiquifyActive()) {
-        const layerPos = (() => {
-          const layer = editorState.document.layers.find((l) => l.id === activeLayerId);
-          return layer ? { x: canvasPos.x - layer.x, y: canvasPos.y - layer.y } : canvasPos;
-        })();
-        handleLiquifyDown(layerPos);
-        stateRef.current = { ...INITIAL_STATE, drawing: true, gesture: { kind: 'liquify' }, layerId: activeLayerId };
-        return;
-      }
-
-      if (handleTiltShiftDown(canvasPos)) {
-        stateRef.current = {
-          ...INITIAL_STATE,
-          drawing: true,
-          gesture: { kind: 'tiltShift' },
-          layerId: activeLayerId,
-        };
-        return;
-      }
-
-      if (handleMeshWarpDown(canvasPos)) {
-        stateRef.current = {
-          ...INITIAL_STATE,
-          drawing: true,
-          gesture: { kind: 'meshWarp' },
-          layerId: activeLayerId,
-        };
-        return;
+      for (const guard of PRE_TOOL_DOWN_GUARDS) {
+        const next = guard(canvasPos, activeLayerId);
+        if (next) {
+          stateRef.current = next;
+          return;
+        }
       }
 
       const engine = getEngine();
@@ -488,7 +463,7 @@ export function useCanvasInteraction(
           useEditorStore.getState().notifyRender();
 
           // Mark the stroke as done so mouseup becomes a no-op
-          stateRef.current = { ...INITIAL_STATE };
+          stateRef.current = { ...INITIAL_INTERACTION_STATE };
         }, HOLD_TIMEOUT_MS);
       }
     },
@@ -504,15 +479,15 @@ export function useCanvasInteraction(
     switch (state.gesture.kind) {
       case 'tiltShift':
         handleTiltShiftUp();
-        stateRef.current = { ...INITIAL_STATE };
+        stateRef.current = { ...INITIAL_INTERACTION_STATE };
         return;
       case 'liquify':
         handleLiquifyUp();
-        stateRef.current = { ...INITIAL_STATE };
+        stateRef.current = { ...INITIAL_INTERACTION_STATE };
         return;
       case 'meshWarp':
         handleMeshWarpUp();
-        stateRef.current = { ...INITIAL_STATE };
+        stateRef.current = { ...INITIAL_INTERACTION_STATE };
         return;
       case 'idle':
       case 'transform':
@@ -521,7 +496,7 @@ export function useCanvasInteraction(
     }
 
     if (!state.tool) {
-      stateRef.current = { ...INITIAL_STATE };
+      stateRef.current = { ...INITIAL_INTERACTION_STATE };
       return;
     }
 
@@ -611,7 +586,7 @@ export function useCanvasInteraction(
       }
     }
 
-    stateRef.current = { ...INITIAL_STATE };
+    stateRef.current = { ...INITIAL_INTERACTION_STATE };
   }, [screenToCanvas, containerRef, cancelHoldTimer]);
 
   const clearPersistentTransform = useCallback(() => {

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -40,7 +40,6 @@ import { expandLayerToDocSize, cropLayerToContent, hasFloat, getLayerTextureDime
 import { invalidateCachedSnapshot } from './store/history-slice';
 import { clearJsPixelData } from './store/clear-js-pixel-data';
 import { PAINT_TOOLS } from '../tools/tool-registry';
-import { clearJsPixelData } from './store/clear-js-pixel-data';
 
 
 /**


### PR DESCRIPTION
## Summary

Tonight's incremental piece of #444 — paying down the **down-phase if-ladder** acceptance criterion. The mousedown dispatcher in `useCanvasInteraction.ts` used to walk three priority-encoded `if` blocks that each constructed the InteractionState inline:

```ts
if (isLiquifyActive()) {
  const layerPos = (() => { ... })();
  handleLiquifyDown(layerPos);
  stateRef.current = { ...INITIAL_STATE, drawing: true, gesture: { kind: 'liquify' }, layerId: activeLayerId };
  return;
}

if (handleTiltShiftDown(canvasPos)) {
  stateRef.current = { ...INITIAL_STATE, drawing: true, gesture: { kind: 'tiltShift' }, layerId: activeLayerId };
  return;
}

if (handleMeshWarpDown(canvasPos)) {
  stateRef.current = { ...INITIAL_STATE, drawing: true, gesture: { kind: 'meshWarp' }, layerId: activeLayerId };
  return;
}
```

The audit issue calls out the down phase as structurally different from move/up: it *constructs* gestures rather than dispatching on them, so a literal `switch (state.gesture.kind)` doesn't fit. The next-best shape is what `handleTransformDown` already uses — each handler returns `InteractionState | null`, and the dispatcher iterates them.

This PR introduces a `PreToolDownGuard` type:

```ts
export type PreToolDownGuard = (
  canvasPos: Point,
  activeLayerId: string,
) => InteractionState | null;
```

…makes liquify / tilt-shift / mesh-warp conform to it (each constructs its own variant inline), and collapses the if-ladder to:

```ts
for (const guard of PRE_TOOL_DOWN_GUARDS) {
  const next = guard(canvasPos, activeLayerId);
  if (next) {
    stateRef.current = next;
    return;
  }
}
```

Adding a new pre-tool gesture is now a one-line registry change in `useCanvasInteraction.ts` plus the new handler file. Each guard owns the construction of its own variant — the dispatcher no longer needs to know which gesture-kind goes with which guard.

The `INITIAL_STATE` template moves from `useCanvasInteraction.ts` to `interaction-types.ts` as `INITIAL_INTERACTION_STATE` so the guards can import it.

`isLiquifyActive()` is dropped — its only caller was the if-ladder itself.

## Remaining #444 acceptance criteria (still open)

- [ ] Per-variant migration of the remaining `MutableRefObject` fields on `InteractionContext` (`stampOffsetRef`, `floatingSelectionRef`, `persistentTransformRef`, `lastPaintPointRef`). These persist *across* gestures, so they're not naturally gesture-variant state — needs design.
- [ ] No-mutation rule for the gesture object outside the dispatcher: the tool path still has the line `newState.gesture = { kind: 'tool', usedGpuStroke: !!useGpuStroke };` at `useCanvasInteraction.ts:306`. That's PR #558's territory — landing both will close this criterion.

## Drive-by

`useCanvasRendering.ts` had two identical `import { clearJsPixelData }` lines introduced by the merge in #551, breaking `tsc --noEmit` on main. Removed the redundant import in a separate commit so this PR can pass the pre-push hook. (Same drive-by as PR #558 — if both land, the second is a no-op.)

## Test plan

- [x] New `pre-tool-down-guards.test.ts` covers: each guard returns `null` with no active session; liquify returns a `liquify`-variant state with the right `layerId` / `drawing` when a session is active.
- [x] Extended `interaction-types.test.ts`: `INITIAL_INTERACTION_STATE` starts idle with no drawing/layer/tool; `PreToolDownGuard` signature compiles and round-trips.
- [x] Full unit-test suite: 952/952 passing.
- [x] `tsc --noEmit` clean (was broken on main pre drive-by).
- [x] `npm run lint` clean (0 errors).

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoeWueBuc1PGUY43ekUr2e)_