### PR TITLE
fix(raf): unbreak file picker, suppress sky CFA grid

### DIFF
--- a/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
@@ -50,14 +50,13 @@ const B: u8 = 2;
 pub fn demosaic_xtrans(raw: &[f32], width: u32, height: u32, pattern: &[u8; 36]) -> Vec<f32> {
     let w = width as usize;
     let h = height as usize;
-    // Simple 5×5 same-color averaging is bias-free across the 6×6 CFA
-    // grid, so no post-blur is needed and uniform regions (sky, walls)
-    // stay clean. Trade-off: small high-saturation features (the red
-    // shield over the door, etc.) get color-averaged with adjacent
-    // larger color regions. The Markesteijn implementation below
-    // preserves more edge detail but introduces per-CFA-position bias
-    // visible as a faint pattern in uniform areas.
-    simple_demosaic(raw, w, h, pattern)
+    // The 5×5 same-color averaging is mostly bias-free but the window
+    // doesn't cleanly cover the 6×6 CFA period, so uniform areas (sky,
+    // walls) show a faint 6-pixel-period grid that the saturating color
+    // matrix amplifies. A small separable box blur (radius 2 → 5×5)
+    // suppresses it without visibly softening edges at normal zoom.
+    let rgb = simple_demosaic(raw, w, h, pattern);
+    box_blur_separable_rgb(&rgb, w, h, 2)
 }
 
 /// Markesteijn 3-pass demosaicer. Sharper edge reconstruction than

--- a/src/app/MenuBar/menus/file-menu.ts
+++ b/src/app/MenuBar/menus/file-menu.ts
@@ -54,7 +54,11 @@ export function openFileFromDisk(): void {
   if (!confirmIfDirty()) return;
   const input = document.createElement('input');
   input.type = 'file';
-  input.accept = 'image/*,.psd,.dng,.raf,.lopsy';
+  // Mixing `image/*` with bare extensions causes Chrome on macOS to
+  // restrict the picker to a single filter (often the last extension
+  // listed), so users see only `.raf` files. List explicit extensions
+  // for every supported type to keep all files visible.
+  input.accept = '.jpg,.jpeg,.png,.gif,.bmp,.tif,.tiff,.webp,.heic,.psd,.dng,.raf,.lopsy';
   input.onchange = () => {
     const file = input.files?.[0];
     if (!file) return;

--- a/src/components/NewDocumentModal/NewDocumentModal.tsx
+++ b/src/components/NewDocumentModal/NewDocumentModal.tsx
@@ -138,7 +138,7 @@ export function NewDocumentModal({ onCreateDocument, onOpenFile, onPasteClipboar
   const handleOpenFile = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = 'image/*,.psd,.dng,.raf,.lopsy';
+    input.accept = '.jpg,.jpeg,.png,.gif,.bmp,.tif,.tiff,.webp,.heic,.psd,.dng,.raf,.lopsy';
     input.onchange = () => {
       const file = input.files?.[0];
       if (file) onOpenFile(file);


### PR DESCRIPTION
## Summary

Two regressions from #562:

1. **Open File picker only showed `.raf` files.** Mixing `image/*` with bare extensions in `accept` makes Chrome (and Finder) restrict the picker to the last extension listed. Replaced with explicit extensions so all supported file types stay visible.
2. **Sky and uniform regions showed a faint 6-pixel diagonal grid.** The 5×5 same-color demosaic window doesn't cleanly cover the 6×6 X-Trans CFA period, so different window positions produce slightly different per-color averages — the saturating color matrix then amplifies those into a visible pattern. Added a small (radius 2 → 5×5) separable box blur after demosaic that suppresses the grid without visibly softening real edges.

## Test plan

- [x] `npm run build` clean
- [x] `npm run typecheck` clean
- [x] Unit tests pass (`useDocumentOpenHandlers`)
- [x] `e2e/raf-compare.spec.ts` passes — ΔE76 ≈ 11.3 against reference (unchanged)
- [x] Sky region at full zoom is now smooth (no more 6-pixel diagonal pattern)
- [ ] Verify Open File picker now shows all image types on macOS Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)