### PR TITLE
feat(adjustments): raise Saturation/Vibrance cap to 200

### DIFF
--- a/src/panels/AdjustmentsPanel/controls/SaturationControls.tsx
+++ b/src/panels/AdjustmentsPanel/controls/SaturationControls.tsx
@@ -6,9 +6,9 @@ import styles from '../AdjustmentsPanel.module.css';
 export function SaturationControls({ node, onChange }: NodeControlProps<SaturationNode>) {
   return (
     <div className={styles.sliders}>
-      <Slider label="Saturation" value={node.saturation} min={-100} max={100} step={1} defaultValue={0}
+      <Slider label="Saturation" value={node.saturation} min={-100} max={200} step={1} defaultValue={0}
         onChange={(v) => onChange({ saturation: v })} />
-      <Slider label="Vibrance" value={node.vibrance} min={-100} max={100} step={1} defaultValue={0}
+      <Slider label="Vibrance" value={node.vibrance} min={-100} max={200} step={1} defaultValue={0}
         onChange={(v) => onChange({ vibrance: v })} />
     </div>
   );


### PR DESCRIPTION
## Summary

The group/layer **Saturation** and **Vibrance** sliders capped at 100, but the GPU shader has more headroom. Raises the cap to **200** (kept the −100 floor = full desaturation).

## Why it's safe

The value flows: slider → `setGroupAdjustments` → `compositor.rs` (`saturation / 100.0`) → shader `mix(vec3(gray), rgb, 1.0 + sat/100)`, with the `clamp(rgb, 0, 1)` applied **after** the mix. Nothing clamps the value itself, so 200 = a 3× push from gray (vs 2× at 100) — it extrapolates further and only clips at the gamut edge. Past ~300 it's mostly clipping, so 200 is a sensible new ceiling.

Pure JS/TS change (the engine already handles any `f32`), so it takes effect on the next dev reload — no wasm rebuild. Typecheck + adjustment unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)