### PR TITLE
fix(raf): correct Fujifilm X-Trans color — root-cause CFA phase misalignment

### DIFF
--- a/engine-rs/Cargo.lock
+++ b/engine-rs/Cargo.lock
@@ -224,6 +224,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "jpeg-encoder"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b454d911ac55068f53495488d8ccd0646eaa540c033a28ee15b07838afafb01f"
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +271,8 @@ name = "lopsy-core"
 version = "0.1.0"
 dependencies = [
  "flate2",
+ "jpeg-decoder",
+ "jpeg-encoder",
  "lz4_flex",
  "png",
  "serde",

--- a/engine-rs/crates/lopsy-core/Cargo.toml
+++ b/engine-rs/crates/lopsy-core/Cargo.toml
@@ -9,3 +9,7 @@ serde_json = "1"
 png = "0.17"
 flate2 = "1"
 lz4_flex = { version = "0.11", default-features = false, features = ["safe-encode", "safe-decode", "frame"] }
+
+[dev-dependencies]
+jpeg-encoder = "0.6"
+jpeg-decoder = "0.3"

--- a/engine-rs/crates/lopsy-core/src/dng/color.rs
+++ b/engine-rs/crates/lopsy-core/src/dng/color.rs
@@ -162,6 +162,36 @@ fn mul_3x3(a: &[f64; 9], b: &[f64; 9]) -> [f32; 9] {
     out
 }
 
+/// Rebalance a camera→sRGB matrix so that a neutral input (R=G=B) maps to a
+/// neutral output, by absorbing the matrix's own white point (pre_mul) into
+/// its columns. Unlike per-row normalization this preserves the matrix's
+/// off-diagonal (saturation) structure. dcraw's approach: pre_mul = M⁻¹·[1,1,1].
+pub fn neutralize_matrix(m: &[f32; 9]) -> [f32; 9] {
+    let m64: [f64; 9] = [
+        m[0] as f64, m[1] as f64, m[2] as f64,
+        m[3] as f64, m[4] as f64, m[5] as f64,
+        m[6] as f64, m[7] as f64, m[8] as f64,
+    ];
+    let inv = match invert_3x3(&m64) {
+        Some(i) => i,
+        None => return *m,
+    };
+    // pre_mul = M⁻¹ · [1,1,1]ᵀ  — the c-th element is the sum of row c of M⁻¹
+    let pre_mul = [
+        inv[0] + inv[1] + inv[2],
+        inv[3] + inv[4] + inv[5],
+        inv[6] + inv[7] + inv[8],
+    ];
+    // Scale each column c by pre_mul[c] so M_final · [1,1,1]ᵀ = [1,1,1]ᵀ
+    let mut out = [0.0f32; 9];
+    for r in 0..3 {
+        for c in 0..3 {
+            out[r * 3 + c] = (m64[r * 3 + c] * pre_mul[c]) as f32;
+        }
+    }
+    out
+}
+
 fn invert_3x3(m: &[f64; 9]) -> Option<[f64; 9]> {
     let det = m[0] * (m[4] * m[8] - m[5] * m[7])
             - m[1] * (m[3] * m[8] - m[5] * m[6])
@@ -181,4 +211,41 @@ fn invert_3x3(m: &[f64; 9]) -> Option<[f64; 9]> {
         (m[1] * m[6] - m[0] * m[7]) * inv_det,
         (m[0] * m[4] - m[1] * m[3]) * inv_det,
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neutralize_matrix_keeps_gray_neutral_and_preserves_saturation() {
+        // Real per-camera matrix (X-T5/X100VI) derived from DNG ColorMatrix1
+        // [12662,-5961,-1025,-4129,12025,2399,-752,1455,6531]/10000.
+        let cm_raw: [f64; 9] = [
+            1.2662, -0.5961, -0.1025,
+            -0.4129, 1.2025, 0.2399,
+            -0.0752, 0.1455, 0.6531,
+        ];
+        let cam_to_srgb = color_matrix_to_srgb(&cm_raw);
+        let m = neutralize_matrix(&cam_to_srgb);
+
+        // A neutral input must produce a neutral output (within 1e-4).
+        let v = 0.5f32;
+        let r_out = m[0] * v + m[1] * v + m[2] * v;
+        let g_out = m[3] * v + m[4] * v + m[5] * v;
+        let b_out = m[6] * v + m[7] * v + m[8] * v;
+        assert!(
+            (r_out - g_out).abs() < 1e-4 && (g_out - b_out).abs() < 1e-4,
+            "neutral in → non-neutral out: r={r_out:.6} g={g_out:.6} b={b_out:.6}"
+        );
+
+        // A saturated input (red-heavy) must stay saturated after neutralization.
+        let saturated_in = [0.8f32, 0.2, 0.1];
+        let r_s = m[0] * saturated_in[0] + m[1] * saturated_in[1] + m[2] * saturated_in[2];
+        let g_s = m[3] * saturated_in[0] + m[4] * saturated_in[1] + m[5] * saturated_in[2];
+        let b_s = m[6] * saturated_in[0] + m[7] * saturated_in[1] + m[8] * saturated_in[2];
+        // The output must not be nearly gray (max - min must be substantial).
+        let spread = (r_s - g_s).abs().max((g_s - b_s).abs()).max((r_s - b_s).abs());
+        assert!(spread > 0.1, "saturated input was crushed to near-gray: r={r_s:.4} g={g_s:.4} b={b_s:.4}");
+    }
 }

--- a/engine-rs/crates/lopsy-core/src/raf/base_curves.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/base_curves.rs
@@ -99,7 +99,47 @@ pub const FUJI_DR400: BaseCurve = BaseCurve {
 /// (the camera's "standard" rendering) when no model-specific override
 /// is known.
 pub fn default_curve_for_model(_camera_model: &str) -> &'static BaseCurve {
-    &FUJI_VELVIA
+    &FUJI_PROVIA
+}
+
+/// Select the base curve matching the Fujifilm FilmMode makernote tag (0x1401).
+/// Falls back to Provia (the camera's "Standard" rendering) when the mode is
+/// unknown or absent.
+///
+/// Tag values follow the exiftool FujiFilm FilmMode convention:
+///   0x000              → Standard / Provia
+///   0x100/0x120/0x130  → Astia / portrait family variants
+///   0x200              → Velvia (Fujichrome, vivid)
+///   0x300              → Astia family
+///   0x400              → Velvia (another Velvia variant)
+///   0x500/0x501        → Pro Neg Std / Pro Neg Hi — no dedicated curve, use Provia
+///   0x600              → Classic Chrome
+pub fn curve_for_film_mode(film_mode: Option<u16>) -> &'static BaseCurve {
+    match film_mode {
+        Some(0x000) => &FUJI_PROVIA,
+        Some(0x100) | Some(0x120) | Some(0x130) => &FUJI_ASTIA,
+        Some(0x200) => &FUJI_VELVIA,
+        Some(0x300) => &FUJI_ASTIA,
+        Some(0x400) => &FUJI_VELVIA,
+        Some(0x500) | Some(0x501) => &FUJI_PROVIA,
+        Some(0x600) => &FUJI_CLASSIC_CHROME,
+        _ => &FUJI_PROVIA,
+    }
+}
+
+/// Linear-space chroma multiplier approximating each film simulation's
+/// saturation, applied before the tone curve and sRGB gamma. These are
+/// stronger than equivalent display-space factors because gamma compresses
+/// the chroma boost. Values are look approximations, not measured LUTs.
+pub fn saturation_for_film_mode(film_mode: Option<u16>) -> f32 {
+    match film_mode {
+        Some(0x200) | Some(0x400) => 3.4,                          // Velvia (vivid)
+        Some(0x000) => 3.0,                                         // Provia (standard)
+        Some(0x100) | Some(0x120) | Some(0x130) | Some(0x300) => 2.4, // Astia/portrait (soft)
+        Some(0x600) => 2.4,                                         // Classic Chrome (muted)
+        Some(0x500) | Some(0x501) => 2.2,                          // Pro Neg
+        _ => 3.0,                                                    // default ~Provia
+    }
 }
 
 // ── Apply ────────────────────────────────────────────────────────────
@@ -117,7 +157,14 @@ pub fn apply_base_curve(rgb: &mut [f32], curve: &BaseCurve) {
 /// 4096 entries: enough resolution that linear interpolation between
 /// adjacent samples adds less error than the curve's own quantization
 /// after sRGB gamma.
-const LUT_SIZE: usize = 4096;
+pub const LUT_SIZE: usize = 4096;
+
+/// Build and return the precomputed LUT for a curve. Callers that want
+/// luminance-preserving application (via `color::apply_lut`) use this
+/// instead of `apply_base_curve`, which applies the curve per-channel.
+pub fn curve_lut(curve: &BaseCurve) -> [f32; LUT_SIZE] {
+    build_lut(curve)
+}
 
 fn sample_lut(lut: &[f32; LUT_SIZE], x: f32) -> f32 {
     let xc = x.clamp(0.0, 1.0);

--- a/engine-rs/crates/lopsy-core/src/raf/base_curves.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/base_curves.rs
@@ -131,14 +131,17 @@ pub fn curve_for_film_mode(film_mode: Option<u16>) -> &'static BaseCurve {
 /// saturation, applied before the tone curve and sRGB gamma. These are
 /// stronger than equivalent display-space factors because gamma compresses
 /// the chroma boost. Values are look approximations, not measured LUTs.
+///
+/// Values reduced from their previous (3.x) crutch levels now that the
+/// CFA phase is correctly aligned and real sensor chroma is preserved.
 pub fn saturation_for_film_mode(film_mode: Option<u16>) -> f32 {
     match film_mode {
-        Some(0x200) | Some(0x400) => 3.4,                          // Velvia (vivid)
-        Some(0x000) => 3.0,                                         // Provia (standard)
-        Some(0x100) | Some(0x120) | Some(0x130) | Some(0x300) => 2.4, // Astia/portrait (soft)
-        Some(0x600) => 2.4,                                         // Classic Chrome (muted)
-        Some(0x500) | Some(0x501) => 2.2,                          // Pro Neg
-        _ => 3.0,                                                    // default ~Provia
+        Some(0x200) | Some(0x400) => 1.40,                              // Velvia (vivid)
+        Some(0x000) => 1.20,                                             // Provia (standard)
+        Some(0x100) | Some(0x120) | Some(0x130) | Some(0x300) => 1.12, // Astia/portrait (soft)
+        Some(0x600) => 1.15,                                             // Classic Chrome (muted)
+        Some(0x500) | Some(0x501) => 1.10,                              // Pro Neg
+        _ => 1.20,                                                        // default ~Provia
     }
 }
 

--- a/engine-rs/crates/lopsy-core/src/raf/mod.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/mod.rs
@@ -26,6 +26,30 @@ use crate::dng::color;
 use crate::dng::tiff::TiffReader;
 use crate::dng::demosaic;
 
+/// Which demosaic algorithm `read_raf_opts` uses for X-Trans sensors.
+#[derive(Clone, Copy, PartialEq)]
+pub enum DemosaicMode {
+    /// Full Markesteijn multi-pass (production quality).
+    Markesteijn,
+    /// Nearest-same-colour lookup, phase-faithful but deliberately dumb.
+    /// Used only for the demosaic-localisation experiment.
+    Nearest,
+}
+
+/// Decode options for `read_raf_opts`.
+#[derive(Clone, Copy)]
+pub struct RafDecodeOpts {
+    pub demosaic: DemosaicMode,
+    /// Whether to apply post-demosaic chroma + luma denoise.
+    pub denoise: bool,
+}
+
+impl Default for RafDecodeOpts {
+    fn default() -> Self {
+        Self { demosaic: DemosaicMode::Markesteijn, denoise: true }
+    }
+}
+
 /// EXIF and Fujifilm makernote metadata extracted from the embedded JPEG preview.
 #[derive(Debug, Clone, Default)]
 pub struct RafExifInfo {
@@ -47,7 +71,19 @@ pub struct RafImage {
     pub debug_log: Vec<String>,
 }
 
+/// Decode a Fujifilm RAF file with production defaults (Markesteijn demosaic,
+/// denoise on). This is the stable public interface called by the WASM bridge;
+/// its behaviour is identical to the pre-opts code.
 pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
+    read_raf_opts(data, RafDecodeOpts::default())
+}
+
+/// Decode a Fujifilm RAF file with caller-supplied options.
+///
+/// `opts.demosaic` selects the X-Trans demosaic algorithm (Bayer path is
+/// always bilinear regardless). `opts.denoise` gates the chroma-median
+/// and luma-bilateral post-demosaic passes.
+pub fn read_raf_opts(data: &[u8], opts: RafDecodeOpts) -> Result<RafImage, String> {
     let mut debug_log: Vec<String> = Vec::new();
     macro_rules! raf_log {
         ($($arg:tt)*) => { debug_log.push(format!($($arg)*)); };
@@ -249,7 +285,9 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     let is_xtrans = camera_model_is_xtrans(&camera_model);
     let base_pat = cfa_pattern.as_ref().copied().unwrap_or(DEFAULT_XTRANS_CFA);
     let cfa = if is_xtrans {
-        shift_cfa(&base_pat, crop_top as usize, crop_left as usize)
+        let (rs, cs) = detect_cfa_shift(&normalized, w, h, &base_pat, crop_top as usize, crop_left as usize);
+        raf_log!("[RAF] CFA phase auto-detected: row_shift={}, col_shift={}", rs, cs);
+        shift_cfa(&base_pat, rs, cs)
     } else {
         [0u8, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2,
          0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2,
@@ -257,11 +295,21 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     };
     let cfa_period = if is_xtrans { 6 } else { 2 };
 
-    if let Some(as_shot) = cfa_meta.as_shot_wb {
-        raf_log!("[RAF] as-shot WB (tag 0xF00D, not used): [{:.4}, {:.4}, {:.4}]", as_shot[0], as_shot[1], as_shot[2]);
-    }
-    let wb = auto_wb_gray_world(&normalized, w, h, &cfa, cfa_period);
-    raf_log!("[RAF] WB (gray-world): [{:.4}, {:.4}, {:.4}]", wb[0], wb[1], wb[2]);
+    // Use the camera's as-shot WB from tag 0xF00D when present; it is expressed
+    // as [r/g, 1, b/g] multipliers. Fall back to gray-world only when absent
+    // (e.g. some third-party RAF writers omit the tag). The as-shot values can
+    // clip R/B highlights before G, but desaturate_highlights (applied later)
+    // handles that by blending towards neutral luma.
+    let wb = if let Some(as_shot) = cfa_meta.as_shot_wb {
+        raf_log!("[RAF] WB source: as-shot (tag 0xF00D): [{:.4}, {:.4}, {:.4}]",
+            as_shot[0], as_shot[1], as_shot[2]);
+        as_shot
+    } else {
+        let gw = auto_wb_gray_world(&normalized, w, h, &cfa, cfa_period);
+        raf_log!("[RAF] WB source: gray-world fallback: [{:.4}, {:.4}, {:.4}]",
+            gw[0], gw[1], gw[2]);
+        gw
+    };
     for row in 0..h {
         for col in 0..w {
             let cfa_idx = (row % cfa_period) * cfa_period + (col % cfa_period);
@@ -273,9 +321,16 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     // ── Demosaic ────────────────────────────────────────────────
 
     let mut rgb_f32 = if is_xtrans {
-        raf_log!("[RAF] X-Trans demosaic (CFA shifted by row={}, col={})",
-            crop_top % 6, crop_left % 6);
-        xtrans::demosaic_xtrans(&normalized, width, height, &cfa)
+        match opts.demosaic {
+            DemosaicMode::Markesteijn => {
+                raf_log!("[RAF] X-Trans demosaic Markesteijn");
+                xtrans::demosaic_xtrans(&normalized, width, height, &cfa)
+            }
+            DemosaicMode::Nearest => {
+                raf_log!("[RAF] X-Trans demosaic nearest-neighbour (diagnostic)");
+                xtrans::demosaic_nearest(&normalized, width, height, &cfa)
+            }
+        }
     } else {
         raf_log!("[RAF] Bayer demosaic");
         demosaic::bilinear(&normalized, width, height, &cfa[..4])
@@ -304,23 +359,25 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     // real sensor data by median-filtering the color-difference planes.
     // A median erases isolated false-color pixels while preserving edges
     // and real color regions — unlike a box blur it cannot desaturate.
-    raf_log!("[RAF] chroma denoise (separable median, radius 3 — spans 6px CFA period)");
-    denoise_chroma(&mut rgb_f32, w, h);
+    if opts.denoise {
+        // The green-sublattice phase misalignment is now fixed at the source,
+        // so this is a mild residual chroma noise pass — not a grid-eraser.
+        // Radius 1 (3-wide separable median) removes isolated false-color speckle
+        // while leaving real color edges and fine detail intact.
+        raf_log!("[RAF] chroma denoise (separable median, radius 1)");
+        denoise_chroma(&mut rgb_f32, w, h);
 
-    // ── Luma denoise (bilateral, linear space) ──────────────────
-    // Sensor grain and residual demosaic texture appear as luma variation in
-    // flat areas. Filtering before saturation and the tone curve means the
-    // smoothed signal is never amplified. range_sigma ~0.04 in linear space
-    // is conservative: the raw sits in the lower ~30% of [0,1], so 0.04
-    // bridges same-level noise while real edges (≥several×0.04) are unaffected.
-    // Radius 3 (7-px window) is chosen so the filter spans the full 6×6 CFA
-    // period: the X-Trans green sub-lattice sits on different sites than R/B,
-    // and the small residual green-vs-R/B level difference shows up as a fine
-    // diagonal luminance weave at the mosaic period. A window narrower than the
-    // period cannot average that weave out; a 7-px window does, while the range
-    // term keeps real edges intact.
-    raf_log!("[RAF] luma denoise bilateral (radius=3, range_sigma=0.05)");
-    denoise_luma_bilateral(&mut rgb_f32, w, h, 3, 0.05);
+        // ── Luma denoise (bilateral, linear space) ──────────────────
+        // Mild grain reduction on real sensor noise. The green-sublattice weave
+        // that previously required a radius-3 bilateral to span the full 6×6 CFA
+        // period is now eliminated at the demosaic phase, so a lighter pass
+        // suffices. range_sigma ~0.03 bridges only same-level sensor grain;
+        // real edges (much larger step) are unaffected.
+        raf_log!("[RAF] luma denoise bilateral (radius=2, range_sigma=0.03)");
+        denoise_luma_bilateral(&mut rgb_f32, w, h, 2, 0.03);
+    } else {
+        raf_log!("[RAF] denoise skipped (opts.denoise=false)");
+    }
 
     // ── Film-sim saturation (linear space) ─────────────────────
     // Fuji film sims are much more saturated than a plain colorimetric
@@ -334,10 +391,10 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
 
     // ── Exposure boost ─────────────────────────────────────────
     // Raw sensor data uses ~30% of the 14-bit range (cameras expose for
-    // highlights to preserve headroom). Gray-world WB produces near-unity
-    // multipliers (no ~1.8× as-shot boost), so a larger scale is needed
-    // here to restore perceived brightness. Done in linear space.
-    const EXPOSURE_SCALE: f32 = 1.8;
+    // highlights to preserve headroom). The as-shot WB already boosts R/B
+    // ~1.8×, so a smaller scale is needed than with gray-world. Done in
+    // linear space.
+    const EXPOSURE_SCALE: f32 = 1.3;
     for v in rgb_f32.iter_mut() {
         *v *= EXPOSURE_SCALE;
     }
@@ -391,6 +448,242 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
         apply_exif_orientation(width, height, &rgba, exif_orientation);
 
     Ok(RafImage { width: final_w, height: final_h, pixels: final_pixels, exif_info, debug_log })
+}
+
+/// Diagnostic accessor: run the decode up to and including per-CFA-channel
+/// white balance, returning the cropped WB-applied mosaic plane plus dims and
+/// the shifted CFA pattern. Used only by the demosaic-localisation experiment.
+pub fn debug_wb_mosaic(data: &[u8]) -> Result<(Vec<f32>, usize, usize, [u8; 36]), String> {
+    if data.len() < 120 {
+        return Err("File too small for RAF header".into());
+    }
+    if &data[0..16] != b"FUJIFILMCCD-RAW " {
+        return Err("Not a Fujifilm RAF file (bad magic)".into());
+    }
+
+    let camera_model = parse_camera_model(&data[28..60]);
+
+    let cfa_header_offset = read_be_u32(data, 92) as usize;
+    let cfa_header_length = read_be_u32(data, 96) as usize;
+    let cfa_data_offset   = read_be_u32(data, 100) as usize;
+    let cfa_data_length   = read_be_u32(data, 104) as usize;
+
+    if cfa_data_offset + cfa_data_length > data.len() {
+        return Err("CFA data extends past end of file".into());
+    }
+
+    let cfa_header_info = if cfa_header_offset > 0
+        && cfa_header_offset + cfa_header_length <= data.len()
+        && cfa_header_length >= 4
+    {
+        parse_cfa_header(&data[cfa_header_offset..cfa_header_offset + cfa_header_length])
+    } else {
+        None
+    };
+
+    let cfa_pattern  = cfa_header_info.as_ref().and_then(|h| h.cfa_pattern);
+    let crop_top     = cfa_header_info.as_ref().map(|h| h.crop_top).unwrap_or(0);
+    let crop_left    = cfa_header_info.as_ref().map(|h| h.crop_left).unwrap_or(0);
+    let out_w        = cfa_header_info.as_ref().and_then(|h| h.output_width);
+    let out_h        = cfa_header_info.as_ref().and_then(|h| h.output_height);
+
+    let cfa_section = &data[cfa_data_offset..cfa_data_offset + cfa_data_length];
+    let cfa_meta    = parse_cfa_tiff(cfa_section)?;
+
+    let raw_w  = cfa_meta.width as usize;
+    let raw_h  = cfa_meta.height as usize;
+    let bits   = cfa_meta.bits_per_sample;
+    let pixel_offset = cfa_meta.strip_offset as usize;
+    let pixel_bytes  = cfa_meta.strip_byte_count as usize;
+
+    if pixel_offset + pixel_bytes > cfa_section.len() {
+        return Err("Pixel data extends past CFA section".into());
+    }
+    let pixel_data = &cfa_section[pixel_offset..pixel_offset + pixel_bytes];
+
+    let white_level: u16 = if bits > 0 && bits <= 16 {
+        ((1u32 << bits) - 1) as u16
+    } else {
+        u16::MAX
+    };
+
+    let base_pat_for_decompress = cfa_pattern.as_ref().copied().unwrap_or(DEFAULT_XTRANS_CFA);
+    let structured_compressed = compression::is_compressed_strip(pixel_data, raw_w as u32, raw_h as u32);
+    let is_compressed = cfa_meta.is_compressed || structured_compressed;
+
+    let raw_plane: Vec<u16> = if is_compressed {
+        compression::decompress_fuji_strip(pixel_data, raw_w as u32, raw_h as u32, &base_pat_for_decompress)
+            .map_err(|e| format!("Compressed RAF decode failed: {e}"))?
+    } else {
+        let expected_bytes = raw_w * raw_h * 2;
+        if pixel_bytes < expected_bytes {
+            return Err(format!("Pixel data too small: expected {expected_bytes}, got {pixel_bytes}"));
+        }
+        let mut buf = Vec::with_capacity(raw_w * raw_h);
+        for i in 0..(raw_w * raw_h) {
+            let off = i * 2;
+            if off + 1 < pixel_data.len() {
+                buf.push(u16::from_le_bytes([pixel_data[off], pixel_data[off + 1]]));
+            } else {
+                buf.push(0);
+            }
+        }
+        buf
+    };
+
+    let width  = out_w.unwrap_or(raw_w as u32).min(raw_w as u32 - crop_left as u32);
+    let height = out_h.unwrap_or(raw_h as u32).min(raw_h as u32 - crop_top as u32);
+    let w = width as usize;
+    let h = height as usize;
+
+    let black   = cfa_meta.black_level.unwrap_or(0.0);
+    let max_val = white_level as f64;
+    let range   = max_val - black;
+
+    let mut normalized: Vec<f32> = Vec::with_capacity(w * h);
+    for row in 0..h {
+        let src_row = row + crop_top as usize;
+        for col in 0..w {
+            let src_col = col + crop_left as usize;
+            let idx = src_row * raw_w + src_col;
+            let v = raw_plane.get(idx).copied().unwrap_or(0).min(white_level);
+            normalized.push(((v as f64 - black) / range).clamp(0.0, 1.0) as f32);
+        }
+    }
+
+    let is_xtrans = camera_model_is_xtrans(&camera_model);
+    let base_pat = cfa_pattern.as_ref().copied().unwrap_or(DEFAULT_XTRANS_CFA);
+    let cfa = if is_xtrans {
+        let (rs, cs) = detect_cfa_shift(&normalized, w, h, &base_pat, crop_top as usize, crop_left as usize);
+        shift_cfa(&base_pat, rs, cs)
+    } else {
+        [0u8, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2,
+         0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2,
+         0, 1, 1, 2]
+    };
+    let cfa_period = if is_xtrans { 6 } else { 2 };
+
+    let wb = if let Some(as_shot) = cfa_meta.as_shot_wb {
+        as_shot
+    } else {
+        auto_wb_gray_world(&normalized, w, h, &cfa, cfa_period)
+    };
+    for row in 0..h {
+        for col in 0..w {
+            let cfa_idx = (row % cfa_period) * cfa_period + (col % cfa_period);
+            let color = cfa[cfa_idx] as usize;
+            normalized[row * w + col] *= wb[color];
+        }
+    }
+
+    Ok((normalized, w, h, cfa))
+}
+
+/// Diagnostic accessor: decode up to the cropped, normalised raw mosaic
+/// (black-subtracted, [0,1]) BEFORE white balance, returning it with dims, the
+/// raw 6×6 CFA pattern as read from the file (tag 0x0131, Fuji indices, NOT
+/// shifted/remapped), and the crop offsets. Used by the CFA phase-alignment sweep.
+///
+/// Returns `(normalized, w, h, base_pattern_from_file, crop_top, crop_left)`.
+/// For compressed RAF files this returns an error — convert to uncompressed first.
+pub fn debug_raw_mosaic(data: &[u8]) -> Result<(Vec<f32>, usize, usize, [u8; 36], u32, u32), String> {
+    if data.len() < 120 {
+        return Err("File too small for RAF header".into());
+    }
+    if &data[0..16] != b"FUJIFILMCCD-RAW " {
+        return Err("Not a Fujifilm RAF file (bad magic)".into());
+    }
+
+    let cfa_header_offset = read_be_u32(data, 92) as usize;
+    let cfa_header_length = read_be_u32(data, 96) as usize;
+    let cfa_data_offset   = read_be_u32(data, 100) as usize;
+    let cfa_data_length   = read_be_u32(data, 104) as usize;
+
+    if cfa_data_offset + cfa_data_length > data.len() {
+        return Err("CFA data extends past end of file".into());
+    }
+
+    let cfa_header_info = if cfa_header_offset > 0
+        && cfa_header_offset + cfa_header_length <= data.len()
+        && cfa_header_length >= 4
+    {
+        parse_cfa_header(&data[cfa_header_offset..cfa_header_offset + cfa_header_length])
+    } else {
+        None
+    };
+
+    let cfa_pattern  = cfa_header_info.as_ref().and_then(|h| h.cfa_pattern);
+    let crop_top     = cfa_header_info.as_ref().map(|h| h.crop_top).unwrap_or(0);
+    let crop_left    = cfa_header_info.as_ref().map(|h| h.crop_left).unwrap_or(0);
+    let out_w        = cfa_header_info.as_ref().and_then(|h| h.output_width);
+    let out_h        = cfa_header_info.as_ref().and_then(|h| h.output_height);
+
+    // The base pattern from file (Fuji indices: 0=B, 1=G, 2=R) — NOT shifted/remapped.
+    let base_pat = cfa_pattern.unwrap_or(DEFAULT_XTRANS_CFA);
+
+    let cfa_section = &data[cfa_data_offset..cfa_data_offset + cfa_data_length];
+    let cfa_meta    = parse_cfa_tiff(cfa_section)?;
+
+    let raw_w  = cfa_meta.width as usize;
+    let raw_h  = cfa_meta.height as usize;
+    let bits   = cfa_meta.bits_per_sample;
+    let pixel_offset = cfa_meta.strip_offset as usize;
+    let pixel_bytes  = cfa_meta.strip_byte_count as usize;
+
+    if pixel_offset + pixel_bytes > cfa_section.len() {
+        return Err("Pixel data extends past CFA section".into());
+    }
+    let pixel_data = &cfa_section[pixel_offset..pixel_offset + pixel_bytes];
+
+    let white_level: u16 = if bits > 0 && bits <= 16 {
+        ((1u32 << bits) - 1) as u16
+    } else {
+        u16::MAX
+    };
+
+    let structured_compressed = compression::is_compressed_strip(pixel_data, raw_w as u32, raw_h as u32);
+    let is_compressed = cfa_meta.is_compressed || structured_compressed;
+
+    if is_compressed {
+        return Err("debug_raw_mosaic: compressed RAF not supported — convert to uncompressed first".into());
+    }
+
+    let expected_bytes = raw_w * raw_h * 2;
+    if pixel_bytes < expected_bytes {
+        return Err(format!("Pixel data too small: expected {expected_bytes}, got {pixel_bytes}"));
+    }
+    let mut raw_plane = Vec::with_capacity(raw_w * raw_h);
+    for i in 0..(raw_w * raw_h) {
+        let off = i * 2;
+        if off + 1 < pixel_data.len() {
+            raw_plane.push(u16::from_le_bytes([pixel_data[off], pixel_data[off + 1]]));
+        } else {
+            raw_plane.push(0);
+        }
+    }
+
+    let width  = out_w.unwrap_or(raw_w as u32).min(raw_w as u32 - crop_left as u32);
+    let height = out_h.unwrap_or(raw_h as u32).min(raw_h as u32 - crop_top as u32);
+    let w = width as usize;
+    let h = height as usize;
+
+    let black   = cfa_meta.black_level.unwrap_or(0.0);
+    let max_val = white_level as f64;
+    let range   = (max_val - black).max(1.0);
+
+    let mut normalized = Vec::with_capacity(w * h);
+    for row in 0..h {
+        let src_row = row + crop_top as usize;
+        for col in 0..w {
+            let src_col = col + crop_left as usize;
+            let idx = src_row * raw_w + src_col;
+            let v = raw_plane.get(idx).copied().unwrap_or(0).min(white_level);
+            normalized.push(((v as f64 - black) / range).clamp(0.0, 1.0) as f32);
+        }
+    }
+
+    // Return the base pattern as read from file (Fuji indices, NOT shifted/remapped).
+    Ok((normalized, w, h, base_pat, crop_top, crop_left))
 }
 
 /// Apply EXIF orientation tag to a RGBA f32 buffer. Returns new (w, h, pixels).
@@ -597,6 +890,99 @@ fn parse_camera_model(bytes: &[u8]) -> String {
     String::from_utf8_lossy(&bytes[..end]).trim().to_string()
 }
 
+/// Auto-detect the X-Trans CFA phase shift (row_shift, col_shift) to apply to
+/// the file's base pattern. The green sublattice is physically ~1.8× brighter
+/// than R/B sites, so the correct alignment is the (row_shift, col_shift) whose
+/// green-labelled positions cluster tightest in per-position raw brightness.
+/// Among the (R/B-ambiguous) best-scoring ties, prefer the shift implied by the
+/// crop offset (sensor readout constant +4,+1 from crop%6) to resolve R vs B.
+fn detect_cfa_shift(
+    normalized: &[f32],
+    w: usize,
+    h: usize,
+    base_pat: &[u8; 36],
+    crop_top: usize,
+    crop_left: usize,
+) -> (usize, usize) {
+    // Accumulate per-6×6-position mean brightness over the interior of the image.
+    // Exclude the outer 1/8 border (overscan / sensor edge effects) and very dark
+    // values (< 0.01) that are black pixels or below the black level.
+    let row_start = h / 8;
+    let row_end   = (7 * h) / 8;
+    let col_start = w / 8;
+    let col_end   = (7 * w) / 8;
+
+    let mut pos_sum   = [0.0f64; 36];
+    let mut pos_count = [0u64; 36];
+
+    for row in row_start..row_end {
+        for col in col_start..col_end {
+            let v = normalized[row * w + col];
+            if v < 0.01 {
+                continue;
+            }
+            let pos = (row % 6) * 6 + (col % 6);
+            pos_sum[pos]   += v as f64;
+            pos_count[pos] += 1;
+        }
+    }
+
+    let pos_mean: [f64; 36] = std::array::from_fn(|i| {
+        if pos_count[i] > 0 { pos_sum[i] / pos_count[i] as f64 } else { 0.0 }
+    });
+
+    // Score each shift by how tightly its green positions cluster in brightness.
+    // Lower spread (max−min for green + max−min for non-green) = better alignment.
+    let mut best_score = f64::MAX;
+    let mut best_shifts: Vec<(usize, usize)> = Vec::new();
+
+    for rs in 0..6 {
+        for cs in 0..6 {
+            let mut g_min = f64::MAX;
+            let mut g_max = f64::MIN;
+            let mut non_g_min = f64::MAX;
+            let mut non_g_max = f64::MIN;
+
+            for r in 0..6 {
+                for c in 0..6 {
+                    let pat_idx = ((r + rs) % 6) * 6 + ((c + cs) % 6);
+                    let mean = pos_mean[r * 6 + c];
+                    if base_pat[pat_idx] == 1 {
+                        // Fujifilm index 1 = green
+                        if mean < g_min { g_min = mean; }
+                        if mean > g_max { g_max = mean; }
+                    } else {
+                        if mean < non_g_min { non_g_min = mean; }
+                        if mean > non_g_max { non_g_max = mean; }
+                    }
+                }
+            }
+
+            let g_spread    = if g_max > g_min { g_max - g_min } else { 0.0 };
+            let non_g_spread = if non_g_max > non_g_min { non_g_max - non_g_min } else { 0.0 };
+            let score = g_spread + non_g_spread;
+
+            if score < best_score - 1e-6 {
+                best_score = score;
+                best_shifts.clear();
+                best_shifts.push((rs, cs));
+            } else if score < best_score + 1e-6 {
+                best_shifts.push((rs, cs));
+            }
+        }
+    }
+
+    // Tie-break: the sensor readout places crop%6 at a constant (+4,+1) offset
+    // from the physically-correct phase. Use that formula to resolve R/B when
+    // multiple shifts score equally well.
+    let formula = ((crop_top % 6 + 4) % 6, (crop_left % 6 + 1) % 6);
+    if best_shifts.contains(&formula) {
+        return formula;
+    }
+
+    best_shifts.into_iter().next().unwrap_or((1, 1))
+}
+
 /// Shift the CFA pattern by the crop offset so it aligns with the
 /// cropped output pixels, and remap Fujifilm's color indices
 /// (0=B, 1=G, 2=R in RAF files) to the standard convention
@@ -753,14 +1139,11 @@ fn denoise_chroma(rgb: &mut [f32], w: usize, h: usize) {
         cb[i] = rgb[o + 2] - l;
     }
 
-    // The X-Trans demosaic leaves a CFA-locked false-colour lattice whose
-    // period is the 6×6 mosaic. A 3×3 median only spans half that period, so
-    // the lattice survives and — once the saturation boost amplifies it and the
-    // canvas resamples it at non-integer zoom — aliases into a coarse coloured
-    // checkerboard (moiré). A separable median whose window (2·3+1 = 7) exceeds
-    // the 6-px period erases the lattice while still preserving real colour
-    // edges (a median does not average across them, unlike a box blur).
-    const CHROMA_MEDIAN_RADIUS: i32 = 3;
+    // Residual chroma speckle from demosaicing (isolated false-color pixels).
+    // The CFA phase is now correctly aligned at the source, so there is no
+    // period-6 false-colour lattice to erase — a 3-wide median (radius 1)
+    // is sufficient to clean up isolated outlier pixels without over-smoothing.
+    const CHROMA_MEDIAN_RADIUS: i32 = 1;
     cr = median_filter_separable(&cr, w, h, CHROMA_MEDIAN_RADIUS);
     cg = median_filter_separable(&cg, w, h, CHROMA_MEDIAN_RADIUS);
     cb = median_filter_separable(&cb, w, h, CHROMA_MEDIAN_RADIUS);
@@ -1199,6 +1582,39 @@ fn color_matrix_for_model(model: &str) -> [f32; 9] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detect_cfa_shift_finds_correct_phase() {
+        // Build a synthetic mosaic where green positions (per a (1,1)-shifted pattern)
+        // are 1.8× brighter than R/B sites. Use crop_top=3, crop_left=0 so that the
+        // formula tie-breaker resolves to exactly (1,1):
+        //   formula_rs = (3 % 6 + 4) % 6 = 1
+        //   formula_cs = (0 % 6 + 1) % 6 = 1
+        let target_rs = 1usize;
+        let target_cs = 1usize;
+
+        // Build the "true" CFA for the output crop: base_pat shifted by (1,1).
+        let base_pat = DEFAULT_XTRANS_CFA;
+        let true_cfa = shift_cfa(&base_pat, target_rs, target_cs);
+
+        let w = 48usize;
+        let h = 48usize;
+        let mut mosaic = vec![0.0f32; w * h];
+        for row in 0..h {
+            for col in 0..w {
+                let cfa_idx = (row % 6) * 6 + (col % 6);
+                // Fuji green (index 1 in base_pat) is ~1.8× brighter than R/B.
+                // After shift_cfa remapping, green = standard index 1.
+                mosaic[row * w + col] = if true_cfa[cfa_idx] == 1 { 0.18 } else { 0.10 };
+            }
+        }
+
+        // crop_top=3, crop_left=0 → formula=(1,1); it is among the best-scoring
+        // ties, so the detector returns it.
+        let (rs, cs) = detect_cfa_shift(&mosaic, w, h, &base_pat, 3, 0);
+        assert_eq!((rs, cs), (target_rs, target_cs),
+            "detector returned ({rs},{cs}), expected ({target_rs},{target_cs})");
+    }
 
     #[test]
     fn row_normalized_matrix_keeps_gray_neutral() {

--- a/engine-rs/crates/lopsy-core/src/raf/mod.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/mod.rs
@@ -26,10 +26,24 @@ use crate::dng::color;
 use crate::dng::tiff::TiffReader;
 use crate::dng::demosaic;
 
+/// EXIF and Fujifilm makernote metadata extracted from the embedded JPEG preview.
+#[derive(Debug, Clone, Default)]
+pub struct RafExifInfo {
+    /// EXIF orientation tag (0x0112). Defaults to 1 (no rotation) when absent.
+    pub orientation: u16,
+    /// Fujifilm FilmMode makernote tag (0x1401). None when absent or unreadable.
+    pub film_mode: Option<u16>,
+    /// Fujifilm WhiteBalance makernote tag (0x1002). None when absent or unreadable.
+    pub white_balance: Option<u16>,
+    /// Fujifilm DynamicRange makernote tag (0x1400). None when absent or unreadable.
+    pub dynamic_range: Option<u16>,
+}
+
 pub struct RafImage {
     pub width: u32,
     pub height: u32,
     pub pixels: Vec<f32>,
+    pub exif_info: RafExifInfo,
     pub debug_log: Vec<String>,
 }
 
@@ -49,17 +63,19 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     let camera_model = parse_camera_model(&data[28..60]);
     raf_log!("[RAF] camera model: {}", camera_model);
 
-    // EXIF orientation lives in the JPEG preview block. Read it so we
-    // can rotate the decoded image to the camera-intended orientation
-    // (portrait shots are stored landscape in the sensor's native frame).
+    // EXIF orientation and Fujifilm makernote tags live in the JPEG preview
+    // block. Parse them together so we avoid walking the APP1 structure twice.
     let jpeg_offset = read_be_u32(data, 84) as usize;
     let jpeg_length = read_be_u32(data, 88) as usize;
-    let exif_orientation = if jpeg_offset > 0 && jpeg_offset + jpeg_length <= data.len() {
-        parse_exif_orientation(&data[jpeg_offset..jpeg_offset + jpeg_length]).unwrap_or(1)
+    let exif_info = if jpeg_offset > 0 && jpeg_offset + jpeg_length <= data.len() {
+        parse_raf_exif(&data[jpeg_offset..jpeg_offset + jpeg_length])
     } else {
-        1
+        RafExifInfo { orientation: 1, ..Default::default() }
     };
+    let exif_orientation = if exif_info.orientation == 0 { 1 } else { exif_info.orientation };
     raf_log!("[RAF] EXIF orientation: {}", exif_orientation);
+    raf_log!("[RAF] film_mode: {:?}, white_balance: {:?}, dynamic_range: {:?}",
+        exif_info.film_mode, exif_info.white_balance, exif_info.dynamic_range);
 
     let cfa_header_offset = read_be_u32(data, 92) as usize;
     let cfa_header_length = read_be_u32(data, 96) as usize;
@@ -222,10 +238,13 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
         .collect();
 
     // ── Per-pixel white balance (raw CFA-aware) ─────────────────
-    // For X-Trans cameras, raw R and B channels need a significant boost
-    // (~1.9×) so a gray scene produces neutral camera RGB. After this,
-    // the camera→sRGB matrix maps gray to gray. Without this step, gray
-    // areas become magenta because the matrix expects WB-corrected input.
+    // These sensors' raw R≈G≈B for provably-neutral subjects (measured
+    // R/G≈0.95, B/G≈0.94), so the as-shot levels from tag 0xF00D
+    // (~[1.745, 1, 1.805]) are wrong as direct multipliers — they
+    // over-boost R and B and produce a magenta cast. Gray-world
+    // auto-WB approximates the correct near-unity multipliers well.
+    //
+    // The as-shot value is preserved in CfaMeta.as_shot_wb for reference.
 
     let is_xtrans = camera_model_is_xtrans(&camera_model);
     let base_pat = cfa_pattern.as_ref().copied().unwrap_or(DEFAULT_XTRANS_CFA);
@@ -238,8 +257,11 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     };
     let cfa_period = if is_xtrans { 6 } else { 2 };
 
+    if let Some(as_shot) = cfa_meta.as_shot_wb {
+        raf_log!("[RAF] as-shot WB (tag 0xF00D, not used): [{:.4}, {:.4}, {:.4}]", as_shot[0], as_shot[1], as_shot[2]);
+    }
     let wb = auto_wb_gray_world(&normalized, w, h, &cfa, cfa_period);
-    raf_log!("[RAF] WB multipliers (R,G,B) [gray-world]: [{:.4}, {:.4}, {:.4}]", wb[0], wb[1], wb[2]);
+    raf_log!("[RAF] WB (gray-world): [{:.4}, {:.4}, {:.4}]", wb[0], wb[1], wb[2]);
     for row in 0..h {
         for col in 0..w {
             let cfa_idx = (row % cfa_period) * cfa_period + (col % cfa_period);
@@ -247,8 +269,6 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
             normalized[row * w + col] *= wb[color];
         }
     }
-    let _ = wb_presets::default_daylight_wb(&camera_model);
-    let _ = matrix_compatible_wb(&camera_model);
 
     // ── Demosaic ────────────────────────────────────────────────
 
@@ -263,38 +283,84 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
 
     // ── Color matrix ────────────────────────────────────────────
     // Real per-camera camera→sRGB matrix derived from the DNG ColorMatrix1
-    // values in `color_matrix_for_model`. Row-normalized so that a neutral
-    // input (R=G=B, as produced by the gray-world WB above) maps to a
-    // neutral output — this is what keeps grays neutral instead of the
-    // magenta cast the old hand-tuned saturation matrix was working around.
-    let cam_to_srgb = normalize_matrix_rows(color_matrix_for_model(&camera_model));
+    // values in `color_matrix_for_model`. Column-scaled (neutralized) so
+    // that a neutral input (R=G=B, as produced by the as-shot WB) maps to
+    // a neutral output — this preserves off-diagonal saturation structure
+    // unlike per-row normalization, which scales each row independently and
+    // crushes saturation by up to ~5%.
+
+    let cam_to_srgb = color::neutralize_matrix(&color_matrix_for_model(&camera_model));
     raf_log!(
-        "[RAF] cam→sRGB (row-normalized): [{:.3} {:.3} {:.3}; {:.3} {:.3} {:.3}; {:.3} {:.3} {:.3}]",
+        "[RAF] cam→sRGB (neutralized): [{:.3} {:.3} {:.3}; {:.3} {:.3} {:.3}; {:.3} {:.3} {:.3}]",
         cam_to_srgb[0], cam_to_srgb[1], cam_to_srgb[2],
         cam_to_srgb[3], cam_to_srgb[4], cam_to_srgb[5],
         cam_to_srgb[6], cam_to_srgb[7], cam_to_srgb[8]
     );
+
     color::apply_matrix(&mut rgb_f32, &cam_to_srgb);
+
+    // ── Chroma denoise ─────────────────────────────────────────
+    // Remove the magenta/green speckle that X-Trans demosaicing leaves on
+    // real sensor data by median-filtering the color-difference planes.
+    // A median erases isolated false-color pixels while preserving edges
+    // and real color regions — unlike a box blur it cannot desaturate.
+    raf_log!("[RAF] chroma denoise (separable median, radius 3 — spans 6px CFA period)");
+    denoise_chroma(&mut rgb_f32, w, h);
+
+    // ── Luma denoise (bilateral, linear space) ──────────────────
+    // Sensor grain and residual demosaic texture appear as luma variation in
+    // flat areas. Filtering before saturation and the tone curve means the
+    // smoothed signal is never amplified. range_sigma ~0.04 in linear space
+    // is conservative: the raw sits in the lower ~30% of [0,1], so 0.04
+    // bridges same-level noise while real edges (≥several×0.04) are unaffected.
+    // Radius 3 (7-px window) is chosen so the filter spans the full 6×6 CFA
+    // period: the X-Trans green sub-lattice sits on different sites than R/B,
+    // and the small residual green-vs-R/B level difference shows up as a fine
+    // diagonal luminance weave at the mosaic period. A window narrower than the
+    // period cannot average that weave out; a 7-px window does, while the range
+    // term keeps real edges intact.
+    raf_log!("[RAF] luma denoise bilateral (radius=3, range_sigma=0.05)");
+    denoise_luma_bilateral(&mut rgb_f32, w, h, 3, 0.05);
+
+    // ── Film-sim saturation (linear space) ─────────────────────
+    // Fuji film sims are much more saturated than a plain colorimetric
+    // matrix render. Applied here in linear light — before the tone curve
+    // and gamma — where the luma-preserving boost is strongest. Linear
+    // saturation can push the minimum channel slightly negative; that is
+    // intentional (later RGBA conversion clamps to [0,1]).
+    let sat = base_curves::saturation_for_film_mode(exif_info.film_mode);
+    raf_log!("[RAF] film-sim saturation (linear): {sat}");
+    apply_saturation(&mut rgb_f32, sat);
 
     // ── Exposure boost ─────────────────────────────────────────
     // Raw sensor data uses ~30% of the 14-bit range (cameras expose for
-    // highlights to preserve headroom). With the base curve also lifting
-    // midtones, ~1.5× (≈ +0.6 EV) is enough to land daylight scenes at
-    // natural brightness without clipping. Done in linear space so the
-    // boost is multiplicative on light intensity.
+    // highlights to preserve headroom). Gray-world WB produces near-unity
+    // multipliers (no ~1.8× as-shot boost), so a larger scale is needed
+    // here to restore perceived brightness. Done in linear space.
     const EXPOSURE_SCALE: f32 = 1.8;
     for v in rgb_f32.iter_mut() {
         *v *= EXPOSURE_SCALE;
     }
+
+    // ── Highlight desaturation ──────────────────────────────────
+    // Bright areas can clip unevenly across R/G/B channels, which renders
+    // blown highlights as a colour cast rather than white. Blend pixels
+    // smoothly toward a neutral luminance-gray as they exceed 1.0 so that
+    // clipped regions go white instead of tinted.
+    desaturate_highlights(&mut rgb_f32);
 
     // ── Base curve (per-camera tone mapping) ───────────────────
     // Approximates the camera JPEG's tone rendering. The curve provides
     // its own highlight rolloff, replacing the previous Reinhard-style
     // compression, and shapes shadows/midtones to match the in-camera
     // look. Applied in linear light, before sRGB gamma.
-    let curve = base_curves::default_curve_for_model(&camera_model);
-    raf_log!("[RAF] applying base curve: {}", curve.name);
-    base_curves::apply_base_curve(&mut rgb_f32, curve);
+    //
+    // Prefer the film simulation recorded in the makernote when available;
+    // fall back to the generic Provia default.
+    let curve = base_curves::curve_for_film_mode(exif_info.film_mode);
+    raf_log!("[RAF] film_mode={:?} → base curve: {} (luminance-preserving)", exif_info.film_mode, curve.name);
+    let curve_lut = base_curves::curve_lut(curve);
+    color::apply_lut(&mut rgb_f32, &curve_lut);
 
     // ── sRGB gamma ──────────────────────────────────────────────
 
@@ -324,7 +390,7 @@ pub fn read_raf(data: &[u8]) -> Result<RafImage, String> {
     let (final_w, final_h, final_pixels) =
         apply_exif_orientation(width, height, &rgba, exif_orientation);
 
-    Ok(RafImage { width: final_w, height: final_h, pixels: final_pixels, debug_log })
+    Ok(RafImage { width: final_w, height: final_h, pixels: final_pixels, exif_info, debug_log })
 }
 
 /// Apply EXIF orientation tag to a RGBA f32 buffer. Returns new (w, h, pixels).
@@ -368,43 +434,153 @@ fn apply_exif_orientation(w: u32, h: u32, src: &[f32], orientation: u16) -> (u32
     (out_w, out_h, dst)
 }
 
-/// Parse the EXIF Orientation tag (0x0112) from a JPEG block.
-/// Returns the value (1..=8) or `None` if not found.
-fn parse_exif_orientation(jpeg: &[u8]) -> Option<u16> {
-    // Find APP1 with "Exif\0\0" payload
+/// Extract the embedded JPEG preview from a RAF file.
+///
+/// The preview offset (big-endian u32 at byte 84) and length (byte 88) are
+/// the same fields used by `read_raf` when parsing EXIF orientation.
+pub fn extract_jpeg_preview(data: &[u8]) -> Result<Vec<u8>, String> {
+    if data.len() < 92 {
+        return Err("File too small for RAF header".into());
+    }
+    if &data[0..16] != b"FUJIFILMCCD-RAW " {
+        return Err("Not a Fujifilm RAF file (bad magic)".into());
+    }
+    let offset = read_be_u32(data, 84) as usize;
+    let length = read_be_u32(data, 88) as usize;
+    if offset == 0 || length == 0 {
+        return Err("RAF has no JPEG preview (offset/length are zero)".into());
+    }
+    if offset + length > data.len() {
+        return Err(format!(
+            "JPEG preview extends past end of file (offset={offset}, length={length}, file_len={})",
+            data.len()
+        ));
+    }
+    Ok(data[offset..offset + length].to_vec())
+}
+
+/// Parse orientation and Fujifilm makernote tags from the JPEG preview bytes.
+///
+/// Walks APP1 → TIFF IFD0 → EXIF sub-IFD → Fujifilm makernote IFD.
+/// Every step is defensive: on any bounds error or missing tag, the function
+/// returns what it has so far rather than panicking.
+pub fn parse_raf_exif(jpeg: &[u8]) -> RafExifInfo {
+    let mut result = RafExifInfo { orientation: 1, ..Default::default() };
+
+    let Some(tiff) = find_exif_tiff(jpeg) else { return result; };
+    if tiff.len() < 8 { return result; }
+
+    let le = tiff[0] == b'I' && tiff[1] == b'I';
+
+    let ru16 = |data: &[u8], o: usize| -> Option<u16> {
+        let b = data.get(o..o + 2)?;
+        Some(if le { u16::from_le_bytes([b[0], b[1]]) } else { u16::from_be_bytes([b[0], b[1]]) })
+    };
+    let ru32 = |data: &[u8], o: usize| -> Option<u32> {
+        let b = data.get(o..o + 4)?;
+        Some(if le { u32::from_le_bytes([b[0], b[1], b[2], b[3]]) } else { u32::from_be_bytes([b[0], b[1], b[2], b[3]]) })
+    };
+
+    let ifd0_off = match ru32(tiff, 4) {
+        Some(v) => v as usize,
+        None => return result,
+    };
+
+    // Walk IFD0: collect orientation and the EXIF sub-IFD pointer.
+    let Some(ifd0_count) = ru16(tiff, ifd0_off) else { return result; };
+    let mut exif_ifd_off: Option<usize> = None;
+
+    for j in 0..ifd0_count as usize {
+        let e = ifd0_off + 2 + j * 12;
+        let Some(tag) = ru16(tiff, e) else { break; };
+        match tag {
+            0x0112 => {
+                if let Some(v) = ru16(tiff, e + 8) {
+                    result.orientation = v;
+                }
+            }
+            0x8769 => {
+                if let Some(v) = ru32(tiff, e + 8) {
+                    exif_ifd_off = Some(v as usize);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let exif_off = match exif_ifd_off {
+        Some(o) => o,
+        None => return result,
+    };
+
+    // Walk the EXIF sub-IFD to find the MakerNote (tag 0x927C).
+    let Some(exif_count) = ru16(tiff, exif_off) else { return result; };
+    let mut makernote_off: Option<usize> = None;
+
+    for j in 0..exif_count as usize {
+        let e = exif_off + 2 + j * 12;
+        let Some(tag) = ru16(tiff, e) else { break; };
+        if tag == 0x927C {
+            // UNDEFINED type: value offset points into tiff data.
+            if let Some(off) = ru32(tiff, e + 8) {
+                makernote_off = Some(off as usize);
+            }
+            break;
+        }
+    }
+
+    let mn_start = match makernote_off {
+        Some(o) => o,
+        None => return result,
+    };
+
+    // Fujifilm makernote: "FUJIFILM" (8 bytes) + u32 LE IFD offset relative
+    // to the start of the makernote blob. The internal IFD is always LE.
+    let Some(mn_blob) = tiff.get(mn_start..) else { return result; };
+    if mn_blob.len() < 12 { return result; }
+    if &mn_blob[..8] != b"FUJIFILM" { return result; }
+
+    let mn_ifd_rel = u32::from_le_bytes([mn_blob[8], mn_blob[9], mn_blob[10], mn_blob[11]]) as usize;
+    let Some(mn_ifd_blob) = mn_blob.get(mn_ifd_rel..) else { return result; };
+    if mn_ifd_blob.len() < 2 { return result; }
+
+    // Makernote IFD is always little-endian regardless of outer TIFF endianness.
+    let mn_u16 = |data: &[u8], o: usize| -> Option<u16> {
+        let b = data.get(o..o + 2)?;
+        Some(u16::from_le_bytes([b[0], b[1]]))
+    };
+
+    let mn_count = u16::from_le_bytes([mn_ifd_blob[0], mn_ifd_blob[1]]) as usize;
+    for j in 0..mn_count {
+        let e = 2 + j * 12;
+        let Some(tag) = mn_u16(mn_ifd_blob, e) else { break; };
+        match tag {
+            0x1002 => { result.white_balance = mn_u16(mn_ifd_blob, e + 8); }
+            0x1400 => { result.dynamic_range = mn_u16(mn_ifd_blob, e + 8); }
+            0x1401 => { result.film_mode = mn_u16(mn_ifd_blob, e + 8); }
+            _ => {}
+        }
+    }
+
+    result
+}
+
+/// Find the TIFF block inside a JPEG's APP1 "Exif\0\0" segment.
+/// Returns a slice starting at the TIFF header ("II" or "MM").
+fn find_exif_tiff(jpeg: &[u8]) -> Option<&[u8]> {
     let mut i = 2usize;
     while i + 4 < jpeg.len() {
         if jpeg[i] == 0xFF && jpeg[i + 1] == 0xE1 {
-            let payload = &jpeg[i + 4..];
-            if payload.len() < 6 || &payload[..4] != b"Exif" { return None; }
-            let tiff = &payload[6..];
-            if tiff.len() < 8 { return None; }
-            let le = tiff[0] == b'I' && tiff[1] == b'I';
-            let read_u16 = |o: usize| -> u16 {
-                if le { u16::from_le_bytes([tiff[o], tiff[o+1]]) }
-                else { u16::from_be_bytes([tiff[o], tiff[o+1]]) }
-            };
-            let read_u32 = |o: usize| -> u32 {
-                if le { u32::from_le_bytes([tiff[o], tiff[o+1], tiff[o+2], tiff[o+3]]) }
-                else { u32::from_be_bytes([tiff[o], tiff[o+1], tiff[o+2], tiff[o+3]]) }
-            };
-            let ifd0 = read_u32(4) as usize;
-            if ifd0 + 2 > tiff.len() { return None; }
-            let count = read_u16(ifd0) as usize;
-            for j in 0..count {
-                let off = ifd0 + 2 + j * 12;
-                if off + 12 > tiff.len() { break; }
-                let tag = read_u16(off);
-                if tag == 0x0112 {
-                    return Some(read_u16(off + 8));
-                }
-            }
-            return None;
+            let payload = jpeg.get(i + 4..)?;
+            if payload.len() < 6 { return None; }
+            if &payload[..4] != b"Exif" { return None; }
+            return payload.get(6..);
         }
         i += 1;
     }
     None
 }
+
 
 // ── Helpers ─────────────────────────────────────────────────────
 
@@ -456,9 +632,8 @@ const SIMPLE_CAM_TO_SRGB: [f32; 9] = [
 ];
 
 /// Capture-sharpening strength (fraction of the high-pass detail added
-/// back). Modest by design — enough to match the camera JPEG's crispness
-/// without visible ringing.
-const CAPTURE_SHARPEN_AMOUNT: f32 = 0.45;
+/// back). Kept mild so it does not amplify chroma speckle from demosaicing.
+const CAPTURE_SHARPEN_AMOUNT: f32 = 0.10;
 
 /// Mild luma unsharp mask on interleaved RGB. Sharpens the luminance high-
 /// frequency detail only (chroma is left untouched), which avoids the color
@@ -521,6 +696,7 @@ fn unsharp_mask_luma(rgb: &mut [f32], w: usize, h: usize, amount: f32) {
 /// combination of equal inputs. This is dcraw's gray-preservation step and
 /// is what lets us use a real per-camera color matrix without the magenta
 /// cast that comes from composing an un-normalized matrix with our WB.
+#[allow(dead_code)]
 fn normalize_matrix_rows(m: [f32; 9]) -> [f32; 9] {
     let mut out = m;
     for r in 0..3 {
@@ -534,10 +710,276 @@ fn normalize_matrix_rows(m: [f32; 9]) -> [f32; 9] {
     out
 }
 
-/// Stub — kept for future use when WB-compatible per-camera matrices
-/// are wired up. Currently unused (we use `auto_wb_gray_world`).
-fn matrix_compatible_wb(_model: &str) -> [f32; 3] {
-    [2.163, 1.0, 1.364]
+/// Boost chroma to approximate the Fujifilm film-simulation look, which is
+/// more saturated than a plain colorimetric matrix render. Luma-preserving
+/// (Rec.709): each channel is pushed away from the pixel's luma by `factor`,
+/// so grays stay neutral and only colored pixels gain saturation.
+fn apply_saturation(rgb: &mut [f32], factor: f32) {
+    if (factor - 1.0).abs() < 1e-4 { return; }
+    let n = rgb.len() / 3;
+    for i in 0..n {
+        let o = i * 3;
+        let luma = 0.2126 * rgb[o] + 0.7152 * rgb[o + 1] + 0.0722 * rgb[o + 2];
+        rgb[o]     = luma + factor * (rgb[o]     - luma);
+        rgb[o + 1] = luma + factor * (rgb[o + 1] - luma);
+        rgb[o + 2] = luma + factor * (rgb[o + 2] - luma);
+    }
+    // (final RGBA conversion already clamps to [0,1])
+}
+
+/// Suppress chroma noise (the colored speckle X-Trans demosaicing leaves on
+/// real, noisy sensor data) by median-filtering the color-difference planes.
+/// Luma carries the detail and is left untouched. A 3×3 median removes
+/// isolated false-color speckle while preserving edges and the chroma of
+/// uniform colored regions — it does not average neighbors, so it cannot
+/// desaturate a real color region the way a box blur would.
+fn denoise_chroma(rgb: &mut [f32], w: usize, h: usize) {
+    if w == 0 || h == 0 {
+        return;
+    }
+    let n = w * h;
+
+    // Extract per-pixel luma and three chroma-difference planes (R−luma, G−luma, B−luma).
+    let mut luma = vec![0.0f32; n];
+    let mut cr = vec![0.0f32; n];
+    let mut cg = vec![0.0f32; n];
+    let mut cb = vec![0.0f32; n];
+    for i in 0..n {
+        let o = i * 3;
+        let l = 0.2126 * rgb[o] + 0.7152 * rgb[o + 1] + 0.0722 * rgb[o + 2];
+        luma[i] = l;
+        cr[i] = rgb[o]     - l;
+        cg[i] = rgb[o + 1] - l;
+        cb[i] = rgb[o + 2] - l;
+    }
+
+    // The X-Trans demosaic leaves a CFA-locked false-colour lattice whose
+    // period is the 6×6 mosaic. A 3×3 median only spans half that period, so
+    // the lattice survives and — once the saturation boost amplifies it and the
+    // canvas resamples it at non-integer zoom — aliases into a coarse coloured
+    // checkerboard (moiré). A separable median whose window (2·3+1 = 7) exceeds
+    // the 6-px period erases the lattice while still preserving real colour
+    // edges (a median does not average across them, unlike a box blur).
+    const CHROMA_MEDIAN_RADIUS: i32 = 3;
+    cr = median_filter_separable(&cr, w, h, CHROMA_MEDIAN_RADIUS);
+    cg = median_filter_separable(&cg, w, h, CHROMA_MEDIAN_RADIUS);
+    cb = median_filter_separable(&cb, w, h, CHROMA_MEDIAN_RADIUS);
+
+    // Recombine: exact luma plus median-filtered chroma.
+    for i in 0..n {
+        let o = i * 3;
+        rgb[o]     = luma[i] + cr[i];
+        rgb[o + 1] = luma[i] + cg[i];
+        rgb[o + 2] = luma[i] + cb[i];
+    }
+}
+
+/// Edge-preserving luma noise reduction. Smooths luminance in flat regions
+/// (sensor grain, residual demosaic texture) while leaving edges and fine
+/// detail intact, by bilaterally weighting neighbours by both spatial distance
+/// and luma similarity. Chroma is preserved exactly: only the luma is filtered
+/// and RGB is rescaled by the luma ratio.
+fn denoise_luma_bilateral(rgb: &mut [f32], w: usize, h: usize, radius: i32, range_sigma: f32) {
+    if w == 0 || h == 0 || radius <= 0 {
+        return;
+    }
+    let n = w * h;
+
+    // Luma plane (Rec.709) for every pixel in the current linear-light RGB.
+    let mut luma = vec![0.0f32; n];
+    for i in 0..n {
+        let o = i * 3;
+        luma[i] = 0.2126 * rgb[o] + 0.7152 * rgb[o + 1] + 0.0722 * rgb[o + 2];
+    }
+
+    // Precompute spatial Gaussian weights for the (2r+1)×(2r+1) window.
+    // Spatial sigma ≈ radius/2 keeps most weight near the centre, so real
+    // detail is only marginally affected even when range_sigma is generous.
+    let r = radius as usize;
+    let side = 2 * r + 1;
+    let spatial_sigma = radius as f32 * 0.5;
+    let two_ss = 2.0 * spatial_sigma * spatial_sigma;
+    let mut spatial_w = vec![0.0f32; side * side];
+    for dy in 0..side {
+        for dx in 0..side {
+            let ddx = dx as f32 - r as f32;
+            let ddy = dy as f32 - r as f32;
+            spatial_w[dy * side + dx] = (-(ddx * ddx + ddy * ddy) / two_ss).exp();
+        }
+    }
+
+    let two_rs = 2.0 * range_sigma * range_sigma;
+
+    // Precompute the range weight exp(-dl²/2σ²) into a LUT keyed by |dl|. The
+    // weight is negligible beyond ~4σ, so tabulating |dl| over [0, 4σ] and
+    // treating anything past it as zero replaces a per-sample exp() (the hot-
+    // path cost across a 40 MP image) with an index + load.
+    const RANGE_LUT_N: usize = 1024;
+    let range_max = (4.0 * range_sigma).max(1e-6);
+    let inv_step = (RANGE_LUT_N as f32 - 1.0) / range_max;
+    let mut range_lut = vec![0.0f32; RANGE_LUT_N];
+    for k in 0..RANGE_LUT_N {
+        let d = k as f32 / inv_step;
+        range_lut[k] = (-(d * d) / two_rs).exp();
+    }
+
+    let mut luma_smooth = vec![0.0f32; n];
+
+    for row in 0..h {
+        for col in 0..w {
+            let l_center = luma[row * w + col];
+            let mut sum_w = 0.0f32;
+            let mut sum_wl = 0.0f32;
+
+            for dy in 0..side {
+                let nr = (row as i32 + dy as i32 - r as i32).clamp(0, h as i32 - 1) as usize;
+                let row_off = nr * w;
+                let sw_off = dy * side;
+                for dx in 0..side {
+                    let nc = (col as i32 + dx as i32 - r as i32).clamp(0, w as i32 - 1) as usize;
+                    let l_nb = luma[row_off + nc];
+                    // Range weight via LUT: only same-level (noisy) neighbours
+                    // contribute; across a real edge the weight collapses to 0.
+                    let idx = ((l_center - l_nb).abs() * inv_step) as usize;
+                    let range_w = if idx < RANGE_LUT_N { range_lut[idx] } else { 0.0 };
+                    let w_ij = spatial_w[sw_off + dx] * range_w;
+                    sum_w += w_ij;
+                    sum_wl += w_ij * l_nb;
+                }
+            }
+
+            luma_smooth[row * w + col] = if sum_w > 1e-8 { sum_wl / sum_w } else { l_center };
+        }
+    }
+
+    // Rescale RGB by the smoothed/original luma ratio to update only luminance;
+    // chroma ratios are kept exactly — same pattern as unsharp_mask_luma.
+    for i in 0..n {
+        let l_orig = luma[i];
+        if l_orig > 1e-4 {
+            let scale = luma_smooth[i] / l_orig;
+            let o = i * 3;
+            rgb[o]     *= scale;
+            rgb[o + 1] *= scale;
+            rgb[o + 2] *= scale;
+        }
+    }
+}
+
+/// 3×3 median filter on a single-channel plane, edge-clamped. Returns a new
+/// buffer. Preserves edges far better than a box blur; removes isolated
+/// false-color speckle without desaturating adjacent real-color pixels.
+#[allow(dead_code)]
+fn median_filter_3x3_plane(plane: &[f32], w: usize, h: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; w * h];
+    for row in 0..h {
+        for col in 0..w {
+            let mut win = [0.0f32; 9];
+            let mut k = 0;
+            for dy in -1i32..=1 {
+                let r = (row as i32 + dy).clamp(0, h as i32 - 1) as usize;
+                for dx in -1i32..=1 {
+                    let c = (col as i32 + dx).clamp(0, w as i32 - 1) as usize;
+                    win[k] = plane[r * w + c];
+                    k += 1;
+                }
+            }
+            out[row * w + col] = median9(win);
+        }
+    }
+    out
+}
+
+/// Median of 9 values via partial selection (find the 5th-smallest).
+#[inline]
+#[allow(dead_code)]
+fn median9(mut v: [f32; 9]) -> f32 {
+    for i in 0..5 {
+        let mut m = i;
+        for j in (i + 1)..9 {
+            if v[j] < v[m] {
+                m = j;
+            }
+        }
+        v.swap(i, m);
+    }
+    v[4]
+}
+
+/// Median of an odd-length window (`len` ≤ 33) via partial selection up to the
+/// middle index. Allocation-free.
+#[inline]
+fn median_window(vals: &[f32]) -> f32 {
+    let n = vals.len();
+    let mid = n / 2;
+    let mut v = [0.0f32; 33];
+    v[..n].copy_from_slice(vals);
+    for i in 0..=mid {
+        let mut m = i;
+        for j in (i + 1)..n {
+            if v[j] < v[m] {
+                m = j;
+            }
+        }
+        v.swap(i, m);
+    }
+    v[mid]
+}
+
+/// Separable median filter (horizontal pass then vertical pass) of half-width
+/// `radius`, edge-clamped. A separable approximation to a full (2r+1)² median:
+/// far cheaper, while still erasing periodic structure up to the window width.
+/// Used on the chroma planes to remove the CFA-period (6 px) false-colour
+/// lattice, which a 3×3 median's reach cannot cover.
+fn median_filter_separable(plane: &[f32], w: usize, h: usize, radius: i32) -> Vec<f32> {
+    let width = (2 * radius + 1) as usize;
+    let mut buf = vec![0.0f32; width];
+
+    let mut tmp = vec![0.0f32; w * h];
+    for row in 0..h {
+        let base = row * w;
+        for col in 0..w {
+            for k in -radius..=radius {
+                let c = (col as i32 + k).clamp(0, w as i32 - 1) as usize;
+                buf[(k + radius) as usize] = plane[base + c];
+            }
+            tmp[base + col] = median_window(&buf);
+        }
+    }
+
+    let mut out = vec![0.0f32; w * h];
+    for col in 0..w {
+        for row in 0..h {
+            for k in -radius..=radius {
+                let r = (row as i32 + k).clamp(0, h as i32 - 1) as usize;
+                buf[(k + radius) as usize] = tmp[r * w + col];
+            }
+            out[row * w + col] = median_window(&buf);
+        }
+    }
+    out
+}
+
+
+/// Blend over-exposed pixels toward neutral gray so that blown highlights
+/// render white instead of pink. The as-shot WB boost makes R and B clip
+/// before G; without this step, areas just above 1.0 show a pink fringe
+/// because R/B are at 1.0 while G still has headroom. Values remain
+/// unclamped here — the final RGBA conversion clamps to [0,1].
+fn desaturate_highlights(rgb: &mut [f32]) {
+    let n = rgb.len() / 3;
+    for i in 0..n {
+        let r = rgb[i * 3];
+        let g = rgb[i * 3 + 1];
+        let b = rgb[i * 3 + 2];
+        let m = r.max(g).max(b);
+        if m > 1.0 {
+            let t = ((m - 1.0) / 0.5).min(1.0);
+            rgb[i * 3]     = r + t * (m - r);
+            rgb[i * 3 + 1] = g + t * (m - g);
+            rgb[i * 3 + 2] = b + t * (m - b);
+        }
+    }
 }
 
 /// Gray-world auto white balance: scale each CFA channel so all three
@@ -648,6 +1090,7 @@ struct CfaMeta {
     strip_byte_count: u32,
     is_compressed: bool,
     black_level: Option<f64>,
+    as_shot_wb: Option<[f32; 3]>,
 }
 
 fn parse_cfa_tiff(cfa_section: &[u8]) -> Result<CfaMeta, String> {
@@ -685,7 +1128,23 @@ fn parse_cfa_tiff(cfa_section: &[u8]) -> Result<CfaMeta, String> {
             Some(vals.iter().map(|&v| v as f64).sum::<f64>() / vals.len() as f64)
         });
 
-    Ok(CfaMeta { width, height, bits_per_sample: bits, strip_offset, strip_byte_count, is_compressed, black_level })
+    // Tag 0xF00D: Fujifilm as-shot white balance, LONG[3] in [G, R, B] order.
+    // Green is the reference channel (typically 302); R and B are larger when
+    // the scene is warm/cool. Normalising to G gives the per-channel multipliers
+    // the demosaicker needs to make a neutral gray render as neutral.
+    let as_shot_wb = sub_ifd.iter()
+        .find(|e| e.tag == 0xF00D)
+        .and_then(|e| {
+            let vals = e.as_u32_vec()?;
+            if vals.len() < 3 { return None; }
+            let g = vals[0] as f32;
+            let r = vals[1] as f32;
+            let b = vals[2] as f32;
+            if g < 1.0 { return None; }
+            Some([r / g, 1.0f32, b / g])
+        });
+
+    Ok(CfaMeta { width, height, bits_per_sample: bits, strip_offset, strip_byte_count, is_compressed, black_level, as_shot_wb })
 }
 
 // ── X-Trans detection ───────────────────────────────────────────
@@ -804,6 +1263,181 @@ mod tests {
         for i in 0..w * h {
             let o = i * 3;
             assert!((rgb[o] - rgb[o + 1]).abs() < 1e-5 && (rgb[o + 1] - rgb[o + 2]).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn apply_saturation_neutral_gray_unchanged() {
+        // A neutral gray pixel (R==G==B) has zero chroma, so boosting
+        // saturation must leave it unchanged.
+        let mut rgb = vec![0.5f32, 0.5, 0.5];
+        apply_saturation(&mut rgb, 1.35);
+        assert!((rgb[0] - 0.5).abs() < 1e-5 && (rgb[1] - 0.5).abs() < 1e-5 && (rgb[2] - 0.5).abs() < 1e-5,
+            "gray should be unchanged: {:?}", rgb);
+    }
+
+    #[test]
+    fn apply_saturation_colored_pixel_gains_chroma() {
+        // A colored pixel should have a wider channel spread after saturation boost.
+        let mut rgb = vec![0.8f32, 0.4, 0.3];
+        let before_spread = rgb[0] - rgb[2];
+        apply_saturation(&mut rgb, 1.35);
+        let after_spread = rgb[0] - rgb[2];
+        assert!(after_spread > before_spread,
+            "channel spread should increase: before={before_spread} after={after_spread}");
+    }
+
+    #[test]
+    fn denoise_chroma_leaves_neutral_gray_unchanged() {
+        // A uniform gray image has zero chroma on every pixel; median-filtering
+        // zero planes and adding them back must yield exactly the original values.
+        let w = 8;
+        let h = 8;
+        let gray = 0.4f32;
+        let mut rgb: Vec<f32> = (0..w * h).flat_map(|_| [gray, gray, gray]).collect();
+        denoise_chroma(&mut rgb, w, h);
+        for (i, &v) in rgb.iter().enumerate() {
+            assert!(
+                (v - gray).abs() < 1e-5,
+                "neutral gray changed at index {i}: expected {gray}, got {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn denoise_chroma_reduces_single_off_color_pixel() {
+        // A single magenta-ish pixel on an otherwise neutral gray field.
+        // A 3×3 median on the chroma planes replaces the isolated outlier
+        // with the surrounding gray's zero-chroma, so the center pixel
+        // becomes neutral. Mean luma is unaffected.
+        let w = 9;
+        let h = 9;
+        let gray = 0.5f32;
+        let mut rgb: Vec<f32> = (0..w * h).flat_map(|_| [gray, gray, gray]).collect();
+
+        // Place a single noisy (magenta-ish) pixel at the center.
+        let cx = 4;
+        let cy = 4;
+        let o = (cy * w + cx) * 3;
+        rgb[o]     = 0.8;   // R high
+        rgb[o + 1] = 0.3;   // G low
+        rgb[o + 2] = 0.8;   // B high
+
+        // Record mean luma before.
+        let mean_luma_before: f32 = (0..w * h)
+            .map(|i| 0.2126 * rgb[i * 3] + 0.7152 * rgb[i * 3 + 1] + 0.0722 * rgb[i * 3 + 2])
+            .sum::<f32>() / (w * h) as f32;
+
+        denoise_chroma(&mut rgb, w, h);
+
+        let mean_luma_after: f32 = (0..w * h)
+            .map(|i| 0.2126 * rgb[i * 3] + 0.7152 * rgb[i * 3 + 1] + 0.0722 * rgb[i * 3 + 2])
+            .sum::<f32>() / (w * h) as f32;
+
+        // Luma is preserved globally (median on zero-sum chroma planes is a no-op for luma).
+        assert!(
+            (mean_luma_before - mean_luma_after).abs() < 1e-4,
+            "mean luma shifted: before={mean_luma_before} after={mean_luma_after}"
+        );
+
+        // The center pixel's chroma spread is eliminated: median picks the
+        // surrounding gray's zero chroma, so the pixel becomes neutral.
+        let center_r = rgb[o];
+        let center_g = rgb[o + 1];
+        let center_b = rgb[o + 2];
+        let spread_after = (center_r - center_g).abs().max((center_b - center_g).abs());
+        let spread_before = (0.8f32 - 0.3f32).abs().max((0.8f32 - 0.3f32).abs());
+        assert!(
+            spread_after < spread_before * 0.5,
+            "off-color pixel chroma not sufficiently reduced: before={spread_before:.3} after={spread_after:.3}"
+        );
+    }
+
+    #[test]
+    fn denoise_luma_bilateral_smooths_flat_noise() {
+        // A flat gray field with alternating ±0.02 luma jitter (fixed, deterministic)
+        // should come out smoother (lower variance) while preserving the mean
+        // and keeping the output exactly neutral (R==G==B).
+        let w = 16;
+        let h = 16;
+        let base = 0.15f32; // in linear space, near the raw's ~30% range
+        let mut rgb: Vec<f32> = (0..w * h)
+            .flat_map(|i| {
+                let v = base + if i % 2 == 0 { 0.02 } else { -0.02 };
+                [v, v, v]
+            })
+            .collect();
+
+        let variance_before = {
+            let mean = rgb.iter().step_by(3).map(|&v| v as f64).sum::<f64>() / (w * h) as f64;
+            rgb.iter().step_by(3).map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / (w * h) as f64
+        };
+        let mean_before = rgb.iter().step_by(3).map(|&v| v as f64).sum::<f64>() / (w * h) as f64;
+
+        denoise_luma_bilateral(&mut rgb, w, h, 2, 0.04);
+
+        let variance_after = {
+            let mean = rgb.iter().step_by(3).map(|&v| v as f64).sum::<f64>() / (w * h) as f64;
+            rgb.iter().step_by(3).map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / (w * h) as f64
+        };
+        let mean_after = rgb.iter().step_by(3).map(|&v| v as f64).sum::<f64>() / (w * h) as f64;
+
+        assert!(
+            variance_after < variance_before,
+            "bilateral filter did not reduce variance: before={variance_before:.6} after={variance_after:.6}"
+        );
+        assert!(
+            (mean_after - mean_before).abs() < 1e-3,
+            "mean luma shifted: before={mean_before:.5} after={mean_after:.5}"
+        );
+        // Chroma must stay neutral (R==G==B) throughout.
+        for i in 0..w * h {
+            let o = i * 3;
+            assert!(
+                (rgb[o] - rgb[o + 1]).abs() < 1e-5 && (rgb[o + 1] - rgb[o + 2]).abs() < 1e-5,
+                "chroma shifted at pixel {i}: R={} G={} B={}", rgb[o], rgb[o+1], rgb[o+2]
+            );
+        }
+    }
+
+    #[test]
+    fn denoise_luma_bilateral_preserves_edge() {
+        // A sharp luma step edge (left half 0.2, right half 0.6) should be
+        // preserved: range_sigma=0.04 << 0.4 step so bilateral weights across
+        // the edge collapse to near zero.
+        let w = 20;
+        let h = 5;
+        let dark = 0.2f32;
+        let bright = 0.6f32;
+        let mut rgb: Vec<f32> = (0..w * h)
+            .flat_map(|i| {
+                let col = i % w;
+                let v = if col < w / 2 { dark } else { bright };
+                [v, v, v]
+            })
+            .collect();
+
+        denoise_luma_bilateral(&mut rgb, w, h, 2, 0.04);
+
+        // Pixels well away from the border (≥radius pixels) must keep their values.
+        let r = 2usize;
+        for row in 0..h {
+            // Dark side, columns far from edge
+            for col in 0..w / 2 - r {
+                let v = rgb[(row * w + col) * 3];
+                assert!(
+                    (v - dark).abs() < 0.01,
+                    "dark side blurred at ({row},{col}): got {v:.4} expected ≈{dark}"
+                );
+            }
+            // Bright side, columns far from edge
+            for col in w / 2 + r..w {
+                let v = rgb[(row * w + col) * 3];
+                assert!(
+                    (v - bright).abs() < 0.01,
+                    "bright side blurred at ({row},{col}): got {v:.4} expected ≈{bright}"
+                );
+            }
         }
     }
 

--- a/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
@@ -136,6 +136,62 @@ pub fn demosaic_xtrans_passes(
 /// suppress CFA-locked false colour. Three matches dcraw's Markesteijn.
 const CHROMA_MEDIAN_PASSES: usize = 3;
 
+/// Deliberately dumb, phase-faithful demosaic for diagnostics: each output
+/// channel is the value of the NEAREST same-colour sample (the pixel itself if
+/// it already carries that colour). No directional or homogeneity logic, no
+/// cross-channel mixing — so any CFA-period structure it produces comes purely
+/// from the CFA phase map and the channel levels, not from clever interpolation.
+pub fn demosaic_nearest(raw: &[f32], width: u32, height: u32, pattern: &[u8; 36]) -> Vec<f32> {
+    let w = width as usize;
+    let h = height as usize;
+    let mut rgb = vec![0.0f32; w * h * 3];
+
+    for row in 0..h {
+        for col in 0..w {
+            let out = (row * w + col) * 3;
+            let own_color = cfa_color(pattern, row, col);
+
+            for target in 0u8..3 {
+                if own_color == target {
+                    rgb[out + target as usize] = raw[row * w + col];
+                } else {
+                    // Search growing Chebyshev rings until at least one sample
+                    // of the target colour is found, then average all such
+                    // samples in that ring. Cap at radius 6 to bound cost.
+                    let mut found_sum = 0.0f32;
+                    let mut found_count = 0u32;
+                    'rings: for radius in 1i32..=6 {
+                        for dy in -radius..=radius {
+                            for dx in -radius..=radius {
+                                // Only the outermost shell of the Chebyshev ring.
+                                if dy.abs() != radius && dx.abs() != radius {
+                                    continue;
+                                }
+                                let nr = (row as i32 + dy).clamp(0, h as i32 - 1) as usize;
+                                let nc = (col as i32 + dx).clamp(0, w as i32 - 1) as usize;
+                                if cfa_color(pattern, nr, nc) == target {
+                                    found_sum += raw[nr * w + nc];
+                                    found_count += 1;
+                                }
+                            }
+                        }
+                        if found_count > 0 {
+                            break 'rings;
+                        }
+                    }
+                    rgb[out + target as usize] = if found_count > 0 {
+                        found_sum / found_count as f32
+                    } else {
+                        raw[row * w + col]
+                    };
+                }
+            }
+        }
+    }
+
+    rgb
+}
+
 /// 3×3 median filter on a single-channel plane, edge-clamped. Returns a new
 /// buffer. Used on the chroma (color-difference) planes for false-colour
 /// suppression; it preserves edges far better than a linear blur.
@@ -971,6 +1027,33 @@ mod tests {
                     }
                 }
             }
+        }
+    }
+
+    #[test]
+    fn demosaic_nearest_uniform_gray_is_exact() {
+        // A uniform mosaic (all samples = 0.5) must reconstruct to 0.5 in
+        // every channel at every pixel: no tiling or phase error, because the
+        // nearest same-colour sample always has the same value.
+        let w = 36usize;
+        let h = 36usize;
+        let raw = vec![0.5f32; w * h];
+        let rgb = demosaic_nearest(&raw, w as u32, h as u32, &TEST_PATTERN);
+        assert_eq!(rgb.len(), w * h * 3, "output length mismatch");
+        for i in 0..w * h {
+            let o = i * 3;
+            assert!(
+                (rgb[o]     - 0.5).abs() < 1e-6,
+                "R wrong at pixel {i}: {}",  rgb[o]
+            );
+            assert!(
+                (rgb[o + 1] - 0.5).abs() < 1e-6,
+                "G wrong at pixel {i}: {}", rgb[o + 1]
+            );
+            assert!(
+                (rgb[o + 2] - 0.5).abs() < 1e-6,
+                "B wrong at pixel {i}: {}", rgb[o + 2]
+            );
         }
     }
 

--- a/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
+++ b/engine-rs/crates/lopsy-core/src/raf/xtrans.rs
@@ -483,7 +483,11 @@ fn interpolate_green(
 
             // Inverse-gradient blending. Squaring sharpens the direction
             // preference: a 2× lower gradient → 4× higher weight.
-            let eps = 1e-5f32;
+            // Noise-floor epsilon: large enough that noise-level gradients do
+            // not dominate the directional weighting (which produced diagonal
+            // "worm" artifacts in flat/shadow areas on real sensor data), while
+            // real edges still have gradients well above it and snap correctly.
+            let eps = 1e-3f32;
             let mut g_final = 0.0f32;
             let mut weight_sum = 0.0f32;
             for d in 0..4 {
@@ -577,7 +581,11 @@ fn refine_green(
                 gradients[d] = grad_green + grad_chroma;
             }
 
-            let eps = 1e-5f32;
+            // Noise-floor epsilon: large enough that noise-level gradients do
+            // not dominate the directional weighting (which produced diagonal
+            // "worm" artifacts in flat/shadow areas on real sensor data), while
+            // real edges still have gradients well above it and snap correctly.
+            let eps = 1e-3f32;
             let mut g_final = 0.0f32;
             let mut weight_sum = 0.0f32;
             for d in 0..4 {

--- a/engine-rs/crates/lopsy-core/tests/raf_color_measure.rs
+++ b/engine-rs/crates/lopsy-core/tests/raf_color_measure.rs
@@ -1,0 +1,458 @@
+//! Quantitative color measurement: export (read_raf) vs embedded JPEG preview.
+//!
+//! Run with:
+//!   cargo test -p lopsy-core --test raf_color_measure -- --nocapture
+
+use std::fs;
+use std::path::PathBuf;
+
+fn samples_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent().unwrap()
+        .parent().unwrap()
+        .parent().unwrap()
+        .join("samples")
+}
+
+/// Apply EXIF orientation to an RGB8 buffer.
+fn rotate_rgb8_by_orientation(src: &[u8], w: usize, h: usize, orientation: u16) -> (usize, usize, Vec<u8>) {
+    if orientation <= 1 {
+        return (w, h, src.to_vec());
+    }
+    let (out_w, out_h) = match orientation {
+        5 | 6 | 7 | 8 => (h, w),
+        _ => (w, h),
+    };
+    let mut dst = vec![0u8; out_w * out_h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let s = (y * w + x) * 3;
+            let (ox, oy) = match orientation {
+                2 => (w - 1 - x, y),
+                3 => (w - 1 - x, h - 1 - y),
+                4 => (x, h - 1 - y),
+                5 => (y, x),
+                6 => (h - 1 - y, x),
+                7 => (h - 1 - y, w - 1 - x),
+                8 => (y, w - 1 - x),
+                _ => (x, y),
+            };
+            let d = (oy * out_w + ox) * 3;
+            dst[d]     = src[s];
+            dst[d + 1] = src[s + 1];
+            dst[d + 2] = src[s + 2];
+        }
+    }
+    (out_w, out_h, dst)
+}
+
+/// Compute mean RGB [0,1] over a fractional region of an RGBA f32 buffer.
+fn mean_rgba_f32_region(pixels: &[f32], img_w: usize, img_h: usize,
+                         x0f: f64, y0f: f64, x1f: f64, y1f: f64) -> [f64; 3] {
+    let x0 = ((x0f * img_w as f64).floor() as usize).min(img_w);
+    let y0 = ((y0f * img_h as f64).floor() as usize).min(img_h);
+    let x1 = ((x1f * img_w as f64).ceil() as usize).min(img_w);
+    let y1 = ((y1f * img_h as f64).ceil() as usize).min(img_h);
+    if x1 <= x0 || y1 <= y0 { return [0.0; 3]; }
+    let mut sum = [0.0f64; 3];
+    let mut count = 0u64;
+    for row in y0..y1 {
+        for col in x0..x1 {
+            let o = (row * img_w + col) * 4;
+            sum[0] += pixels[o] as f64;
+            sum[1] += pixels[o + 1] as f64;
+            sum[2] += pixels[o + 2] as f64;
+            count += 1;
+        }
+    }
+    if count == 0 { return [0.0; 3]; }
+    [sum[0] / count as f64, sum[1] / count as f64, sum[2] / count as f64]
+}
+
+/// Compute mean RGB [0,1] over a fractional region of an RGB8 buffer.
+fn mean_rgb8_region(pixels: &[u8], img_w: usize, img_h: usize,
+                    x0f: f64, y0f: f64, x1f: f64, y1f: f64) -> [f64; 3] {
+    let x0 = ((x0f * img_w as f64).floor() as usize).min(img_w);
+    let y0 = ((y0f * img_h as f64).floor() as usize).min(img_h);
+    let x1 = ((x1f * img_w as f64).ceil() as usize).min(img_w);
+    let y1 = ((y1f * img_h as f64).ceil() as usize).min(img_h);
+    if x1 <= x0 || y1 <= y0 { return [0.0; 3]; }
+    let mut sum = [0.0f64; 3];
+    let mut count = 0u64;
+    for row in y0..y1 {
+        for col in x0..x1 {
+            let o = (row * img_w + col) * 3;
+            sum[0] += pixels[o] as f64 / 255.0;
+            sum[1] += pixels[o + 1] as f64 / 255.0;
+            sum[2] += pixels[o + 2] as f64 / 255.0;
+            count += 1;
+        }
+    }
+    if count == 0 { return [0.0; 3]; }
+    [sum[0] / count as f64, sum[1] / count as f64, sum[2] / count as f64]
+}
+
+fn saturation(rgb: [f64; 3]) -> f64 {
+    let mx = rgb[0].max(rgb[1]).max(rgb[2]);
+    let mn = rgb[0].min(rgb[1]).min(rgb[2]);
+    if mx < 1e-6 { 0.0 } else { (mx - mn) / mx }
+}
+
+/// Solve diagonal least-squares: for each channel c, find g_c minimising
+/// Σ(g_c * exp_c - prev_c)².  Closed-form: g_c = Σ(exp_c * prev_c) / Σ(exp_c²).
+fn fit_diagonal(pairs: &[([f64; 3], [f64; 3])]) -> [f64; 3] {
+    let mut num = [0.0f64; 3];
+    let mut den = [0.0f64; 3];
+    for (e, p) in pairs {
+        for c in 0..3 {
+            num[c] += e[c] * p[c];
+            den[c] += e[c] * e[c];
+        }
+    }
+    [
+        if den[0] > 1e-12 { num[0] / den[0] } else { 1.0 },
+        if den[1] > 1e-12 { num[1] / den[1] } else { 1.0 },
+        if den[2] > 1e-12 { num[2] / den[2] } else { 1.0 },
+    ]
+}
+
+/// RMS residual for the diagonal model.
+fn diagonal_rms(pairs: &[([f64; 3], [f64; 3])], g: [f64; 3]) -> f64 {
+    let mut sse = 0.0f64;
+    let mut n = 0usize;
+    for (e, p) in pairs {
+        for c in 0..3 {
+            let diff = g[c] * e[c] - p[c];
+            sse += diff * diff;
+            n += 1;
+        }
+    }
+    if n == 0 { 0.0 } else { (sse / n as f64).sqrt() }
+}
+
+/// Solve full 3×3 least-squares M·exp ≈ prev via three independent
+/// normal-equation solves (one per output channel).
+/// Returns M as row-major [f64; 9]: prev_c = M[c*3..c*3+3] · exp.
+fn fit_3x3(pairs: &[([f64; 3], [f64; 3])]) -> [f64; 9] {
+    // For each output channel c: solve (E^T E) x = E^T p_c
+    // E is N×3 design matrix, each row is one export RGB triple.
+    // AtA[i][j] = Σ e_i * e_j, AtB[c][i] = Σ e_i * p_c
+    let mut ata = [[0.0f64; 3]; 3];
+    let mut atb = [[0.0f64; 3]; 3]; // atb[out_c][in_c]
+    for (e, p) in pairs {
+        for i in 0..3 {
+            for j in 0..3 {
+                ata[i][j] += e[i] * e[j];
+            }
+            for c in 0..3 {
+                atb[c][i] += e[i] * p[c];
+            }
+        }
+    }
+    // Solve 3×3 symmetric system via Cramer's rule / direct inverse.
+    // Using Gauss-Jordan on the 3×3 ATA for each channel.
+    let solve3 = |b: [f64; 3]| -> [f64; 3] {
+        // Augmented matrix [ATA | b]
+        let mut m: [[f64; 4]; 3] = [
+            [ata[0][0], ata[0][1], ata[0][2], b[0]],
+            [ata[1][0], ata[1][1], ata[1][2], b[1]],
+            [ata[2][0], ata[2][1], ata[2][2], b[2]],
+        ];
+        for col in 0..3 {
+            // Pivot
+            let mut max_row = col;
+            for row in (col + 1)..3 {
+                if m[row][col].abs() > m[max_row][col].abs() { max_row = row; }
+            }
+            m.swap(col, max_row);
+            let piv = m[col][col];
+            if piv.abs() < 1e-14 { continue; }
+            for j in col..4 { m[col][j] /= piv; }
+            for row in 0..3 {
+                if row == col { continue; }
+                let f = m[row][col];
+                for j in col..4 { m[row][j] -= f * m[col][j]; }
+            }
+        }
+        [m[0][3], m[1][3], m[2][3]]
+    };
+
+    let mut out = [0.0f64; 9];
+    for c in 0..3 {
+        let x = solve3(atb[c]);
+        out[c * 3]     = x[0];
+        out[c * 3 + 1] = x[1];
+        out[c * 3 + 2] = x[2];
+    }
+    out
+}
+
+/// RMS residual for the 3×3 model.
+fn matrix_rms(pairs: &[([f64; 3], [f64; 3])], m: &[f64; 9]) -> f64 {
+    let mut sse = 0.0f64;
+    let mut n = 0usize;
+    for (e, p) in pairs {
+        for c in 0..3 {
+            let pred = m[c*3]*e[0] + m[c*3+1]*e[1] + m[c*3+2]*e[2];
+            let diff = pred - p[c];
+            sse += diff * diff;
+            n += 1;
+        }
+    }
+    if n == 0 { 0.0 } else { (sse / n as f64).sqrt() }
+}
+
+#[test]
+fn measure_color_delta() {
+    let samples = samples_dir();
+    if !samples.exists() {
+        println!("samples/ not found at {} — skipping", samples.display());
+        return;
+    }
+
+    const ROWS: usize = 8;
+    const COLS: usize = 6;
+    const DARK_THRESH: f64 = 0.04;
+
+    let sample_names = ["sample_00.raf", "sample_01.raf"];
+
+    for name in &sample_names {
+        let raf_path = samples.join(name);
+        if !raf_path.exists() {
+            println!("{name}: not found — skipping");
+            continue;
+        }
+
+        println!("\n╔══════════════════════════════════════════════════════════════╗");
+        println!("║  {name:<62}║");
+        println!("╚══════════════════════════════════════════════════════════════╝");
+
+        let data = match fs::read(&raf_path) {
+            Ok(d) => d,
+            Err(e) => { println!("  read error: {e}"); continue; }
+        };
+
+        // ── Render via read_raf (display orientation) ───────────────────────
+        let img = match lopsy_core::raf::read_raf(&data) {
+            Ok(i) => i,
+            Err(e) => { println!("  read_raf error: {e}"); continue; }
+        };
+        let exp_w = img.width as usize;
+        let exp_h = img.height as usize;
+        println!("  export: {}x{}", exp_w, exp_h);
+
+        // ── Decode embedded JPEG preview and orient to display orientation ──
+        let jpeg_bytes = match lopsy_core::raf::extract_jpeg_preview(&data) {
+            Ok(b) => b,
+            Err(e) => { println!("  extract_jpeg_preview error: {e}"); continue; }
+        };
+
+        let orientation = if img.exif_info.orientation == 0 { 1 } else { img.exif_info.orientation };
+
+        let (prev_rgb8, prev_w, prev_h) = {
+            let mut decoder = jpeg_decoder::Decoder::new(jpeg_bytes.as_slice());
+            match decoder.decode() {
+                Ok(pixels) => {
+                    let meta = decoder.info().unwrap();
+                    let pw = meta.width as usize;
+                    let ph = meta.height as usize;
+                    let rgb8 = match meta.pixel_format {
+                        jpeg_decoder::PixelFormat::RGB24 => pixels,
+                        jpeg_decoder::PixelFormat::L8 => {
+                            pixels.iter().flat_map(|&v| [v, v, v]).collect()
+                        }
+                        jpeg_decoder::PixelFormat::CMYK32 => {
+                            pixels.chunks(4).flat_map(|c| {
+                                let k = c[3] as f32 / 255.0;
+                                [(c[0] as f32 * k) as u8,
+                                 (c[1] as f32 * k) as u8,
+                                 (c[2] as f32 * k) as u8]
+                            }).collect()
+                        }
+                        _ => pixels,
+                    };
+                    let (dw, dh, rotated) = rotate_rgb8_by_orientation(&rgb8, pw, ph, orientation);
+                    println!("  preview: stored {}x{} → display {}x{} (orientation {})",
+                        pw, ph, dw, dh, orientation);
+                    (rotated, dw, dh)
+                }
+                Err(e) => {
+                    println!("  jpeg_decoder error: {e}");
+                    continue;
+                }
+            }
+        };
+
+        // ── Build 8×6 grid, compute cell means ─────────────────────────────
+        let mut export_cells: Vec<[f64; 3]> = Vec::with_capacity(ROWS * COLS);
+        let mut preview_cells: Vec<[f64; 3]> = Vec::with_capacity(ROWS * COLS);
+
+        println!("\n  Grid cell means (8 rows × 6 cols, export vs preview):");
+        println!("  {:>7} {:>5}  {:>20}   {:>20}", "cell", "r,c",
+                 "--- export ---", "--- preview ---");
+        println!("  {:>7} {:>5}  {:>6} {:>6} {:>6}   {:>6} {:>6} {:>6}",
+                 "", "", "R", "G", "B", "R", "G", "B");
+
+        for row in 0..ROWS {
+            for col in 0..COLS {
+                let x0f = col as f64 / COLS as f64;
+                let x1f = (col + 1) as f64 / COLS as f64;
+                let y0f = row as f64 / ROWS as f64;
+                let y1f = (row + 1) as f64 / ROWS as f64;
+
+                let e = mean_rgba_f32_region(&img.pixels, exp_w, exp_h, x0f, y0f, x1f, y1f);
+                let p = mean_rgb8_region(&prev_rgb8, prev_w, prev_h, x0f, y0f, x1f, y1f);
+
+                println!("  cell {:>3}  {:>1},{:>1}  {:>6.3} {:>6.3} {:>6.3}   {:>6.3} {:>6.3} {:>6.3}",
+                    row * COLS + col, row, col,
+                    e[0], e[1], e[2], p[0], p[1], p[2]);
+
+                export_cells.push(e);
+                preview_cells.push(p);
+            }
+        }
+
+        // ── Build fitting pairs (exclude near-black cells) ──────────────────
+        let mut pairs: Vec<([f64; 3], [f64; 3])> = Vec::new();
+        for i in 0..(ROWS * COLS) {
+            let e = export_cells[i];
+            let p = preview_cells[i];
+            let max_e = e[0].max(e[1]).max(e[2]);
+            if max_e >= DARK_THRESH {
+                pairs.push((e, p));
+            }
+        }
+        println!("\n  Non-dark cells (max export channel >= {DARK_THRESH}): {}", pairs.len());
+
+        // ── Diagonal fit ────────────────────────────────────────────────────
+        let g = fit_diagonal(&pairs);
+        let diag_rms = diagonal_rms(&pairs, g);
+
+        println!("\n  ── (A) Diagonal (per-channel gain) ──");
+        println!("    g_r={:.4}  g_g={:.4}  g_b={:.4}", g[0], g[1], g[2]);
+        println!("    RMS residual: {:.4}", diag_rms);
+
+        // ── Full 3×3 fit ────────────────────────────────────────────────────
+        let m = fit_3x3(&pairs);
+        let mat_rms = matrix_rms(&pairs, &m);
+
+        println!("\n  ── (B) Full 3×3 (M·export ≈ preview) ──");
+        println!("    [{:.4}  {:.4}  {:.4}]", m[0], m[1], m[2]);
+        println!("    [{:.4}  {:.4}  {:.4}]", m[3], m[4], m[5]);
+        println!("    [{:.4}  {:.4}  {:.4}]", m[6], m[7], m[8]);
+        println!("    RMS residual: {:.4}", mat_rms);
+
+        let ratio = if mat_rms > 1e-9 { diag_rms / mat_rms } else { 1.0 };
+        println!("\n  diagonalRMS / matrixRMS = {:.3}", ratio);
+
+        // ── Saturation comparison ───────────────────────────────────────────
+        let mut export_sat_sum = 0.0f64;
+        let mut preview_sat_sum = 0.0f64;
+        let mut ratio_sum = 0.0f64;
+        let mut sat_count = 0usize;
+        for &(e, p) in &pairs {
+            let es = saturation(e);
+            let ps = saturation(p);
+            export_sat_sum += es;
+            preview_sat_sum += ps;
+            if es > 1e-6 {
+                ratio_sum += ps / es;
+                sat_count += 1;
+            }
+        }
+        let n_pairs = pairs.len().max(1) as f64;
+        let mean_exp_sat = export_sat_sum / n_pairs;
+        let mean_prev_sat = preview_sat_sum / n_pairs;
+        let mean_ratio = if sat_count > 0 { ratio_sum / sat_count as f64 } else { 0.0 };
+
+        println!("\n  ── Saturation comparison ──");
+        println!("    mean export  saturation: {:.4}", mean_exp_sat);
+        println!("    mean preview saturation: {:.4}", mean_prev_sat);
+        println!("    mean preview_sat/export_sat ratio: {:.4}", mean_ratio);
+
+        // ── Hue-category example cells ──────────────────────────────────────
+        // Find the cell most matching each hue category by preview color.
+        println!("\n  ── Per-hue example cells (by preview color) ──");
+
+        let n = ROWS * COLS;
+
+        // YELLOW: preview R and G both high, B low; R≈G
+        let best_yellow = (0..n).filter(|&i| {
+            let p = preview_cells[i];
+            p[0] > 0.3 && p[1] > 0.3 && p[2] < p[0] * 0.7 && p[0] > 0.15 && p[1] > 0.15
+        }).max_by(|&a, &b| {
+            let pa = preview_cells[a]; let pb = preview_cells[b];
+            let sa = pa[0].min(pa[1]) - pa[2];
+            let sb = pb[0].min(pb[1]) - pb[2];
+            sa.partial_cmp(&sb).unwrap()
+        });
+
+        // RED: preview R clearly highest
+        let best_red = (0..n).filter(|&i| {
+            let p = preview_cells[i];
+            p[0] > 0.15 && p[0] > p[1] * 1.3 && p[0] > p[2] * 1.3
+        }).max_by(|&a, &b| {
+            let pa = preview_cells[a]; let pb = preview_cells[b];
+            let sa = pa[0] - pa[1].max(pa[2]);
+            let sb = pb[0] - pb[1].max(pb[2]);
+            sa.partial_cmp(&sb).unwrap()
+        });
+
+        // GREEN: preview G clearly highest
+        let best_green = (0..n).filter(|&i| {
+            let p = preview_cells[i];
+            p[1] > 0.15 && p[1] > p[0] * 1.15 && p[1] > p[2] * 1.15
+        }).max_by(|&a, &b| {
+            let pa = preview_cells[a]; let pb = preview_cells[b];
+            let sa = pa[1] - pa[0].max(pa[2]);
+            let sb = pb[1] - pb[0].max(pb[2]);
+            sa.partial_cmp(&sb).unwrap()
+        });
+
+        // BLUE/sky: preview B clearly highest
+        let best_blue = (0..n).filter(|&i| {
+            let p = preview_cells[i];
+            p[2] > 0.15 && p[2] > p[0] * 1.1 && p[2] > p[1] * 1.1
+        }).max_by(|&a, &b| {
+            let pa = preview_cells[a]; let pb = preview_cells[b];
+            let sa = pa[2] - pa[0].max(pa[1]);
+            let sb = pb[2] - pb[0].max(pb[1]);
+            sa.partial_cmp(&sb).unwrap()
+        });
+
+        let hues = [
+            ("YELLOW", best_yellow),
+            ("RED",    best_red),
+            ("GREEN",  best_green),
+            ("BLUE",   best_blue),
+        ];
+
+        for (hue_name, best) in &hues {
+            match best {
+                Some(idx) => {
+                    let e = export_cells[*idx];
+                    let p = preview_cells[*idx];
+                    let row = idx / COLS;
+                    let col = idx % COLS;
+                    println!("    {:6}: cell {:>2} (r{},c{})  export [{:.3},{:.3},{:.3}]  preview [{:.3},{:.3},{:.3}]",
+                        hue_name, idx, row, col, e[0], e[1], e[2], p[0], p[1], p[2]);
+                }
+                None => println!("    {:6}: no qualifying cell found", hue_name),
+            }
+        }
+
+        // ── Overall mean ────────────────────────────────────────────────────
+        let mut exp_mean = [0.0f64; 3];
+        let mut prev_mean = [0.0f64; 3];
+        for i in 0..n {
+            for c in 0..3 {
+                exp_mean[c] += export_cells[i][c];
+                prev_mean[c] += preview_cells[i][c];
+            }
+        }
+        for c in 0..3 { exp_mean[c] /= n as f64; prev_mean[c] /= n as f64; }
+        println!("\n  ── Overall mean (all 48 cells) ──");
+        println!("    export  mean RGB: [{:.4}, {:.4}, {:.4}]", exp_mean[0], exp_mean[1], exp_mean[2]);
+        println!("    preview mean RGB: [{:.4}, {:.4}, {:.4}]", prev_mean[0], prev_mean[1], prev_mean[2]);
+    }
+}

--- a/engine-rs/crates/lopsy-core/tests/raf_compare.rs
+++ b/engine-rs/crates/lopsy-core/tests/raf_compare.rs
@@ -1,0 +1,286 @@
+//! RAF pipeline comparison test.
+//!
+//! For each sample RAF file: extracts the embedded JPEG preview, renders the
+//! full decoded image to JPG, and prints EXIF / makernote metadata so the
+//! caller can compare camera-rendered previews against our decoded output.
+//! Also writes native-resolution crop pairs so colour/noise differences are
+//! visible at 100% without the hiding effect of downscaling.
+//!
+//! Run with:
+//!   cargo test -p lopsy-core --test raf_compare -- --nocapture
+
+use std::fs;
+use std::path::PathBuf;
+
+fn samples_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR = engine-rs/crates/lopsy-core
+    // three parents up → repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("samples")
+}
+
+fn save_jpg(path: &std::path::Path, data: &[u8], width: u32, height: u32) {
+    use jpeg_encoder::{ColorType, Encoder};
+    let encoder = Encoder::new_file(path, 92).unwrap();
+    encoder.encode(data, width as u16, height as u16, ColorType::Rgba).unwrap();
+}
+
+fn save_png_rgb(path: &std::path::Path, data: &[u8], width: u32, height: u32) {
+    use png::{BitDepth, ColorType, Encoder};
+    let f = fs::File::create(path).unwrap();
+    let mut enc = Encoder::new(f, width, height);
+    enc.set_color(ColorType::Rgb);
+    enc.set_depth(BitDepth::Eight);
+    let mut writer = enc.write_header().unwrap();
+    writer.write_image_data(data).unwrap();
+}
+
+/// Apply the same orientation logic used in the RAF decoder to an RGB8 buffer.
+/// Returns (new_w, new_h, rotated_pixels).
+fn rotate_rgb8_by_orientation(src: &[u8], w: usize, h: usize, orientation: u16) -> (usize, usize, Vec<u8>) {
+    if orientation <= 1 {
+        return (w, h, src.to_vec());
+    }
+    let (out_w, out_h) = match orientation {
+        5 | 6 | 7 | 8 => (h, w),
+        _ => (w, h),
+    };
+    let mut dst = vec![0u8; out_w * out_h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let s = (y * w + x) * 3;
+            let (ox, oy) = match orientation {
+                2 => (w - 1 - x, y),
+                3 => (w - 1 - x, h - 1 - y),
+                4 => (x, h - 1 - y),
+                5 => (y, x),
+                6 => (h - 1 - y, x),
+                7 => (h - 1 - y, w - 1 - x),
+                8 => (y, w - 1 - x),
+                _ => (x, y),
+            };
+            let d = (oy * out_w + ox) * 3;
+            dst[d]     = src[s];
+            dst[d + 1] = src[s + 1];
+            dst[d + 2] = src[s + 2];
+        }
+    }
+    (out_w, out_h, dst)
+}
+
+/// Extract a box crop of `side`×`side` centred at `(cx_frac, cy_frac)` from
+/// an RGB8 buffer. Returns (pixel data, actual_x, actual_y, actual_side).
+/// The box is clamped to image bounds, so corner fractions may produce a
+/// slightly smaller crop.
+fn crop_rgb8_centered(
+    src: &[u8],
+    img_w: usize,
+    img_h: usize,
+    cx_frac: f64,
+    cy_frac: f64,
+    side: usize,
+) -> (Vec<u8>, usize, usize, usize, usize) {
+    let cx = (cx_frac * img_w as f64).round() as isize;
+    let cy = (cy_frac * img_h as f64).round() as isize;
+    let half = side as isize / 2;
+    let x0 = (cx - half).max(0) as usize;
+    let y0 = (cy - half).max(0) as usize;
+    let x1 = (cx + half).min(img_w as isize) as usize;
+    let y1 = (cy + half).min(img_h as isize) as usize;
+    let cw = x1 - x0;
+    let ch = y1 - y0;
+    let mut out = Vec::with_capacity(cw * ch * 3);
+    for row in y0..y1 {
+        let row_start = (row * img_w + x0) * 3;
+        out.extend_from_slice(&src[row_start..row_start + cw * 3]);
+    }
+    (out, x0, y0, cw, ch)
+}
+
+/// Same crop but from an RGBA f32 buffer, returning an RGB8 Vec.
+fn crop_rgba_f32_to_rgb8(
+    src: &[f32],
+    img_w: usize,
+    img_h: usize,
+    cx_frac: f64,
+    cy_frac: f64,
+    side: usize,
+) -> (Vec<u8>, usize, usize, usize, usize) {
+    let cx = (cx_frac * img_w as f64).round() as isize;
+    let cy = (cy_frac * img_h as f64).round() as isize;
+    let half = side as isize / 2;
+    let x0 = (cx - half).max(0) as usize;
+    let y0 = (cy - half).max(0) as usize;
+    let x1 = (cx + half).min(img_w as isize) as usize;
+    let y1 = (cy + half).min(img_h as isize) as usize;
+    let cw = x1 - x0;
+    let ch = y1 - y0;
+    let mut out = Vec::with_capacity(cw * ch * 3);
+    for row in y0..y1 {
+        for col in x0..x1 {
+            let o = (row * img_w + col) * 4;
+            out.push((src[o].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+            out.push((src[o + 1].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+            out.push((src[o + 2].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+        }
+    }
+    (out, x0, y0, cw, ch)
+}
+
+#[test]
+fn extract_render_and_report() {
+    let samples = samples_dir();
+    if !samples.exists() {
+        println!("samples/ directory not found at {} — skipping", samples.display());
+        return;
+    }
+
+    let sample_names = ["sample_00.raf", "sample_01.raf"];
+
+    // Fractional (x, y) centres for the native-res comparison crops.
+    let crop_centres: &[(f64, f64)] = &[(0.50, 0.045), (0.45, 0.66), (0.62, 0.22)];
+    const EXPORT_CROP_SIDE: usize = 420;
+
+    for (sample_idx, name) in sample_names.iter().enumerate() {
+        let raf_path = samples.join(name);
+        if !raf_path.exists() {
+            println!("{name}: not found at {} — skipping", raf_path.display());
+            continue;
+        }
+
+        let stem = name.strip_suffix(".raf").unwrap_or(name);
+        let s_prefix = format!("s{:02}", sample_idx);
+        println!("\n=== {name} ===");
+
+        let data = match fs::read(&raf_path) {
+            Ok(d) => d,
+            Err(e) => { println!("  read error: {e}"); continue; }
+        };
+        println!("  file size: {} bytes", data.len());
+
+        // Extract JPEG preview bytes (stored orientation, landscape).
+        let jpeg_bytes = match lopsy_core::raf::extract_jpeg_preview(&data) {
+            Ok(b) => {
+                let preview_path = samples.join(format!("{stem}_preview.jpg"));
+                match fs::write(&preview_path, &b) {
+                    Ok(()) => println!("  preview.jpg: {} bytes → {}", b.len(), preview_path.display()),
+                    Err(e) => println!("  preview.jpg write error: {e}"),
+                }
+                b
+            }
+            Err(e) => {
+                println!("  extract_jpeg_preview error: {e}");
+                vec![]
+            }
+        };
+
+        // Decode the RAF.
+        let img = match lopsy_core::raf::read_raf(&data) {
+            Ok(i) => i,
+            Err(e) => { println!("  read_raf error: {e}"); continue; }
+        };
+
+        println!("  output dimensions: {}x{}", img.width, img.height);
+        println!("  exif_info: {:?}", img.exif_info);
+        println!("  film_mode: {:?}", img.exif_info.film_mode);
+        println!("  white_balance: {:?}", img.exif_info.white_balance);
+        println!("  dynamic_range: {:?}", img.exif_info.dynamic_range);
+        println!("  debug_log:");
+        for line in &img.debug_log {
+            println!("    {line}");
+        }
+
+        // Convert f32 RGBA [0,1] → u8 RGBA for the export JPG.
+        let pixel_count = (img.width * img.height) as usize;
+        let mut u8_pixels = Vec::with_capacity(pixel_count * 4);
+        for &v in &img.pixels {
+            u8_pixels.push((v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+        }
+
+        let export_path = samples.join(format!("{stem}_export.jpg"));
+        save_jpg(&export_path, &u8_pixels, img.width, img.height);
+        let export_size = fs::metadata(&export_path).map(|m| m.len()).unwrap_or(0);
+        println!("  export.jpg: {export_size} bytes → {}", export_path.display());
+
+        // ── Native-resolution comparison crops ─────────────────────────────
+
+        let orientation = if img.exif_info.orientation == 0 { 1 } else { img.exif_info.orientation };
+        let export_w = img.width as usize;
+        let export_h = img.height as usize;
+
+        // Decode the embedded preview JPEG to RGB8 (stored orientation).
+        let (preview_rgb8_display, prev_disp_w, prev_disp_h) = if !jpeg_bytes.is_empty() {
+            let mut decoder = jpeg_decoder::Decoder::new(jpeg_bytes.as_slice());
+            match decoder.decode() {
+                Ok(pixels) => {
+                    let meta = decoder.info().unwrap();
+                    let pw = meta.width as usize;
+                    let ph = meta.height as usize;
+                    // Convert to RGB8 (input may be RGB or YCbCr — jpeg_decoder
+                    // always gives us RGB when asked for a pixel-format decode).
+                    let rgb8 = match meta.pixel_format {
+                        jpeg_decoder::PixelFormat::RGB24 => pixels,
+                        jpeg_decoder::PixelFormat::L8 => {
+                            pixels.iter().flat_map(|&v| [v, v, v]).collect()
+                        }
+                        jpeg_decoder::PixelFormat::CMYK32 => {
+                            // Rare; convert naively.
+                            pixels.chunks(4).flat_map(|c| {
+                                let k = c[3] as f32 / 255.0;
+                                [(c[0] as f32 * k) as u8,
+                                 (c[1] as f32 * k) as u8,
+                                 (c[2] as f32 * k) as u8]
+                            }).collect()
+                        }
+                        _ => pixels,
+                    };
+                    // Apply EXIF orientation so preview is in display orientation.
+                    let (dw, dh, rotated) = rotate_rgb8_by_orientation(&rgb8, pw, ph, orientation);
+                    println!("  preview decoded: stored {}x{} → display {}x{} (orientation {})",
+                        pw, ph, dw, dh, orientation);
+                    (rotated, dw, dh)
+                }
+                Err(e) => {
+                    println!("  jpeg_decoder error: {e}");
+                    (vec![], 0, 0)
+                }
+            }
+        } else {
+            (vec![], 0, 0)
+        };
+
+        // Write native-res crops for each region centre.
+        for (region_idx, &(cx_frac, cy_frac)) in crop_centres.iter().enumerate() {
+            let region_n = region_idx + 1;
+
+            // Export crop: 560×560 at native resolution.
+            let (exp_crop, ex0, ey0, ecw, ech) = crop_rgba_f32_to_rgb8(
+                &img.pixels, export_w, export_h, cx_frac, cy_frac, EXPORT_CROP_SIDE,
+            );
+            let exp_crop_path = samples.join(format!("crop_{s_prefix}_r{region_n}_export.png"));
+            save_png_rgb(&exp_crop_path, &exp_crop, ecw as u32, ech as u32);
+            println!("  crop r{region_n} export: box ({ex0},{ey0}) size {ecw}×{ech} → {}",
+                exp_crop_path.file_name().unwrap().to_string_lossy());
+
+            // Preview crop: proportionally sized so it covers the same fractional area.
+            if prev_disp_w > 0 && prev_disp_h > 0 && !preview_rgb8_display.is_empty() {
+                let prev_side = ((EXPORT_CROP_SIDE as f64 * prev_disp_w as f64
+                    / export_w as f64).round() as usize).max(1);
+                let (prev_crop, px0, py0, pcw, pch) = crop_rgb8_centered(
+                    &preview_rgb8_display, prev_disp_w, prev_disp_h,
+                    cx_frac, cy_frac, prev_side,
+                );
+                let prev_crop_path = samples.join(format!("crop_{s_prefix}_r{region_n}_preview.png"));
+                save_png_rgb(&prev_crop_path, &prev_crop, pcw as u32, pch as u32);
+                println!("  crop r{region_n} preview: box ({px0},{py0}) size {pcw}×{pch} → {}",
+                    prev_crop_path.file_name().unwrap().to_string_lossy());
+            }
+        }
+    }
+}

--- a/engine-rs/crates/lopsy-core/tests/raf_demosaic_experiment.rs
+++ b/engine-rs/crates/lopsy-core/tests/raf_demosaic_experiment.rs
@@ -1,0 +1,272 @@
+//! Demosaic localisation experiment.
+//!
+//! Renders three decode variants for sample_00.raf (Markesteijn+denoise,
+//! Markesteijn+no-denoise, Nearest+no-denoise) and crops a flat sky region
+//! so the CFA-period grid artefact is visible without downscaling.
+//!
+//! Also runs a flat-gray phase test: finds neutral pixels in the embedded
+//! JPEG preview, maps them into the WB'd mosaic, and reports the per-6×6-cell
+//! spread for each CFA colour channel. A large spread indicates a tiling /
+//! phase error in the channel levels coming out of WB.
+//!
+//! Run with:
+//!   cargo test -p lopsy-core --test raf_demosaic_experiment -- --nocapture
+
+use std::fs;
+use std::path::PathBuf;
+
+fn samples_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR = engine-rs/crates/lopsy-core; three levels up → repo root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent().unwrap()
+        .parent().unwrap()
+        .parent().unwrap()
+        .join("samples")
+}
+
+fn save_png_rgb(path: &std::path::Path, data: &[u8], width: u32, height: u32) {
+    use png::{BitDepth, ColorType, Encoder};
+    let f = fs::File::create(path).unwrap();
+    let mut enc = Encoder::new(f, width, height);
+    enc.set_color(ColorType::Rgb);
+    enc.set_depth(BitDepth::Eight);
+    let mut writer = enc.write_header().unwrap();
+    writer.write_image_data(data).unwrap();
+}
+
+/// Crop a box of `side`×`side` pixels centred at `(cx_frac, cy_frac)` from
+/// an RGBA f32 buffer, returning an RGB8 Vec and the actual crop dimensions.
+fn crop_rgba_f32_to_rgb8(
+    src: &[f32],
+    img_w: usize,
+    img_h: usize,
+    cx_frac: f64,
+    cy_frac: f64,
+    side: usize,
+) -> (Vec<u8>, usize, usize) {
+    let cx   = (cx_frac * img_w as f64).round() as isize;
+    let cy   = (cy_frac * img_h as f64).round() as isize;
+    let half = side as isize / 2;
+    let x0 = (cx - half).max(0) as usize;
+    let y0 = (cy - half).max(0) as usize;
+    let x1 = (cx + half).min(img_w as isize) as usize;
+    let y1 = (cy + half).min(img_h as isize) as usize;
+    let cw = x1 - x0;
+    let ch = y1 - y0;
+    let mut out = Vec::with_capacity(cw * ch * 3);
+    for row in y0..y1 {
+        for col in x0..x1 {
+            let o = (row * img_w + col) * 4;
+            out.push((src[o    ].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+            out.push((src[o + 1].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+            out.push((src[o + 2].clamp(0.0, 1.0) * 255.0 + 0.5) as u8);
+        }
+    }
+    (out, cw, ch)
+}
+
+/// Apply the same orientation transform used in the RAF decoder to an RGB8 buffer.
+/// Available for future variant-A preview crops; the phase test works in stored
+/// orientation so this is not called in the current experiment.
+#[allow(dead_code)]
+fn rotate_rgb8(src: &[u8], w: usize, h: usize, orientation: u16) -> (usize, usize, Vec<u8>) {
+    if orientation <= 1 {
+        return (w, h, src.to_vec());
+    }
+    let (out_w, out_h) = match orientation { 5 | 6 | 7 | 8 => (h, w), _ => (w, h) };
+    let mut dst = vec![0u8; out_w * out_h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let s = (y * w + x) * 3;
+            let (ox, oy) = match orientation {
+                2 => (w - 1 - x, y),
+                3 => (w - 1 - x, h - 1 - y),
+                4 => (x, h - 1 - y),
+                5 => (y, x),
+                6 => (h - 1 - y, x),
+                7 => (h - 1 - y, w - 1 - x),
+                8 => (y, w - 1 - x),
+                _ => (x, y),
+            };
+            let d = (oy * out_w + ox) * 3;
+            dst[d]     = src[s];
+            dst[d + 1] = src[s + 1];
+            dst[d + 2] = src[s + 2];
+        }
+    }
+    (out_w, out_h, dst)
+}
+
+#[test]
+fn raf_demosaic_experiment() {
+    use lopsy_core::raf::{
+        DemosaicMode, RafDecodeOpts,
+        debug_wb_mosaic, extract_jpeg_preview, read_raf_opts,
+    };
+
+    let samples = samples_dir();
+    let raf_path = samples.join("sample_00.raf");
+    if !raf_path.exists() {
+        println!("samples/sample_00.raf not found at {} — skipping", raf_path.display());
+        return;
+    }
+
+    let data = fs::read(&raf_path).expect("read sample_00.raf");
+    println!("\n=== raf_demosaic_experiment ===");
+    println!("file: {} ({} bytes)", raf_path.display(), data.len());
+
+    // ── Part A: Three render variants ────────────────────────────────────────
+    //
+    // All three use the production pipeline up to and including EXIF orientation,
+    // so the output is in display orientation (sky at the top after orientation).
+
+    let variants: &[(&str, RafDecodeOpts)] = &[
+        ("exp_markesteijn_denoise_on.png",  RafDecodeOpts::default()),
+        ("exp_markesteijn_denoise_off.png", RafDecodeOpts { demosaic: DemosaicMode::Markesteijn, denoise: false }),
+        ("exp_nearest_denoise_off.png",     RafDecodeOpts { demosaic: DemosaicMode::Nearest,     denoise: false }),
+    ];
+
+    // Sky centre: fractional position (0.50, 0.045) in display orientation.
+    // The display image has sky at the top after EXIF orientation is applied.
+    const SKY_CX: f64 = 0.50;
+    const SKY_CY: f64 = 0.045;
+    const CROP_SIDE: usize = 420;
+
+    for (filename, opts) in variants {
+        let img = match read_raf_opts(&data, *opts) {
+            Ok(i) => i,
+            Err(e) => { println!("  {filename}: read_raf_opts error: {e}"); continue; }
+        };
+        let (crop_rgb8, cw, ch) = crop_rgba_f32_to_rgb8(
+            &img.pixels, img.width as usize, img.height as usize,
+            SKY_CX, SKY_CY, CROP_SIDE,
+        );
+        let out_path = samples.join(filename);
+        save_png_rgb(&out_path, &crop_rgb8, cw as u32, ch as u32);
+        println!("  wrote {} ({}×{} crop at ({SKY_CX},{SKY_CY}) of display {}×{})",
+            filename, cw, ch, img.width, img.height);
+    }
+
+    // ── Part B: Flat-gray phase test ─────────────────────────────────────────
+    //
+    // Strategy: work entirely in stored (pre-orientation) coordinates to avoid
+    // the complexity of inverting the orientation mapping.
+    //
+    // 1. Decode the JPEG preview in stored orientation (no rotation).
+    // 2. Find neutral pixels (low chroma, mid luma) in stored preview space.
+    // 3. Scale stored-preview coords to mosaic coords using the width ratio
+    //    (mosaic_w / preview_stored_w).  Both are landscape stored images, so
+    //    the same scale applies in both axes.
+    // 4. For each mosaic pixel (rx, ry), accumulate the WB'd mosaic value into
+    //    bin (ry%6)*6 + (rx%6).
+
+    println!("\n--- Phase test (stored-orientation coords) ---");
+
+    let jpeg_bytes = match extract_jpeg_preview(&data) {
+        Ok(b) => b,
+        Err(e) => { println!("  extract_jpeg_preview: {e}"); return; }
+    };
+
+    // Decode preview in stored orientation (skip EXIF rotation here).
+    let (prev_stored_rgb8, prev_stored_w, prev_stored_h) = {
+        let mut decoder = jpeg_decoder::Decoder::new(jpeg_bytes.as_slice());
+        match decoder.decode() {
+            Ok(pixels) => {
+                let meta = decoder.info().unwrap();
+                let pw = meta.width as usize;
+                let ph = meta.height as usize;
+                let rgb8 = match meta.pixel_format {
+                    jpeg_decoder::PixelFormat::RGB24 => pixels,
+                    jpeg_decoder::PixelFormat::L8 => {
+                        pixels.iter().flat_map(|&v| [v, v, v]).collect()
+                    }
+                    _ => pixels,
+                };
+                println!("  preview stored: {}×{}", pw, ph);
+                (rgb8, pw, ph)
+            }
+            Err(e) => {
+                println!("  jpeg_decoder error: {e}");
+                return;
+            }
+        }
+    };
+
+    // WB'd mosaic in stored orientation (w×h before EXIF rotation).
+    let (mosaic, mosaic_w, mosaic_h, cfa) = match debug_wb_mosaic(&data) {
+        Ok(r) => r,
+        Err(e) => { println!("  debug_wb_mosaic: {e}"); return; }
+    };
+    println!("  mosaic: {}×{}", mosaic_w, mosaic_h);
+
+    // Scale factor: same-axis ratio (both stored in landscape).
+    let scale_x = mosaic_w as f64 / prev_stored_w as f64;
+    let scale_y = mosaic_h as f64 / prev_stored_h as f64;
+    println!("  scale (mosaic/preview): x={scale_x:.3} y={scale_y:.3}");
+
+    // Neutral pixel selection in stored-preview space:
+    // luma in [60,220] on 0..255 and max(R,G,B)-min(R,G,B) < 12.
+    let mut bin_sums  = [0.0f64; 36];
+    let mut bin_counts = [0u64; 36];
+    let mut neutral_count = 0u64;
+
+    for py in 0..prev_stored_h {
+        for px in 0..prev_stored_w {
+            let o = (py * prev_stored_w + px) * 3;
+            let pr = prev_stored_rgb8[o    ] as i32;
+            let pg = prev_stored_rgb8[o + 1] as i32;
+            let pb = prev_stored_rgb8[o + 2] as i32;
+            let luma = (pr * 2126 + pg * 7152 + pb * 722) / 10000;
+            let chroma_spread = (pr.max(pg).max(pb) - pr.min(pg).min(pb)) as u8;
+            if luma < 60 || luma > 220 || chroma_spread >= 12 {
+                continue;
+            }
+            // Map to mosaic coords (edge-clamp).
+            let rx = ((px as f64 * scale_x).round() as usize).min(mosaic_w - 1);
+            let ry = ((py as f64 * scale_y).round() as usize).min(mosaic_h - 1);
+            let bin = (ry % 6) * 6 + (rx % 6);
+            bin_sums[bin]   += mosaic[ry * mosaic_w + rx] as f64;
+            bin_counts[bin] += 1;
+            neutral_count   += 1;
+        }
+    }
+
+    println!("  neutral pixels used: {neutral_count}");
+    println!();
+    println!("  Per-bin means (bin 0..35), colour labels: 0=R 1=G 2=B");
+    println!("  {:>4}  {:>5}  {:>9}  {:>6}", "bin", "color", "mean", "count");
+
+    let color_name = |c: u8| match c { 0 => 'R', 2 => 'B', _ => 'G' };
+
+    let mut bin_means = [0.0f64; 36];
+    for b in 0..36usize {
+        bin_means[b] = if bin_counts[b] > 0 {
+            bin_sums[b] / bin_counts[b] as f64
+        } else {
+            0.0
+        };
+        println!("  {:>4}  {:>5}  {:>9.6}  {:>6}",
+            b, color_name(cfa[b]), bin_means[b], bin_counts[b]);
+    }
+
+    // Per-channel spread (max−min of per-bin means for that channel's positions).
+    println!();
+    println!("  Per-channel spread (max−min of bin means) and cast check:");
+    for ch in 0u8..3 {
+        let positions: Vec<usize> = (0..36).filter(|&b| cfa[b] == ch).collect();
+        if positions.is_empty() { continue; }
+        let means_ch: Vec<f64> = positions.iter().map(|&b| bin_means[b]).collect();
+        let ch_mean  = means_ch.iter().sum::<f64>() / means_ch.len() as f64;
+        let ch_min   = means_ch.iter().cloned().fold(f64::MAX, f64::min);
+        let ch_max   = means_ch.iter().cloned().fold(f64::MIN, f64::max);
+        let spread   = ch_max - ch_min;
+        let spread_frac = if ch_mean > 1e-9 { spread / ch_mean } else { 0.0 };
+        println!("  {} → mean={:.6}  spread={:.6}  spread/mean={:.4}",
+            color_name(ch), ch_mean, spread, spread_frac);
+    }
+
+    println!();
+    println!("  Interpretation guide:");
+    println!("    cast: a channel's mean deviates from ~equal means across channels");
+    println!("    tiling: spread/mean > ~0.05 for a channel = same-colour positions disagree");
+}

--- a/engine-rs/crates/lopsy-core/tests/raf_phase_sweep.rs
+++ b/engine-rs/crates/lopsy-core/tests/raf_phase_sweep.rs
@@ -1,0 +1,189 @@
+//! CFA phase-alignment sweep diagnostic.
+//!
+//! Uses the raw (pre-WB) mosaic brightness fingerprint to find the correct
+//! X-Trans 6×6 CFA phase offset for each sample.
+//!
+//! Background: at neutral patches, the raw mosaic has a fixed positional
+//! brightness pattern — green sites (more photons per microlens) are
+//! ~1.8× brighter than R/B sites. We enumerate all 72 candidate CFA maps
+//! (2 transposes × 6 row-shifts × 6 col-shifts) and score each by how
+//! tightly the per-position mean raw values cluster within each colour.
+//! The correct alignment has the minimum within-colour spread and a
+//! green/nongreen ratio near 1.8.
+//!
+//! Run with:
+//!   cargo test -p lopsy-core --test raf_phase_sweep -- --nocapture
+
+use std::path::PathBuf;
+
+fn samples_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent().unwrap()
+        .parent().unwrap()
+        .parent().unwrap()
+        .join("samples")
+}
+
+#[test]
+fn cfa_phase_alignment_sweep() {
+    let samples = samples_dir();
+    for name in ["sample_00.raf", "sample_01.raf"] {
+        sweep_one(&samples, name);
+    }
+}
+
+fn sweep_one(samples: &PathBuf, name: &str) {
+    let raf_path = samples.join(name);
+    if !raf_path.exists() {
+        println!("{name} not found at {} — skipping", raf_path.display());
+        return;
+    }
+
+    let data = std::fs::read(&raf_path).expect("read raf");
+
+    let (mosaic, mosaic_w, mosaic_h, base_pat, crop_top, crop_left) =
+        match lopsy_core::raf::debug_raw_mosaic(&data) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{name}: debug_raw_mosaic error: {e}");
+                return;
+            }
+        };
+
+    println!("\n=== CFA phase alignment sweep: {name} ===");
+    println!("  mosaic: {mosaic_w}×{mosaic_h}");
+    println!("  crop_top={crop_top}  crop_left={crop_left}  (crop_top%6={}, crop_left%6={})",
+        crop_top % 6, crop_left % 6);
+    println!("  base pattern from file (Fuji indices 0=B,1=G,2=R):");
+    for r in 0..6 {
+        let row: Vec<u8> = (0..6).map(|c| base_pat[r * 6 + c]).collect();
+        println!("    {:?}", row);
+    }
+
+    let jpeg_bytes = match lopsy_core::raf::extract_jpeg_preview(&data) {
+        Ok(b) => b,
+        Err(e) => {
+            println!("{name}: extract_jpeg_preview error: {e} — skipping");
+            return;
+        }
+    };
+
+    let (prev_rgb8, prev_w, prev_h) = {
+        let mut decoder = jpeg_decoder::Decoder::new(jpeg_bytes.as_slice());
+        match decoder.decode() {
+            Ok(pixels) => {
+                let meta = decoder.info().unwrap();
+                let pw = meta.width as usize;
+                let ph = meta.height as usize;
+                let rgb8 = match meta.pixel_format {
+                    jpeg_decoder::PixelFormat::RGB24 => pixels,
+                    jpeg_decoder::PixelFormat::L8 => pixels.iter().flat_map(|&v| [v, v, v]).collect(),
+                    jpeg_decoder::PixelFormat::CMYK32 => pixels.chunks(4).flat_map(|c| {
+                        let k = c[3] as f32 / 255.0;
+                        [(c[0] as f32 * k) as u8, (c[1] as f32 * k) as u8, (c[2] as f32 * k) as u8]
+                    }).collect(),
+                    _ => pixels,
+                };
+                println!("  preview (stored): {pw}×{ph}");
+                (rgb8, pw, ph)
+            }
+            Err(e) => {
+                println!("{name}: jpeg_decoder error: {e} — skipping");
+                return;
+            }
+        }
+    };
+
+    let mut neutral: Vec<(usize, usize)> = Vec::new();
+    for py in 0..prev_h {
+        for px in 0..prev_w {
+            let o = (py * prev_w + px) * 3;
+            let r = prev_rgb8[o] as i32;
+            let g = prev_rgb8[o + 1] as i32;
+            let b = prev_rgb8[o + 2] as i32;
+            if r.max(g).max(b) - r.min(g).min(b) >= 12 { continue; }
+            let luma = (299 * r + 587 * g + 114 * b) / 1000;
+            if luma <= 60 || luma >= 220 { continue; }
+            let rx = (((px as f64 + 0.5) * mosaic_w as f64 / prev_w as f64).round() as usize).min(mosaic_w - 1);
+            let ry = (((py as f64 + 0.5) * mosaic_h as f64 / prev_h as f64).round() as usize).min(mosaic_h - 1);
+            neutral.push((rx, ry));
+        }
+    }
+    println!("  neutral preview pixels: {}", neutral.len());
+    if neutral.is_empty() { println!("  No neutral pixels — skip."); return; }
+
+    let mut pos_sum = [0.0f64; 36];
+    let mut pos_cnt = [0u64; 36];
+    for &(rx, ry) in &neutral {
+        let p = (ry % 6) * 6 + (rx % 6);
+        pos_sum[p] += mosaic[ry * mosaic_w + rx] as f64;
+        pos_cnt[p] += 1;
+    }
+    let mut pos_mean = [0.0f64; 36];
+    for p in 0..36 {
+        pos_mean[p] = if pos_cnt[p] > 0 { pos_sum[p] / pos_cnt[p] as f64 } else { 0.0 };
+    }
+
+    println!("  6×6 positional mean raw value (bright=green sites, dark=R/B sites):");
+    for r in 0..6 {
+        let row_vals: Vec<String> = (0..6).map(|c| format!("{:.4}", pos_mean[r * 6 + c])).collect();
+        println!("    [{}]", row_vals.join(", "));
+    }
+
+    struct Candidate { transpose: bool, row_shift: usize, col_shift: usize, score: f64, green_mean: f64, nongreen_mean: f64, ratio: f64, green_count: usize }
+    let mut candidates: Vec<Candidate> = Vec::with_capacity(72);
+
+    for &transpose in &[false, true] {
+        for row_shift in 0..6 {
+            for col_shift in 0..6 {
+                let mut cand = [0u8; 36];
+                for r in 0..6 {
+                    for c in 0..6 {
+                        let (br, bc) = if transpose { (c, r) } else { (r, c) };
+                        let sr = (br + row_shift) % 6;
+                        let sc = (bc + col_shift) % 6;
+                        cand[r * 6 + c] = base_pat[sr * 6 + sc];
+                    }
+                }
+                let green_count = cand.iter().filter(|&&v| v == 1).count();
+                let mut green_vals = Vec::new();
+                let mut nongreen_vals = Vec::new();
+                for p in 0..36 {
+                    if cand[p] == 1 { green_vals.push(pos_mean[p]); } else { nongreen_vals.push(pos_mean[p]); }
+                }
+                let spread = |v: &[f64]| if v.is_empty() { 0.0 } else {
+                    v.iter().cloned().fold(f64::NEG_INFINITY, f64::max) - v.iter().cloned().fold(f64::INFINITY, f64::min)
+                };
+                let mean = |v: &[f64]| if v.is_empty() { 0.0 } else { v.iter().sum::<f64>() / v.len() as f64 };
+                let green_mean = mean(&green_vals);
+                let nongreen_mean = mean(&nongreen_vals);
+                candidates.push(Candidate {
+                    transpose, row_shift, col_shift,
+                    score: spread(&green_vals) + spread(&nongreen_vals),
+                    green_mean, nongreen_mean,
+                    ratio: if nongreen_mean > 1e-9 { green_mean / nongreen_mean } else { 0.0 },
+                    green_count,
+                });
+            }
+        }
+    }
+    candidates.sort_by(|a, b| a.score.partial_cmp(&b.score).unwrap_or(std::cmp::Ordering::Equal));
+
+    println!("  Top 6 candidates (score=within-colour spread, lower=better):");
+    for (rank, c) in candidates.iter().take(6).enumerate() {
+        println!("    {:>2}: transpose={} rs={} cs={}  score={:.5} ratio={:.3} green_count={}",
+            rank + 1, c.transpose, c.row_shift, c.col_shift, c.score, c.ratio, c.green_count);
+    }
+    let curr_rs = (crop_top as usize) % 6;
+    let curr_cs = (crop_left as usize) % 6;
+    if let Some(rank) = candidates.iter().position(|c| !c.transpose && c.row_shift == curr_rs && c.col_shift == curr_cs) {
+        let c = &candidates[rank];
+        println!("  CURRENT (crop%6): rs={curr_rs} cs={curr_cs}  rank={} score={:.5} ratio={:.3}", rank + 1, c.score, c.ratio);
+    }
+    if let Some(best) = candidates.first() {
+        println!("  BEST: rs={} cs={}  score={:.5} ratio={:.3}", best.row_shift, best.col_shift, best.score, best.ratio);
+        println!("  >>> offset from crop%6: drs={} dcs={}",
+            (best.row_shift as i32 - curr_rs as i32 + 6) % 6,
+            (best.col_shift as i32 - curr_cs as i32 + 6) % 6);
+    }
+}


### PR DESCRIPTION
## Summary

Fujifilm RAF (X-Trans) files were rendering with wrong color, a CFA-period grid/moiré that aliased badly on zoom, crushed saturation, and lost twilight warmth. This PR fixes all of it by finding and correcting the **root cause: a CFA phase misalignment**, then peeling back the band-aids that were compensating for it.

## Root cause

The decoder shifted the CFA pattern by `(crop_top%6, crop_left%6)`. That mislabels sites and **smears the bright green sublattice and the dark R/B sublattice into every channel**.

How we proved it's upstream phase (not the demosaic or noise):
- A deliberately dumb **nearest-same-color demosaic** (no directional logic, no denoise) still showed the grid.
- A per-6×6-position brightness test on a real neutral patch showed each labelled channel mixing bright (~0.13) and dark (~0.07) sites — `spread/mean ≈ 0.57`. With a correct map, same-color positions agree.

## Fix

- **Auto-detect the CFA shift** (`detect_cfa_shift`): the green sublattice is ~1.8× brighter, so we pick the alignment whose green positions cluster tightest, tie-breaking R/B by the sensor's `(+4,+1)` crop offset. Detects `(1,1)` on both the X100VI and X-T5 samples; `spread/mean` drops **0.57 → 0.015**.

With the phase correct, the real chroma comes back and the crutches come off:
- **As-shot white balance** from tag `0xF00D` instead of gray-world (it only looked "magenta" before because the channels were smeared).
- **Saturation crutch dropped**: ~3.4× → ~1.4× film-sim boost; measured within ~15% of the camera JPEG (s00 0.272 vs 0.311; s01 0.210 vs 0.231).
- **Lighter denoise**: the period-spanning chroma median + bilateral were only fighting the grid, which is now gone at the source.
- `EXPOSURE_SCALE` 1.8 → 1.3 to match the as-shot WB's R/B boost.

## Results

- s00: vivid yellow building, deep-blue sky, and the red door ornament finally renders **red** (it was brown the whole time).
- s01: the warm purple→orange twilight gradient is **restored**.
- Sky crops are clean at 2× — no grid/weave — with only light NR.
- 206 lib unit tests pass.

## Also included

- `RafDecodeOpts`/`DemosaicMode` plumbing + a nearest-same-color demosaic.
- Two CI-safe diagnostics (skip without sample files): `raf_phase_sweep` (finds the correct CFA alignment), `raf_demosaic_experiment` (localizes grid causes).

## Notes

- This is in the Rust core (`engine-rs`); run `npm run wasm:build` to see it in the app.
- The green-phase detection is sensor-independent; the R/B tie-break uses a `(+4,+1)` constant verified on both bodies (same X-Trans-V sensor). For other sensors it still fixes green/grid; a wrong R/B would be an obvious red↔blue swap to revisit when we have more camera files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)