### PR TITLE
fix(filters): cap Surface Blur radius to prevent GPU watchdog crash

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/api/filter/blur.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/filter/blur.rs
@@ -234,9 +234,17 @@ pub fn filter_tilt_shift_blur(
     );
 }
 
+// Surface blur is a non-separable bilateral filter: the shader samples a
+// (2r+1)^2 neighborhood per pixel, so cost grows with the square of the
+// radius. A large radius would run a single draw call long enough to trip
+// the GPU watchdog and drop the WebGL context, so the radius is capped here
+// regardless of what the caller requests.
+const SURFACE_BLUR_MAX_RADIUS: u32 = 50;
+
 #[wasm_bindgen(js_name = "filterSurfaceBlur")]
 pub fn filter_surface_blur(engine: &mut Engine, layer_id: &str, radius: u32, threshold: f32) {
     if radius == 0 { return; }
+    let radius = radius.min(SURFACE_BLUR_MAX_RADIUS);
     let threshold = threshold.clamp(1.0, 255.0) / 255.0;
     filter_gpu::apply_filter(
         &mut engine.inner,

--- a/src/filters/surface-blur.ts
+++ b/src/filters/surface-blur.ts
@@ -5,7 +5,7 @@ export const surfaceBlur: FilterDefinition = {
   id: 'surface-blur',
   title: 'Surface Blur',
   params: [
-    { key: 'radius', label: 'Radius', min: 1, max: 50, step: 1, defaultValue: 5, dynamicMax: 'doc' },
+    { key: 'radius', label: 'Radius', min: 1, max: 50, step: 1, defaultValue: 5 },
     { key: 'threshold', label: 'Threshold', min: 1, max: 255, step: 1, defaultValue: 15 },
   ],
   applyGpu: (engine, layerId, values) =>


### PR DESCRIPTION
## Problem

Using **Surface Blur** with preview enabled and moving the radius slider freezes the app — hard enough to crash the whole browser.

## Root cause

Surface Blur is a **non-separable bilateral filter**. Its shader (`surface_blur.glsl`) samples a `(2r+1)²` neighborhood per pixel via nested loops driven directly by the `u_radius` uniform, so its cost grows with the **square** of the radius.

The radius param carried `dynamicMax: 'doc'`, which scales the slider ceiling to **1.5× the document's largest dimension, capped at 5000** (`src/utils/slider-ranges.ts`). That flag is correct for the *separable* blurs (box/gaussian/motion are O(r) and absorb large radii via a `u_step` multiplier across passes — see the bounded `-63..63` loop in `box_blur.glsl`), but it was wrongly copied onto surface blur.

So on a normal photo, dragging the radius slider even partway pushes it into the hundreds/thousands → up to ~100 **million** texture samples *per pixel* in a single draw call → the GPU watchdog (TDR) fires → the WebGL context is lost → on many systems the GPU driver resets and the browser crashes. With preview on, each slider nudge re-fires that draw, producing the freeze.

## Fix

1. **`src/filters/surface-blur.ts`** — remove `dynamicMax: 'doc'` from the radius param, restoring its intended `max: 50`. Worst case drops from ~100M to ~10k samples/pixel (comparable to a strong Gaussian — safe and bounded).
2. **`engine-rs/.../api/filter/blur.rs`** — clamp the radius to 50 inside `filterSurfaceBlur` as defense-in-depth, so no caller (presets, future scripting) can drive the O(r²) loop past a safe bound.

The shader keeps its *dynamic* loop bound: once the uniform is guaranteed ≤ 50, it does exactly `(2r+1)²` work, so the common case (default radius 5) stays cheap rather than paying ~10k branch evaluations per pixel from a forced static `-50..50` loop.

## Verification

- `npm run typecheck` passes (only a pre-existing `baseUrl` deprecation warning).
- `cargo check -p lopsy-wasm` compiles clean.

🤖 https://claude.ai/code/session_013yMhB2nvLAA7pSYLQBvNmr

---
_Generated by [Claude Code](https://claude.ai/code/session_013yMhB2nvLAA7pSYLQBvNmr)_