### PR TITLE
docs(features): document wand shift/alt add-subtract and group align

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -184,6 +184,7 @@ The toolbar exposes Size, Opacity, Hardness, Fade, and the symmetry toggle. Ever
 - **Contiguous**: on/off
 - **Graduated**: on/off — when enabled, the wand uses a gradient-aware flood fill that produces partial-coverage selection edges across smooth color transitions, instead of a hard threshold cut
 - **Feather**: 0 - 250 px (shared marquee feather slider; applied after the wand fill)
+- **Shift+click**: adds the new region to the existing selection; **Alt/Option+click**: subtracts it (both combine against the current selection mask via `combineSelections`). Clicking with no modifier replaces the selection, and an Alt-subtract that empties the selection clears it.
 
 ### Quick Selection
 - **Size**: 1 - 100 px (brush radius for the paint stroke; default 20)
@@ -468,7 +469,7 @@ All 14 adjustment types now have first-class UI controls and are fully GPU-accel
 - Reorder (drag)
 - Move to group (reparent)
 - Rename
-- Align (left, center-h, right, top, center-v, bottom)
+- Align (left, center-h, right, top, center-v, bottom) — works on **group** layers too: a group has no pixels of its own, so it aligns by the combined content bounds of its descendants and shifts the group plus every child together (matching how dragging a group with the Move tool behaves)
 - Add/remove/toggle mask — works on raster, text, shape, and **group** layers; group masks are sampled at composite time so the entire group is masked as a single unit (with the group's own opacity and blend mode applied on top)
 - **Cmd/Ctrl+click a layer thumbnail**: loads that layer's alpha as a marquee selection (non-transparent pixels become the selection)
 - **Click a layer's mask thumbnail**: always enters mask edit mode (focus switches to the mask reliably; no toggle behavior).


### PR DESCRIPTION
## What

Reviewed the last two days of commits on `main` and found two user-facing capabilities that shipped without a FEATURES.md entry:

- **Magic Wand selection combine** ([#577](https://github.com/theseamusjames/lopsy.art/pull/577)) — the wand previously always *replaced* the selection. It now reads the modifier already carried on the interaction context: **Shift+click adds** the new region, **Alt/Option+click subtracts** it (both via `combineSelections`), and an Alt-subtract that empties the selection clears it. No modifier still replaces.
- **Align on groups** ([#577](https://github.com/theseamusjames/lopsy.art/pull/577)) — Align/arrange used to no-op on group layers (groups have no pixels to bound). They now align by the combined content bounds of their descendants and shift the whole subtree together, matching Move-tool drag behavior.

## Why

The scheduled "keep FEATURES.md accurate and exhaustive" pass specifically targets tool capabilities and modifier-key behaviors. Both of these are modifier/affordance changes that the catalog should surface.

## Notes

- Branched off `main`, so it does not touch the RAF/Noise documentation currently in flight on [#569](https://github.com/theseamusjames/lopsy.art/pull/569).
- Follow-up flagged in the run: once #569 merges, the RAF X-Trans demosaic paragraph should mention the median-filtered colour-difference planes added in [#571](https://github.com/theseamusjames/lopsy.art/pull/571) (CFA-locked false-colour suppression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)