### PR TITLE
refactor(tool-settings): migrate stamp to per-tool slice (#453)

### DIFF
--- a/src/app/OptionsBar/tool-options/StampOptions.tsx
+++ b/src/app/OptionsBar/tool-options/StampOptions.tsx
@@ -5,15 +5,15 @@ import { docScaledMax } from '../../../utils/slider-ranges';
 import styles from '../OptionsBar.module.css';
 
 export function StampOptions() {
-  const stampSize = useToolSettingsStore((s) => s.stampSize);
-  const setStampSize = useToolSettingsStore((s) => s.setStampSize);
+  const stampSize = useToolSettingsStore((s) => s.settings.stamp.size);
+  const setStampSetting = useToolSettingsStore((s) => s.setStampSetting);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 200);
 
   return (
     <>
-      <Slider label="Size" value={stampSize} min={1} max={sizeMax} sliderMax={300} onChange={setStampSize} />
+      <Slider label="Size" value={stampSize} min={1} max={sizeMax} sliderMax={300} onChange={(size) => setStampSetting('size', size)} />
       <span className={styles.hint}>Alt/Cmd+click to set source</span>
     </>
   );

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -55,7 +55,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'eraser') {
     ts.setEraserSetting('size', ts.settings.eraser.size + delta);
   } else if (tool === 'stamp') {
-    ts.setStampSize(ts.stampSize + delta);
+    ts.setStampSetting('size', ts.settings.stamp.size + delta);
   } else if (tool === 'healing') {
     ts.setHealingSize(ts.healingSize + delta);
   } else if (tool === 'path') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -14,6 +14,8 @@ import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import { DEFAULT_ERASER_SETTINGS } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import { DEFAULT_PATH_SETTINGS } from '../tools/path/path-settings';
+import type { StampSettings } from '../tools/stamp/stamp-settings';
+import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -33,6 +35,7 @@ export interface ToolSettingsSlices {
   sponge: SpongeSettings;
   eraser: EraserSettings;
   path: PathSettings;
+  stamp: StampSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -44,4 +47,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   sponge: DEFAULT_SPONGE_SETTINGS,
   eraser: DEFAULT_ERASER_SETTINGS,
   path: DEFAULT_PATH_SETTINGS,
+  stamp: DEFAULT_STAMP_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -406,6 +406,52 @@ describe('per-tool slice: path (#453)', () => {
   });
 });
 
+describe('per-tool slice: stamp (#453)', () => {
+  it('exposes stamp settings under settings.stamp with the legacy default', () => {
+    // Reset to the legacy default — prior tests in this file may have
+    // mutated the slice through setStampSetting.
+    useToolSettingsStore.getState().setStampSetting('size', 20);
+    const { stamp } = useToolSettingsStore.getState().settings;
+    expect(stamp).toEqual({ size: 20 });
+  });
+
+  it('setStampSetting updates size and clamps it into [1, 5000]', () => {
+    useToolSettingsStore.getState().setStampSetting('size', 75);
+    expect(useToolSettingsStore.getState().settings.stamp.size).toBe(75);
+    useToolSettingsStore.getState().setStampSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.stamp.size).toBe(1);
+    useToolSettingsStore.getState().setStampSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.stamp.size).toBe(5000);
+  });
+
+  it('setStampSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setStampSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.stamp.size).toBe(42);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when stamp changes. This is the
+    // invariant that justifies slicing instead of fattening the flat
+    // bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
 describe('per-tool slice: eraser (#453)', () => {
   it('exposes eraser settings under settings.eraser with the legacy defaults', () => {
     // Reset to the legacy defaults — prior tests in this file may have

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -12,6 +12,7 @@ import { clampPencilSetting } from '../tools/pencil/pencil-settings';
 import { clampSpongeSetting } from '../tools/sponge/sponge-settings';
 import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
+import { clampStampSetting } from '../tools/stamp/stamp-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -57,7 +58,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
   ],
   gradientReverse: false,
-  stampSize: 20,
   healingSize: 20,
   healingOpacity: 100,
   dodgeExposure: 50,
@@ -245,7 +245,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setSymmetryVertical: (enabled) => set({ symmetryVertical: enabled }),
   setSymmetryRadialSegments: (segments) => set({ symmetryRadialSegments: Math.max(0, Math.min(32, Math.round(segments))) }),
   setSymmetryCenter: (center) => set({ symmetryCenter: center }),
-  setStampSize: (size) => set({ stampSize: Math.max(1, Math.min(5000, size)) }),
+  setStampSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      stamp: { ...s.settings.stamp, [key]: clampStampSetting(key, value) },
+    },
+  })),
   setHealingSize: (size) => set({ healingSize: Math.max(1, Math.min(5000, size)) }),
   setHealingOpacity: (opacity) => {
     warnIfNormalisedOpacity('setHealingOpacity', opacity);

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -11,6 +11,7 @@ import type { PencilSettings } from '../tools/pencil/pencil-settings';
 import type { SpongeSettings } from '../tools/sponge/sponge-settings';
 import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
+import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -41,7 +42,6 @@ export interface ToolSettings {
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
-  stampSize: number;
   healingSize: number;
   healingOpacity: number;
   dodgeExposure: number;
@@ -116,7 +116,7 @@ export interface ToolSettings {
   setBrushScatter: (scatter: number) => void;
   setBrushAngle: (angle: number) => void;
   setActiveBrushTip: (tip: BrushTipData | null) => void;
-  setStampSize: (size: number) => void;
+  setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
   setHealingSize: (size: number) => void;
   setHealingOpacity: (opacity: number) => void;
   setDodgeExposure: (exposure: number) => void;

--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -42,7 +42,7 @@ function getToolSize(tool: BrushTool, settings: ReturnType<typeof useToolSetting
     case 'eraser':
       return settings.settings.eraser.size;
     case 'stamp':
-      return settings.stampSize;
+      return settings.settings.stamp.size;
   }
 }
 

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -308,7 +308,7 @@ function renderFrameGpu(
       const size = activeTool === 'brush' ? toolState.brushSize
         : activeTool === 'pencil' ? toolState.settings.pencil.size
         : activeTool === 'eraser' ? toolState.settings.eraser.size
-        : activeTool === 'stamp' ? toolState.stampSize
+        : activeTool === 'stamp' ? toolState.settings.stamp.size
         : activeTool === 'sponge' ? toolState.settings.sponge.size
         : brushCursorInfo.size;
       renderBrushCursor(overlayCtx, cursorPosition, size, viewport.zoom, brushCursorInfo.shape, brushCursorInfo.tip, brushCursorInfo.angle);

--- a/src/tools/stamp/stamp-interaction.ts
+++ b/src/tools/stamp/stamp-interaction.ts
@@ -38,11 +38,11 @@ export function handleStampDown(ctx: InteractionContext): InteractionState | und
       && ctx.lastPaintPointRef.current
       && ctx.lastPaintPointRef.current.layerId === activeLayerId;
     if (stampShiftLine) {
-      const spacing = Math.max(1, toolSettings.stampSize * 0.25);
+      const spacing = Math.max(1, toolSettings.settings.stamp.size * 0.25);
       const pts = interpolateFlat(ctx.lastPaintPointRef.current!.point, layerPos, spacing);
-      gpuStampDabBatch(engine, activeLayerId, pts, ctx.stampOffsetRef.current.x, ctx.stampOffsetRef.current.y, toolSettings.stampSize);
+      gpuStampDabBatch(engine, activeLayerId, pts, ctx.stampOffsetRef.current.x, ctx.stampOffsetRef.current.y, toolSettings.settings.stamp.size);
     } else {
-      gpuStampDab(engine, activeLayerId, layerPos.x, layerPos.y, ctx.stampOffsetRef.current.x, ctx.stampOffsetRef.current.y, toolSettings.stampSize);
+      gpuStampDab(engine, activeLayerId, layerPos.x, layerPos.y, ctx.stampOffsetRef.current.x, ctx.stampOffsetRef.current.y, toolSettings.settings.stamp.size);
     }
     editorState.notifyRender();
   }
@@ -69,12 +69,12 @@ export function handleStampMove(
   if (!state.lastPoint || !stampOffsetRef.current) return;
 
   const toolSettings = useToolSettingsStore.getState();
-  const stampSpacing = Math.max(1, toolSettings.stampSize * 0.25);
+  const stampSpacing = Math.max(1, toolSettings.settings.stamp.size * 0.25);
 
   const engine = getEngine();
   if (engine && state.layerId) {
     const pts = interpolateFlat(state.lastPoint, layerLocalPos, stampSpacing);
-    gpuStampDabBatch(engine, state.layerId, pts, stampOffsetRef.current.x, stampOffsetRef.current.y, toolSettings.stampSize);
+    gpuStampDabBatch(engine, state.layerId, pts, stampOffsetRef.current.x, stampOffsetRef.current.y, toolSettings.settings.stamp.size);
   }
   state.lastPoint = layerLocalPos;
   useEditorStore.getState().notifyRender();

--- a/src/tools/stamp/stamp-settings.test.ts
+++ b/src/tools/stamp/stamp-settings.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_STAMP_SETTINGS,
+  clampStampSetting,
+  type StampSettings,
+} from './stamp-settings';
+
+describe('stamp-settings (#453 per-tool slice)', () => {
+  it('defaults match the legacy flat-bag value', () => {
+    const defaults: StampSettings = DEFAULT_STAMP_SETTINGS;
+    expect(defaults).toEqual({ size: 20 });
+  });
+
+  it('clampStampSetting clamps size into [1, 5000]', () => {
+    expect(clampStampSetting('size', 0)).toBe(1);
+    expect(clampStampSetting('size', -10)).toBe(1);
+    expect(clampStampSetting('size', 1)).toBe(1);
+    expect(clampStampSetting('size', 25)).toBe(25);
+    expect(clampStampSetting('size', 5000)).toBe(5000);
+    expect(clampStampSetting('size', 99999)).toBe(5000);
+  });
+});

--- a/src/tools/stamp/stamp-settings.ts
+++ b/src/tools/stamp/stamp-settings.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-tool settings slice for the Clone Stamp tool.
+ *
+ * Authoritative settings type for stamp. The slice lives under
+ * `settings.stamp` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` +
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Single numeric field, but covers the
+ * clone-stamp tool class (the others were paint / selection / vector)
+ * so the slice infrastructure is exercised on a new tool class.
+ */
+export interface StampSettings {
+  size: number;
+}
+
+export const DEFAULT_STAMP_SETTINGS: StampSettings = {
+  size: 20,
+};
+
+export function clampStampSetting<K extends keyof StampSettings>(
+  key: K,
+  value: StampSettings[K],
+): StampSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as StampSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Tenth per-tool slice for the #453 rollout. **Stamp** is the first slice on the clone-stamp tool class — the others were paint (brush family) / selection (wand, marquee) / vector (path), so the slice infrastructure is exercised on a new tool class. Single numeric field (`size`), same shape as marquee / pencil / path.

The slice introduces `src/tools/stamp/stamp-settings.ts` with `StampSettings` + `DEFAULT_STAMP_SETTINGS` + `clampStampSetting`, registers `stamp: StampSettings` in `ToolSettingsSlices`, and replaces the flat `stampSize` field and `setStampSize` setter with a single typed `setStampSetting<K extends keyof StampSettings>(key, value)`.

Read sites in `StampOptions.tsx`, `stamp-interaction.ts`, `useCanvasRendering.ts`, `useCanvasCursor.ts`, and `tool-shortcuts.ts` now access `settings.stamp.size` instead of `stampSize`. No e2e tests reference the legacy field names.

The store tests assert sibling-slice referential identity across all eight `main`-side slices (wand, fill, marquee, smudge, pencil, sponge, path, eraser, stamp), so the invariant stays locked in for the rest of the rollout.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run src/tools/stamp/ src/app/tool-settings-store.test.ts` — 49/49 pass (3 new stamp slice tests + 2 standalone unit tests)
- [x] Full unit test suite — 1021/1021 pass
- [ ] Manual: switch to Clone Stamp tool, change size via slider and `[`/`]` shortcuts; alt-click to set source; clone-stamp a layer — confirms the size value reaches the GPU dab and cursor render paths through the new slice.

https://claude.ai/code/session_016R5ZgY2QBqUpP86aVTY9bJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016R5ZgY2QBqUpP86aVTY9bJ)_