### PR TITLE
refactor(tool-settings): migrate pencil to per-tool slice (#453)

### DIFF
--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -265,6 +265,16 @@ async function setFillSetting(page: Page, key: 'tolerance' | 'contiguous', value
   }, { key, value });
 }
 
+/** Write to the pencil per-tool settings slice; see #453. */
+async function setPencilSetting(page: Page, key: 'size', value: number) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setPencilSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setPencilSetting(key, value);
+  }, { key, value });
+}
+
 async function setUIState(page: Page, setter: string, value: unknown) {
   await page.evaluate(
     ({ setter, value }) => {
@@ -415,7 +425,7 @@ test.describe('Pencil Tool', () => {
 
   test('drawing with pencil creates hard-edged pixels', async ({ page }) => {
     await page.keyboard.press('n');
-    await setToolSetting(page, 'setPencilSize', 3);
+    await setPencilSetting(page, 'size', 3);
     await drawStroke(page, { x: 100, y: 100 }, { x: 200, y: 100 }, 20);
 
     // Pencil produces fully opaque pixels (hard edges)
@@ -427,7 +437,7 @@ test.describe('Pencil Tool', () => {
     await page.keyboard.press('n');
 
     const baseline = await readComposited(page);
-    await setToolSetting(page, 'setPencilSize', 1);
+    await setPencilSetting(page, 'size', 1);
     await drawStroke(page, { x: 50, y: 50 }, { x: 350, y: 50 }, 20);
     const smallDiff = pixelDiff(baseline, await readComposited(page));
 
@@ -435,7 +445,7 @@ test.describe('Pencil Tool', () => {
 
     const baseline2 = await readComposited(page);
     await page.keyboard.press('n');
-    await setToolSetting(page, 'setPencilSize', 10);
+    await setPencilSetting(page, 'size', 10);
     await drawStroke(page, { x: 50, y: 50 }, { x: 350, y: 50 }, 20);
     const largeDiff = pixelDiff(baseline2, await readComposited(page));
 

--- a/src/app/OptionsBar/tool-options/PencilOptions.tsx
+++ b/src/app/OptionsBar/tool-options/PencilOptions.tsx
@@ -6,8 +6,8 @@ import { IconButton } from '../../../components/IconButton/IconButton';
 import { docScaledMax } from '../../../utils/slider-ranges';
 
 export function PencilOptions() {
-  const pencilSize = useToolSettingsStore((s) => s.pencilSize);
-  const setPencilSize = useToolSettingsStore((s) => s.setPencilSize);
+  const pencilSize = useToolSettingsStore((s) => s.settings.pencil.size);
+  const setPencilSetting = useToolSettingsStore((s) => s.setPencilSetting);
   const symmetryH = useToolSettingsStore((s) => s.symmetryHorizontal);
   const symmetryV = useToolSettingsStore((s) => s.symmetryVertical);
   const setSymH = useToolSettingsStore((s) => s.setSymmetryHorizontal);
@@ -18,7 +18,7 @@ export function PencilOptions() {
 
   return (
     <>
-      <Slider label="Size" value={pencilSize} min={1} max={sizeMax} onChange={setPencilSize} />
+      <Slider label="Size" value={pencilSize} min={1} max={sizeMax} onChange={(size) => setPencilSetting('size', size)} />
       <IconButton
         icon={<FlipVertical2 size={16} />}
         label="Symmetry Horizontal"

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -142,7 +142,7 @@ export function handlePaintDown(
         gpuQuickMaskDab(engine, canvasPos.x, canvasPos.y, size, hardness, opacity, mode);
       }
     } else if (tool === 'pencil') {
-      const size = toolSettings.pencilSize;
+      const size = toolSettings.settings.pencil.size;
       const color = { r: 255, g: 255, b: 255, a: 1 };
       gpuQuickMaskPencil(
         engine,
@@ -221,7 +221,7 @@ export function handlePaintDown(
         gpuMaskDab(engine, activeLayerId, layerPos.x, layerPos.y, size, hardness, opacity, mode);
       }
     } else if (tool === 'pencil') {
-      const size = toolSettings.pencilSize;
+      const size = toolSettings.settings.pencil.size;
       gpuMaskPencilLine(
         engine, activeLayerId,
         lineFrom.x, lineFrom.y, layerPos.x, layerPos.y,
@@ -387,7 +387,7 @@ export function handlePaintDown(
   } else if (tool === 'pencil') {
     const color = strokeColor;
     useToolSettingsStore.getState().addRecentColor(color);
-    const size = toolSettings.pencilSize;
+    const size = toolSettings.settings.pencil.size;
     gpuDrawPencilLine(engine, activeLayerId,
       lineFrom.x, lineFrom.y, layerPos.x, layerPos.y,
       color.r / 255, color.g / 255, color.b / 255, color.a, size);
@@ -678,7 +678,7 @@ function handleMaskPaintMoveUnified(
       emitDabs(toolSettings.brushSize, toolSettings.brushHardness / 100, toolSettings.brushOpacity / 100);
       break;
     case 'pencil': {
-      const size = toolSettings.pencilSize;
+      const size = toolSettings.settings.pencil.size;
       if (isQuickMask) {
         gpuQuickMaskPencil(engine, state.lastPoint.x, state.lastPoint.y, pos.x, pos.y, 1, 1, 1, 1, size, mode);
       } else {

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -51,7 +51,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'smudge') {
     ts.setSmudgeSetting('size', ts.settings.smudge.size + delta);
   } else if (tool === 'pencil') {
-    ts.setPencilSize(ts.pencilSize + delta);
+    ts.setPencilSetting('size', ts.settings.pencil.size + delta);
   } else if (tool === 'eraser') {
     ts.setEraserSize(ts.eraserSize + delta);
   } else if (tool === 'stamp') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -6,6 +6,8 @@ import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
 import { DEFAULT_MARQUEE_SETTINGS } from '../tools/marquee/marquee-settings';
 import type { SmudgeSettings } from '../tools/smudge/smudge-settings';
 import { DEFAULT_SMUDGE_SETTINGS } from '../tools/smudge/smudge-settings';
+import type { PencilSettings } from '../tools/pencil/pencil-settings';
+import { DEFAULT_PENCIL_SETTINGS } from '../tools/pencil/pencil-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -21,6 +23,7 @@ export interface ToolSettingsSlices {
   fill: FillSettings;
   marquee: MarqueeSettings;
   smudge: SmudgeSettings;
+  pencil: PencilSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -28,4 +31,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   fill: DEFAULT_FILL_SETTINGS,
   marquee: DEFAULT_MARQUEE_SETTINGS,
   smudge: DEFAULT_SMUDGE_SETTINGS,
+  pencil: DEFAULT_PENCIL_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -260,3 +260,41 @@ describe('per-tool slice: smudge (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: pencil (#453)', () => {
+  it('exposes pencil settings under settings.pencil with the legacy default', () => {
+    // Reset to the legacy default — prior tests in this file may have
+    // mutated the slice through setPencilSetting.
+    useToolSettingsStore.getState().setPencilSetting('size', 1);
+    const { pencil } = useToolSettingsStore.getState().settings;
+    expect(pencil).toEqual({ size: 1 });
+  });
+
+  it('setPencilSetting updates size and clamps it into [1, 5000]', () => {
+    useToolSettingsStore.getState().setPencilSetting('size', 25);
+    expect(useToolSettingsStore.getState().settings.pencil.size).toBe(25);
+    useToolSettingsStore.getState().setPencilSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.pencil.size).toBe(1);
+    useToolSettingsStore.getState().setPencilSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.pencil.size).toBe(5000);
+  });
+
+  it('setPencilSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setPencilSetting('size', 7);
+    expect(useToolSettingsStore.getState().settings.pencil.size).toBe(7);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when pencil changes. This is
+    // the invariant that justifies slicing instead of fattening the
+    // flat bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -8,6 +8,7 @@ import { clampWandSetting } from '../tools/wand/wand-settings';
 import { clampFillSetting } from '../tools/fill/fill-settings';
 import { clampMarqueeSetting } from '../tools/marquee/marquee-settings';
 import { clampSmudgeSetting } from '../tools/smudge/smudge-settings';
+import { clampPencilSetting } from '../tools/pencil/pencil-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -36,7 +37,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushSize: 10,
   brushOpacity: 100,
   brushHardness: 80,
-  pencilSize: 1,
   eraserSize: 10,
   eraserOpacity: 100,
   shapeMode: 'ellipse',
@@ -175,7 +175,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     set({ brushOpacity: Math.max(1, Math.min(100, opacity)) });
   },
   setBrushHardness: (hardness) => set({ brushHardness: Math.max(0, Math.min(100, hardness)) }),
-  setPencilSize: (size) => set({ pencilSize: Math.max(1, Math.min(5000, size)) }),
+  setPencilSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      pencil: { ...s.settings.pencil, [key]: clampPencilSetting(key, value) },
+    },
+  })),
   setEraserSize: (size) => set({ eraserSize: Math.max(1, Math.min(5000, size)) }),
   setEraserOpacity: (opacity) => {
     warnIfNormalisedOpacity('setEraserOpacity', opacity);

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -8,6 +8,7 @@ import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
 import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
 import type { SmudgeSettings } from '../tools/smudge/smudge-settings';
+import type { PencilSettings } from '../tools/pencil/pencil-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -24,7 +25,6 @@ export interface ToolSettings {
   brushSize: number;
   brushOpacity: number;
   brushHardness: number;
-  pencilSize: number;
   eraserSize: number;
   eraserOpacity: number;
   shapeMode: ShapeMode;
@@ -149,7 +149,7 @@ export interface ToolSettings {
   setTextStrikethrough: (strikethrough: boolean) => void;
   setBrushOpacity: (opacity: number) => void;
   setBrushHardness: (hardness: number) => void;
-  setPencilSize: (size: number) => void;
+  setPencilSetting: <K extends keyof PencilSettings>(key: K, value: PencilSettings[K]) => void;
   setEraserSize: (size: number) => void;
   setEraserOpacity: (opacity: number) => void;
   setFillSetting: <K extends keyof FillSettings>(key: K, value: FillSettings[K]) => void;

--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -38,7 +38,7 @@ function getToolSize(tool: BrushTool, settings: ReturnType<typeof useToolSetting
     case 'sponge':
       return settings.spongeSize;
     case 'pencil':
-      return settings.pencilSize;
+      return settings.settings.pencil.size;
     case 'eraser':
       return settings.eraserSize;
     case 'stamp':

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -301,7 +301,7 @@ function renderFrameGpu(
     const brushCursorInfo = getBrushCursorInfo(activeTool);
     if (brushCursorInfo !== null && cursorOnCanvas) {
       const size = activeTool === 'brush' ? toolState.brushSize
-        : activeTool === 'pencil' ? toolState.pencilSize
+        : activeTool === 'pencil' ? toolState.settings.pencil.size
         : activeTool === 'eraser' ? toolState.eraserSize
         : activeTool === 'stamp' ? toolState.stampSize
         : activeTool === 'sponge' ? toolState.spongeSize

--- a/src/tools/pencil/pencil-settings.test.ts
+++ b/src/tools/pencil/pencil-settings.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PENCIL_SETTINGS,
+  clampPencilSetting,
+  type PencilSettings,
+} from './pencil-settings';
+
+describe('pencil-settings (#453 per-tool slice)', () => {
+  it('defaults match the legacy flat-bag value', () => {
+    const defaults: PencilSettings = DEFAULT_PENCIL_SETTINGS;
+    expect(defaults).toEqual({ size: 1 });
+  });
+
+  it('clampPencilSetting clamps size into [1, 5000]', () => {
+    expect(clampPencilSetting('size', 0)).toBe(1);
+    expect(clampPencilSetting('size', -10)).toBe(1);
+    expect(clampPencilSetting('size', 1)).toBe(1);
+    expect(clampPencilSetting('size', 100)).toBe(100);
+    expect(clampPencilSetting('size', 5000)).toBe(5000);
+    expect(clampPencilSetting('size', 99999)).toBe(5000);
+  });
+});

--- a/src/tools/pencil/pencil-settings.ts
+++ b/src/tools/pencil/pencil-settings.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-tool settings slice for the Pencil tool.
+ *
+ * Authoritative settings type for pencil. The slice lives under
+ * `settings.pencil` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts`: `<Tool>Settings`
+ * interface + `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting`
+ * helper, then registered in `tool-settings-slices.ts`. Single
+ * numeric field — same shape as marquee, but covers a paint tool
+ * (rather than a selection tool) so the slice infrastructure is
+ * exercised on the paint-tool code path before the largest paint
+ * slice (brush) inherits it.
+ */
+export interface PencilSettings {
+  size: number;
+}
+
+export const DEFAULT_PENCIL_SETTINGS: PencilSettings = {
+  size: 1,
+};
+
+export function clampPencilSetting<K extends keyof PencilSettings>(
+  key: K,
+  value: PencilSettings[K],
+): PencilSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as PencilSettings[K];
+  }
+  return value;
+}

--- a/src/tools/pencil/pencil-stroke.ts
+++ b/src/tools/pencil/pencil-stroke.ts
@@ -16,7 +16,7 @@ export function handlePencilStroke(
 
   const toolSettings = useToolSettingsStore.getState();
   const color = state.strokeColor ?? toolSettings.foregroundColor;
-  const size = toolSettings.pencilSize;
+  const size = toolSettings.settings.pencil.size;
   gpuDrawPencilLine(engine, state.layerId,
     state.lastPoint.x, state.lastPoint.y, layerLocalPos.x, layerLocalPos.y,
     color.r / 255, color.g / 255, color.b / 255, color.a, size);


### PR DESCRIPTION
## Summary

Sixth per-tool slice in the [#453](https://github.com/theseamusjames/lopsy.art/issues/453) god-store rollout. Follows the established template from wand / fill / marquee / smudge: a `PencilSettings` interface + `DEFAULT_PENCIL_SETTINGS` + `clampPencilSetting` helper in `src/tools/pencil/pencil-settings.ts`, registered in `tool-settings-slices.ts`, accessed via `settings.pencil.*` and written via a single typed `setPencilSetting(key, value)` setter.

Pencil is the **first paint tool** to migrate. Prior slices have been selection tools (wand, marquee) or paint tools with single non-pen-style shapes (fill, smudge). Pencil exercises the paint code path that brush will inherit — `pencil-stroke.ts` (logic), `paint-handlers.ts` (4 sites: down-handler, move-handler, quick-mask, mask edit), `useCanvasRendering.ts` (brush cursor size), `useCanvasCursor.ts` (cursor size) — so the slice infrastructure is shaken out across the full paint pipeline before the largest paint slice (brush) lands.

Drops the flat `pencilSize` field and `setPencilSize` setter from the store. Read sites updated:

- `pencil-stroke.ts` (handlePencilStroke)
- `paint-handlers.ts` (4 pencil-tool branches)
- `PencilOptions.tsx` (Options bar)
- `useCanvasRendering.ts` (brush cursor size lookup)
- `useCanvasCursor.ts` (cursor size lookup)
- `tool-shortcuts.ts` (`[` `]` size-shortcut while pencil is active)

## Tests

- New `pencil-settings.test.ts` (2 tests: defaults, size clamp).
- New `per-tool slice: pencil (#453)` describe block in `tool-settings-store.test.ts` (3 tests: defaults, size clamp via setter, **sibling-slice referential identity** across wand/fill/marquee/smudge).
- e2e `tools.spec.ts` pencil tests updated to use the new `setPencilSetting` helper.

## Test plan

- [x] `npm run typecheck` — clean (only the pre-existing wasm-pack warning unrelated to this change).
- [x] `npm run test` — 983 tests pass across 97 files (full pre-push run).
- [x] `npx vitest run src/tools/pencil src/app/tool-settings-store.test.ts` — 32/32 pass.
- [x] `npm run lint` — no errors.

https://claude.ai/code/session_01EBcwhmnH3GcRBV43rTDhuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVJp64gXHMTbNCRvyozMVJ)_