### PR TITLE
fix: swap CW/CCW UV mappings in rotate90 shader

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/rotate90.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/rotate90.glsl
@@ -7,11 +7,11 @@ out vec4 fragColor;
 void main() {
     vec2 uv;
     if (u_clockwise == 1) {
-        // CW: (x, y) → (1-y, x)
-        uv = vec2(1.0 - v_uv.y, v_uv.x);
-    } else {
-        // CCW: (x, y) → (y, 1-x)
+        // CW: (x, y) → (y, 1-x)
         uv = vec2(v_uv.y, 1.0 - v_uv.x);
+    } else {
+        // CCW: (x, y) → (1-y, x)
+        uv = vec2(1.0 - v_uv.y, v_uv.x);
     }
     fragColor = texture(u_tex, uv);
 }

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -40,7 +40,6 @@ import { expandLayerToDocSize, cropLayerToContent, hasFloat, getLayerTextureDime
 import { invalidateCachedSnapshot } from './store/history-slice';
 import { clearJsPixelData } from './store/clear-js-pixel-data';
 import { PAINT_TOOLS } from '../tools/tool-registry';
-import { clearJsPixelData } from './store/clear-js-pixel-data';
 
 
 /**


### PR DESCRIPTION
## Summary
- The CW and CCW branches in `rotate90.glsl` had their UV lookups swapped, causing "Rotate 90° CW" to rotate counter-clockwise and vice versa.
- Also removes a duplicate `clearJsPixelData` import that was failing the pre-push typecheck.

## Test plan
- [ ] Open lopsy.art with a non-symmetric image
- [ ] Image → Rotate 90° CW — image should rotate clockwise
- [ ] Image → Rotate 90° CCW — image should rotate counter-clockwise
- [ ] Undo both rotations and verify they restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)