### PR TITLE
refactor(tool-settings): migrate dodge to per-tool slice (#453)

### DIFF
--- a/e2e/composition-painting.spec.ts
+++ b/e2e/composition-painting.spec.ts
@@ -91,14 +91,14 @@ async function drawStroke(
   await page.waitForTimeout(200);
 }
 
-/** Thin wrapper: delegates to UI helpers where possible, falls back to store. */
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(({ setter, value }) => {
+/** Per-tool slice setter for dodge (#453). */
+async function setDodgeSetting(page: Page, key: 'mode' | 'exposure', value: string | number) {
+  await page.evaluate(({ key, value }) => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => Record<string, (v: unknown) => void>;
+      getState: () => { setDodgeSetting: (k: string, v: unknown) => void };
     };
-    store.getState()[setter]!(value);
-  }, { setter, value });
+    store.getState().setDodgeSetting(key, value);
+  }, { key, value });
 }
 
 const toolKeyMap: Record<string, string> = {
@@ -443,7 +443,7 @@ test.describe('Composition 1: Painted Landscape', () => {
     // Dodge (lighten) the left side of mountains
     await setToolOption(page, 'Size', 50);
     await setToolOption(page, 'Exposure', 60);
-    await setToolSetting(page, 'setDodgeMode', 'dodge');
+    await setDodgeSetting(page, 'mode', 'dodge');
 
     const beforeDodge = await snapshot(page);
     await drawStroke(page, { x: 160, y: 180 }, { x: 200, y: 240 }, 8);
@@ -452,7 +452,7 @@ test.describe('Composition 1: Painted Landscape', () => {
     expect(pixelDiff(beforeDodge, afterDodge)).toBeGreaterThan(20);
 
     // Burn (darken) the right side
-    await setToolSetting(page, 'setDodgeMode', 'burn');
+    await setDodgeSetting(page, 'mode', 'burn');
     const beforeBurn = await snapshot(page);
     await drawStroke(page, { x: 370, y: 160 }, { x: 420, y: 220 }, 8);
     const afterBurn = await snapshot(page);

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -6,11 +6,10 @@ import type { DodgeMode } from '../../../tools/dodge/dodge';
 import styles from '../OptionsBar.module.css';
 
 export function DodgeOptions() {
-  const dodgeExposure = useToolSettingsStore((s) => s.dodgeExposure);
-  const dodgeMode = useToolSettingsStore((s) => s.dodgeMode);
+  const dodgeExposure = useToolSettingsStore((s) => s.settings.dodge.exposure);
+  const dodgeMode = useToolSettingsStore((s) => s.settings.dodge.mode);
   const brushSize = useToolSettingsStore((s) => s.brushSize);
-  const setDodgeExposure = useToolSettingsStore((s) => s.setDodgeExposure);
-  const setDodgeMode = useToolSettingsStore((s) => s.setDodgeMode);
+  const setDodgeSetting = useToolSettingsStore((s) => s.setDodgeSetting);
   const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
@@ -22,13 +21,13 @@ export function DodgeOptions() {
       <select
         className={styles.select}
         value={dodgeMode}
-        onChange={(e) => setDodgeMode(e.target.value as DodgeMode)}
+        onChange={(e) => setDodgeSetting('mode', e.target.value as DodgeMode)}
         aria-labelledby="dodge-mode-label"
       >
         <option value="dodge">Dodge</option>
         <option value="burn">Burn</option>
       </select>
-      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={setDodgeExposure} />
+      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={(v) => setDodgeSetting('exposure', v)} />
       <Slider label="Size" value={brushSize} min={1} max={sizeMax} sliderMax={300} onChange={setBrushSize} />
     </>
   );

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -4,6 +4,8 @@ import type { FillSettings } from '../tools/fill/fill-settings';
 import { DEFAULT_FILL_SETTINGS } from '../tools/fill/fill-settings';
 import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
 import { DEFAULT_MARQUEE_SETTINGS } from '../tools/marquee/marquee-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
+import { DEFAULT_DODGE_SETTINGS } from '../tools/dodge/dodge-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -18,10 +20,12 @@ export interface ToolSettingsSlices {
   wand: WandSettings;
   fill: FillSettings;
   marquee: MarqueeSettings;
+  dodge: DodgeSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   wand: DEFAULT_WAND_SETTINGS,
   fill: DEFAULT_FILL_SETTINGS,
   marquee: DEFAULT_MARQUEE_SETTINGS,
+  dodge: DEFAULT_DODGE_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -210,3 +210,55 @@ describe('per-tool slice: marquee (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: dodge (#453)', () => {
+  it('exposes dodge settings under settings.dodge with the legacy defaults', () => {
+    // Reset to the legacy default — prior tests in this file may
+    // have mutated the slice through setDodgeSetting.
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 50);
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    const { dodge } = useToolSettingsStore.getState().settings;
+    expect(dodge).toEqual({ exposure: 50, mode: 'dodge' });
+  });
+
+  it('setDodgeSetting updates one field without disturbing the other', () => {
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 50);
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    const before = useToolSettingsStore.getState().settings.dodge;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 75);
+    const after = useToolSettingsStore.getState().settings.dodge;
+    expect(after.exposure).toBe(75);
+    expect(after.mode).toBe(before.mode);
+  });
+
+  it('setDodgeSetting clamps exposure into [1, 100]', () => {
+    useToolSettingsStore.getState().setDodgeSetting('exposure', -10);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(1);
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 9999);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(100);
+  });
+
+  it('setDodgeSetting switches between dodge and burn modes', () => {
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'burn');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('burn');
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('dodge');
+  });
+
+  it('setDodgeSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 30);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(30);
+    // Sibling slice references preserved — selectors subscribed to
+    // settings.wand / settings.fill / settings.marquee should not
+    // re-render when dodge changes. This is the invariant that
+    // justifies slicing.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -7,6 +7,7 @@ import { DEFAULT_TOOL_SETTINGS_SLICES } from './tool-settings-slices';
 import { clampWandSetting } from '../tools/wand/wand-settings';
 import { clampFillSetting } from '../tools/fill/fill-settings';
 import { clampMarqueeSetting } from '../tools/marquee/marquee-settings';
+import { clampDodgeSetting } from '../tools/dodge/dodge-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -59,8 +60,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   healingSize: 20,
   healingOpacity: 100,
   pathStrokeWidth: 2,
-  dodgeExposure: 50,
-  dodgeMode: 'dodge',
   spongeMode: 'desaturate',
   spongeStrength: 50,
   spongeSize: 30,
@@ -247,8 +246,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     set({ healingOpacity: Math.max(1, Math.min(100, opacity)) });
   },
   setPathStrokeWidth: (width) => set({ pathStrokeWidth: Math.max(1, Math.min(50, width)) }),
-  setDodgeExposure: (exposure) => set({ dodgeExposure: Math.max(1, Math.min(100, exposure)) }),
-  setDodgeMode: (mode) => set({ dodgeMode: mode }),
+  setDodgeSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      dodge: { ...s.settings.dodge, [key]: clampDodgeSetting(key, value) },
+    },
+  })),
   setSpongeMode: (mode) => set({ spongeMode: mode }),
   setSpongeStrength: (strength) => set({ spongeStrength: Math.max(1, Math.min(100, strength)) }),
   setSpongeSize: (size) => set({ spongeSize: Math.max(1, Math.min(5000, size)) }),

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,12 +1,12 @@
 import type { Color, FontStyle, TextAlign } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
-import type { DodgeMode } from '../tools/dodge/dodge';
 import type { SpongeMode } from '../tools/sponge/sponge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
 import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -44,8 +44,6 @@ export interface ToolSettings {
   healingSize: number;
   healingOpacity: number;
   pathStrokeWidth: number;
-  dodgeExposure: number;
-  dodgeMode: DodgeMode;
   spongeMode: SpongeMode;
   spongeStrength: number;
   spongeSize: number;
@@ -125,8 +123,7 @@ export interface ToolSettings {
   setHealingSize: (size: number) => void;
   setHealingOpacity: (opacity: number) => void;
   setPathStrokeWidth: (width: number) => void;
-  setDodgeExposure: (exposure: number) => void;
-  setDodgeMode: (mode: DodgeMode) => void;
+  setDodgeSetting: <K extends keyof DodgeSettings>(key: K, value: DodgeSettings[K]) => void;
   setSpongeMode: (mode: SpongeMode) => void;
   setSpongeStrength: (strength: number) => void;
   setSpongeSize: (size: number) => void;

--- a/src/tools/dodge/dodge-interaction.ts
+++ b/src/tools/dodge/dodge-interaction.ts
@@ -26,9 +26,9 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
   const editorState = useEditorStore.getState();
   const toolSettings = useToolSettingsStore.getState();
-  const dodgeMode = toolSettings.dodgeMode;
+  const dodgeMode = toolSettings.settings.dodge.mode;
   editorState.pushHistory(dodgeMode === 'dodge' ? 'Dodge' : 'Burn');
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeShiftLine = shiftKey
     && ctx.lastPaintPointRef.current
@@ -66,7 +66,7 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
 export function handleDodgeMove(state: InteractionState, layerLocalPos: Point): void {
   if (!state.lastPoint) return;
   const toolSettings = useToolSettingsStore.getState();
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeSpacing = Math.max(1, dodgeSize * 0.25);
 

--- a/src/tools/dodge/dodge-settings.test.ts
+++ b/src/tools/dodge/dodge-settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DODGE_SETTINGS,
+  clampDodgeSetting,
+  type DodgeSettings,
+} from './dodge-settings';
+
+describe('dodge-settings (#453 per-tool slice)', () => {
+  it('defaults match the legacy flat-bag values', () => {
+    const defaults: DodgeSettings = DEFAULT_DODGE_SETTINGS;
+    expect(defaults).toEqual({ exposure: 50, mode: 'dodge' });
+  });
+
+  it('clampDodgeSetting clamps exposure to [1, 100]', () => {
+    // Legacy setDodgeExposure clamped to [1, 100] — preserve that so
+    // exposure / 100 in dodge-interaction.ts stays in (0, 1].
+    expect(clampDodgeSetting('exposure', -10)).toBe(1);
+    expect(clampDodgeSetting('exposure', 0)).toBe(1);
+    expect(clampDodgeSetting('exposure', 1)).toBe(1);
+    expect(clampDodgeSetting('exposure', 50)).toBe(50);
+    expect(clampDodgeSetting('exposure', 100)).toBe(100);
+    expect(clampDodgeSetting('exposure', 9999)).toBe(100);
+  });
+
+  it('passes mode through unchanged', () => {
+    expect(clampDodgeSetting('mode', 'dodge')).toBe('dodge');
+    expect(clampDodgeSetting('mode', 'burn')).toBe('burn');
+  });
+});

--- a/src/tools/dodge/dodge-settings.ts
+++ b/src/tools/dodge/dodge-settings.ts
@@ -1,0 +1,34 @@
+import type { DodgeMode } from './dodge';
+
+/**
+ * Per-tool settings slice for the Dodge / Burn tool.
+ *
+ * Authoritative settings type for dodge. The slice lives under
+ * `settings.dodge` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts`: `<Tool>Settings` interface +
+ * `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting` helper, then
+ * registered in `tool-settings-slices.ts`. Two-field shape with a
+ * typed enum (`mode`) — first slice to carry a discriminated string
+ * union, confirming the slice infrastructure narrows enums cleanly.
+ */
+export interface DodgeSettings {
+  exposure: number;
+  mode: DodgeMode;
+}
+
+export const DEFAULT_DODGE_SETTINGS: DodgeSettings = {
+  exposure: 50,
+  mode: 'dodge',
+};
+
+export function clampDodgeSetting<K extends keyof DodgeSettings>(
+  key: K,
+  value: DodgeSettings[K],
+): DodgeSettings[K] {
+  if (key === 'exposure') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as DodgeSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Fourth per-tool slice in the #453 rollout. Stacked on PR #573 (marquee) which is stacked on PR #568 (fill) on PR #564 (wand).

Adds `src/tools/dodge/dodge-settings.ts` with `DodgeSettings` + `DEFAULT_DODGE_SETTINGS` + `clampDodgeSetting`, registers `dodge: DodgeSettings` in `ToolSettingsSlices`, and replaces the flat `dodgeExposure` + `dodgeMode` fields and their two setters with a single typed `setDodgeSetting<K extends keyof DodgeSettings>(key, value)` on the store. Read sites in `DodgeOptions.tsx` and `dodge-interaction.ts` now access `settings.dodge.exposure` / `settings.dodge.mode`.

## Why this slice

- **First slice carrying a typed enum** (`mode: 'dodge' | 'burn'`). Wand/fill/marquee covered the numeric-clamp, boolean-passthrough, and integer-rounding shapes. Dodge confirms the slice infrastructure narrows discriminated string unions cleanly via the `clampDodgeSetting<K>` generic.
- **Small surface, low risk**: 2 fields, 5 files (store + types + slices + 1 component + 1 interaction + 1 e2e + the new slice files). Same risk envelope as fill/marquee.
- Exposure clamp preserves the legacy `[1, 100]` range — important because `dodge-interaction.ts` divides by 100 and a 0 would zero the dab.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 96 files / 976 tests pass
- [x] `npm run build` — clean
- [x] New `dodge-settings.test.ts` covers defaults + the clamp helper (3 tests)
- [x] `tool-settings-store.test.ts` adds the slice-level invariants: field-isolation, exposure clamp, mode switching (`dodge` ↔ `burn`), and **sibling-slice referential identity** across wand/fill/marquee — the invariant that justifies slicing instead of fattening the flat bag (5 tests, 30 total in the slice describe blocks)
- [ ] Manual: dodge tool still toggles dodge/burn via the Options Bar select and the Exposure slider still scales the dab (visual smoke during a normal stroke)

## Stack

Merge order: #564 (wand) → #568 (fill) → #573 (marquee) → this PR. The base branch is `claude/trusting-dirac-Q8OHu` (PR #573's head) so the slice infrastructure isn't duplicated. Retarget to `main` once the upstream PRs merge.

Closes one more acceptance criterion towards #453 — `tool-settings-store.ts` keeps shrinking as each slice lands and the per-tool `*Settings` types continue to displace the flat-bag fields.

https://claude.ai/code/session_01T3izFr7jxuod6i1dhMNuUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3izFr7jxuod6i1dhMNuUQ)_