### PR TITLE
refactor(tool-settings): migrate eraser to per-tool slice (#453)

### DIFF
--- a/src/app/OptionsBar/tool-options/EraserOptions.tsx
+++ b/src/app/OptionsBar/tool-options/EraserOptions.tsx
@@ -4,18 +4,17 @@ import { Slider } from '../../../components/Slider/Slider';
 import { docScaledMax } from '../../../utils/slider-ranges';
 
 export function EraserOptions() {
-  const eraserSize = useToolSettingsStore((s) => s.eraserSize);
-  const eraserOpacity = useToolSettingsStore((s) => s.eraserOpacity);
-  const setEraserSize = useToolSettingsStore((s) => s.setEraserSize);
-  const setEraserOpacity = useToolSettingsStore((s) => s.setEraserOpacity);
+  const eraserSize = useToolSettingsStore((s) => s.settings.eraser.size);
+  const eraserOpacity = useToolSettingsStore((s) => s.settings.eraser.opacity);
+  const setEraserSetting = useToolSettingsStore((s) => s.setEraserSetting);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 200);
 
   return (
     <>
-      <Slider label="Size" value={eraserSize} min={1} max={sizeMax} sliderMax={300} onChange={setEraserSize} />
-      <Slider label="Opacity" value={eraserOpacity} min={1} max={100} onChange={setEraserOpacity} />
+      <Slider label="Size" value={eraserSize} min={1} max={sizeMax} sliderMax={300} onChange={(v) => setEraserSetting('size', v)} />
+      <Slider label="Opacity" value={eraserOpacity} min={1} max={100} onChange={(v) => setEraserSetting('opacity', v)} />
     </>
   );
 }

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -152,9 +152,9 @@ export function handlePaintDown(
         mode,
       );
     } else {
-      const size = toolSettings.eraserSize;
+      const size = toolSettings.settings.eraser.size;
       const hardness = 0.8;
-      const opacity = toolSettings.eraserOpacity / 100;
+      const opacity = toolSettings.settings.eraser.opacity / 100;
       if (shiftLine) {
         const spacing = Math.max(1, size * 0.25);
         const pts = interpolatePoints(qmShiftFrom, canvasPos, spacing);
@@ -228,9 +228,9 @@ export function handlePaintDown(
         1.0, size, mode,
       );
     } else {
-      const size = toolSettings.eraserSize;
+      const size = toolSettings.settings.eraser.size;
       const hardness = 0.8;
-      const opacity = toolSettings.eraserOpacity / 100;
+      const opacity = toolSettings.settings.eraser.opacity / 100;
       if (shiftLine) {
         const spacing = Math.max(1, size * 0.25);
         const pts = interpolatePoints(lineFrom, layerPos, spacing);
@@ -401,9 +401,9 @@ export function handlePaintDown(
       }
     }
   } else {
-    const size = toolSettings.eraserSize;
+    const size = toolSettings.settings.eraser.size;
     const hardness = 0.8;
-    const opacity = toolSettings.eraserOpacity / 100;
+    const opacity = toolSettings.settings.eraser.opacity / 100;
 
     if (shiftLine) {
       const spacing = Math.max(1, size * 0.25);
@@ -687,7 +687,7 @@ function handleMaskPaintMoveUnified(
       break;
     }
     case 'eraser':
-      emitDabs(toolSettings.eraserSize, 0.8, toolSettings.eraserOpacity / 100);
+      emitDabs(toolSettings.settings.eraser.size, 0.8, toolSettings.settings.eraser.opacity / 100);
       break;
     default:
       break;

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -53,7 +53,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'pencil') {
     ts.setPencilSetting('size', ts.settings.pencil.size + delta);
   } else if (tool === 'eraser') {
-    ts.setEraserSize(ts.eraserSize + delta);
+    ts.setEraserSetting('size', ts.settings.eraser.size + delta);
   } else if (tool === 'stamp') {
     ts.setStampSize(ts.stampSize + delta);
   } else if (tool === 'healing') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -10,6 +10,8 @@ import type { PencilSettings } from '../tools/pencil/pencil-settings';
 import { DEFAULT_PENCIL_SETTINGS } from '../tools/pencil/pencil-settings';
 import type { SpongeSettings } from '../tools/sponge/sponge-settings';
 import { DEFAULT_SPONGE_SETTINGS } from '../tools/sponge/sponge-settings';
+import type { EraserSettings } from '../tools/eraser/eraser-settings';
+import { DEFAULT_ERASER_SETTINGS } from '../tools/eraser/eraser-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -27,6 +29,7 @@ export interface ToolSettingsSlices {
   smudge: SmudgeSettings;
   pencil: PencilSettings;
   sponge: SpongeSettings;
+  eraser: EraserSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -36,4 +39,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   smudge: DEFAULT_SMUDGE_SETTINGS,
   pencil: DEFAULT_PENCIL_SETTINGS,
   sponge: DEFAULT_SPONGE_SETTINGS,
+  eraser: DEFAULT_ERASER_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -92,13 +92,13 @@ describe('opacity setters — issue #250 (percent vs normalised footgun)', () =>
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('also warns from setEraserOpacity and setSprayOpacity (same footgun)', async () => {
+  it('also warns from setEraserSetting(opacity) and setSprayOpacity (same footgun)', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setEraserOpacity(0.5);
+    store.getState().setEraserSetting('opacity', 0.5);
     store.getState().setSprayOpacity(0.3);
     expect(warnSpy).toHaveBeenCalledTimes(2);
     const messages = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ''));
-    expect(messages.some((m: string) => m.includes('setEraserOpacity'))).toBe(true);
+    expect(messages.some((m: string) => m.includes('setEraserSetting(opacity)'))).toBe(true);
     expect(messages.some((m: string) => m.includes('setSprayOpacity'))).toBe(true);
   });
 });
@@ -346,6 +346,7 @@ describe('per-tool slice: sponge (#453)', () => {
     const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
     const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
     const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
     const beforeBrushSize = useToolSettingsStore.getState().brushSize;
     useToolSettingsStore.getState().setSpongeSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.sponge.size).toBe(42);
@@ -358,6 +359,67 @@ describe('per-tool slice: sponge (#453)', () => {
     expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
     expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: eraser (#453)', () => {
+  it('exposes eraser settings under settings.eraser with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setEraserSetting.
+    useToolSettingsStore.getState().setEraserSetting('size', 10);
+    useToolSettingsStore.getState().setEraserSetting('opacity', 100);
+    const { eraser } = useToolSettingsStore.getState().settings;
+    expect(eraser).toEqual({ size: 10, opacity: 100 });
+  });
+
+  it('setEraserSetting updates one field without disturbing the other', () => {
+    const before = useToolSettingsStore.getState().settings.eraser;
+    useToolSettingsStore.getState().setEraserSetting('size', 75);
+    const after = useToolSettingsStore.getState().settings.eraser;
+    expect(after.size).toBe(75);
+    expect(after.opacity).toBe(before.opacity);
+  });
+
+  it('setEraserSetting clamps size into [1, 5000]', () => {
+    useToolSettingsStore.getState().setEraserSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.eraser.size).toBe(1);
+    useToolSettingsStore.getState().setEraserSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.eraser.size).toBe(5000);
+  });
+
+  it('setEraserSetting clamps opacity into [1, 100]', () => {
+    // The legacy setEraserOpacity clamped to [1, 100], not [0, 100] —
+    // a 0 here would silently produce a no-op eraser stroke, which is
+    // the same percent-vs-normalised footgun guarded by the warn-once
+    // dedupe. Preserve that range under the slice.
+    useToolSettingsStore.getState().setEraserSetting('opacity', -10);
+    expect(useToolSettingsStore.getState().settings.eraser.opacity).toBe(1);
+    useToolSettingsStore.getState().setEraserSetting('opacity', 200);
+    expect(useToolSettingsStore.getState().settings.eraser.opacity).toBe(100);
+  });
+
+  it('setEraserSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setEraserSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.eraser.size).toBe(42);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when eraser changes. This is
+    // the invariant that justifies slicing instead of fattening the
+    // flat bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -10,6 +10,7 @@ import { clampMarqueeSetting } from '../tools/marquee/marquee-settings';
 import { clampSmudgeSetting } from '../tools/smudge/smudge-settings';
 import { clampPencilSetting } from '../tools/pencil/pencil-settings';
 import { clampSpongeSetting } from '../tools/sponge/sponge-settings';
+import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -38,8 +39,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushSize: 10,
   brushOpacity: 100,
   brushHardness: 80,
-  eraserSize: 10,
-  eraserOpacity: 100,
   shapeMode: 'ellipse',
   shapeOutput: 'pixels' as const,
   shapeFillColor: { r: 255, g: 255, b: 255, a: 1 },
@@ -179,10 +178,14 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       pencil: { ...s.settings.pencil, [key]: clampPencilSetting(key, value) },
     },
   })),
-  setEraserSize: (size) => set({ eraserSize: Math.max(1, Math.min(5000, size)) }),
-  setEraserOpacity: (opacity) => {
-    warnIfNormalisedOpacity('setEraserOpacity', opacity);
-    set({ eraserOpacity: Math.max(1, Math.min(100, opacity)) });
+  setEraserSetting: (key, value) => {
+    if (key === 'opacity') warnIfNormalisedOpacity('setEraserSetting(opacity)', value as number);
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        eraser: { ...s.settings.eraser, [key]: clampEraserSetting(key, value) },
+      },
+    }));
   },
   setFillSetting: (key, value) => set((s) => ({
     settings: {

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -9,6 +9,7 @@ import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
 import type { SmudgeSettings } from '../tools/smudge/smudge-settings';
 import type { PencilSettings } from '../tools/pencil/pencil-settings';
 import type { SpongeSettings } from '../tools/sponge/sponge-settings';
+import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -25,8 +26,6 @@ export interface ToolSettings {
   brushSize: number;
   brushOpacity: number;
   brushHardness: number;
-  eraserSize: number;
-  eraserOpacity: number;
   shapeMode: ShapeMode;
   shapeOutput: ShapeOutput;
   shapeFillColor: Color | null;
@@ -145,8 +144,7 @@ export interface ToolSettings {
   setBrushOpacity: (opacity: number) => void;
   setBrushHardness: (hardness: number) => void;
   setPencilSetting: <K extends keyof PencilSettings>(key: K, value: PencilSettings[K]) => void;
-  setEraserSize: (size: number) => void;
-  setEraserOpacity: (opacity: number) => void;
+  setEraserSetting: <K extends keyof EraserSettings>(key: K, value: EraserSettings[K]) => void;
   setFillSetting: <K extends keyof FillSettings>(key: K, value: FillSettings[K]) => void;
   setShapeMode: (mode: ShapeMode) => void;
   setShapeOutput: (output: ShapeOutput) => void;

--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -40,7 +40,7 @@ function getToolSize(tool: BrushTool, settings: ReturnType<typeof useToolSetting
     case 'pencil':
       return settings.settings.pencil.size;
     case 'eraser':
-      return settings.eraserSize;
+      return settings.settings.eraser.size;
     case 'stamp':
       return settings.stampSize;
   }

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -307,7 +307,7 @@ function renderFrameGpu(
     if (brushCursorInfo !== null && cursorOnCanvas) {
       const size = activeTool === 'brush' ? toolState.brushSize
         : activeTool === 'pencil' ? toolState.settings.pencil.size
-        : activeTool === 'eraser' ? toolState.eraserSize
+        : activeTool === 'eraser' ? toolState.settings.eraser.size
         : activeTool === 'stamp' ? toolState.stampSize
         : activeTool === 'sponge' ? toolState.settings.sponge.size
         : brushCursorInfo.size;

--- a/src/tools/eraser/eraser-settings.test.ts
+++ b/src/tools/eraser/eraser-settings.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_ERASER_SETTINGS,
+  clampEraserSetting,
+  type EraserSettings,
+} from './eraser-settings';
+
+describe('eraser-settings (#453 per-tool slice)', () => {
+  it('defaults match the legacy flat-bag values', () => {
+    const defaults: EraserSettings = DEFAULT_ERASER_SETTINGS;
+    expect(defaults).toEqual({ size: 10, opacity: 100 });
+  });
+
+  it('clampEraserSetting clamps size into [1, 5000]', () => {
+    expect(clampEraserSetting('size', 0)).toBe(1);
+    expect(clampEraserSetting('size', -10)).toBe(1);
+    expect(clampEraserSetting('size', 1)).toBe(1);
+    expect(clampEraserSetting('size', 100)).toBe(100);
+    expect(clampEraserSetting('size', 5000)).toBe(5000);
+    expect(clampEraserSetting('size', 99999)).toBe(5000);
+  });
+
+  it('clampEraserSetting clamps opacity into [1, 100]', () => {
+    // The legacy setEraserOpacity clamped to [1, 100] (not [0, 100]),
+    // matching the percent-vs-normalised footgun guard — a caller who
+    // passed 0 would otherwise get a silent no-op stroke.
+    expect(clampEraserSetting('opacity', -10)).toBe(1);
+    expect(clampEraserSetting('opacity', 0)).toBe(1);
+    expect(clampEraserSetting('opacity', 1)).toBe(1);
+    expect(clampEraserSetting('opacity', 50)).toBe(50);
+    expect(clampEraserSetting('opacity', 100)).toBe(100);
+    expect(clampEraserSetting('opacity', 200)).toBe(100);
+  });
+});

--- a/src/tools/eraser/eraser-settings.ts
+++ b/src/tools/eraser/eraser-settings.ts
@@ -1,0 +1,37 @@
+/**
+ * Per-tool settings slice for the Eraser tool.
+ *
+ * Authoritative settings type for eraser. The slice lives under
+ * `settings.eraser` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Two numeric fields: `size` and `opacity`.
+ * The opacity clamp range starts at 1 (not 0) — matches the legacy
+ * `setEraserOpacity` so callers don't silently get a no-op stroke.
+ */
+export interface EraserSettings {
+  size: number;
+  opacity: number;
+}
+
+export const DEFAULT_ERASER_SETTINGS: EraserSettings = {
+  size: 10,
+  opacity: 100,
+};
+
+export function clampEraserSetting<K extends keyof EraserSettings>(
+  key: K,
+  value: EraserSettings[K],
+): EraserSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as EraserSettings[K];
+  }
+  if (key === 'opacity') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as EraserSettings[K];
+  }
+  return value;
+}

--- a/src/tools/eraser/eraser-stroke.ts
+++ b/src/tools/eraser/eraser-stroke.ts
@@ -16,9 +16,9 @@ export function handleEraserStroke(
   if (!state.lastPoint || !state.layerId) return;
 
   const toolSettings = useToolSettingsStore.getState();
-  const size = toolSettings.eraserSize;
+  const size = toolSettings.settings.eraser.size;
   const hardness = 0.8;
-  const opacity = toolSettings.eraserOpacity / 100;
+  const opacity = toolSettings.settings.eraser.opacity / 100;
   const spacing = Math.max(1, size * 0.25);
   const { points: pts, remainder: spacingRem } = interpolateWithSpacing(state.lastPoint, layerLocalPos, spacing, state.spacingRemainder ?? 0);
   state.spacingRemainder = spacingRem;


### PR DESCRIPTION
## Summary

Seventh per-tool settings slice for #453 — migrates **eraser** to `settings.eraser.{size,opacity}`, following the established pattern from wand → fill → marquee → smudge → dodge → pencil.

- Adds `src/tools/eraser/eraser-settings.ts` with `EraserSettings` + `DEFAULT_ERASER_SETTINGS` + `clampEraserSetting`.
- Registers `eraser: EraserSettings` in `ToolSettingsSlices`.
- Replaces the flat `eraserSize` / `eraserOpacity` fields and their two setters with a single typed `setEraserSetting<K extends keyof EraserSettings>(key, value)`.
- Read sites updated in `EraserOptions.tsx`, `eraser-stroke.ts`, `paint-handlers.ts` (×4 branches: quick-mask, mask-edit, line, dab), `useCanvasRendering.ts`, `useCanvasCursor.ts`, and the `[`/`]` size shortcut in `tool-shortcuts.ts`.

## Why eraser, why now

The slice infrastructure has now carried six different shapes (3-field mixed for wand / number+bool for fill / single rounded number for marquee / dual-number for smudge / number+enum for dodge / single-number paint for pencil). Eraser is a useful next data point because it's the **first slice carrying a setter-specific side effect** — the legacy `setEraserOpacity` called the `warnIfNormalisedOpacity` percent-vs-normalised guard. The slice migration preserves that warn-once behaviour by rekeying it to `setEraserSetting(opacity)` so callers passing a fractional value still get the documented warning instead of a silent no-op stroke. This confirms the slice infrastructure can carry per-setter side effects, not just clamps — important before the largest slice (brush) inherits it, since brush opacity and hardness have similar percent-range invariants.

Eraser is also small/safe: 2 numeric fields, 7 read sites across 6 files, no e2e tests reference the legacy field names.

## Test plan

- [x] `src/tools/eraser/eraser-settings.test.ts` — defaults + clamp ranges for both fields, including the `[1, 100]` opacity clamp (rather than `[0, 100]`) that mirrors the legacy setter.
- [x] `src/app/tool-settings-store.test.ts` — new `per-tool slice: eraser (#453)` describe block: default shape, per-field updates, both clamp ranges, sibling-slice referential identity vs. wand / fill / marquee / smudge / pencil.
- [x] Existing `setEraserOpacity` warn-once test rewritten to `setEraserSetting('opacity', …)` — confirms the percent-vs-normalised guard still fires under the slice setter.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors.
- [x] `npm run test` — 991 / 991 unit tests pass.

https://claude.ai/code/session_01EBcwhmnH3GcRBV43rTDhuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfWqLq436Ua6AVs9CFwpMh)_