### PR TITLE
docs(features): document radial brush symmetry and Taper doc-scaling

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,11 +11,11 @@ The toolbar exposes Size, Opacity, Hardness, Fade, and the symmetry toggle. Ever
 - **Opacity**: 1 - 100%
 - **Hardness**: 0 - 100%
 - **Fade**: 0 - 2000 px (opacity fade-out distance, exposed on the options bar)
-- **Taper**: 0 - 2000 px (size taper-out distance, exposed in the modal's Shape tab — brush dabs shrink toward zero over this many pixels of stroke length, independent of the Fade opacity rolloff)
+- **Taper**: 0 - 2000 px base range, auto-scaled by document size like Size (the modal's Shape-tab slider max is `1.5 × longest-document-side`, capped at 5000 px) — size taper-out distance: brush dabs shrink toward zero over this many pixels of stroke length, independent of the Fade opacity rolloff
 - **Spacing**: 1 - 200% of brush size
 - **Scatter**: 0 - 100%
 - **Angle**: 0 - 360 degrees (set via the modal's angle dial)
-- **Symmetry**: horizontal, vertical, or both (4-way)
+- **Symmetry**: horizontal, vertical, both (4-way), or radial (2 - 32 segments). The horizontal/vertical toggles and the **Radial Symmetry** control (with its segment-count slider) all live in the Brush options bar; see the Symmetry section for full behavior.
 
 **Dynamics** (Brushes modal → Dynamics section). Per-dab randomization is performed GPU-side, seeded by each dab's center position so strokes are deterministic for a given path.
 - **Size Jitter**: 0 - 100% — per-dab size randomization
@@ -674,9 +674,9 @@ A compact heads-up readout that mirrors what Photoshop's Info panel surfaces.
 
 ## Symmetry
 
-- **Axes**: horizontal, vertical, or both (4-way)
+- **Axes**: horizontal, vertical, both (4-way), or radial. Radial symmetry mirrors each dab into **2 - 32 evenly-rotated copies** around the center (kaleidoscope-style) and takes precedence over the horizontal/vertical mirrors when its segment count is ≥ 2.
 - **Center**: configurable (defaults to canvas center)
-- Available on brush, pencil, and eraser
+- Available on brush, pencil, and eraser. The symmetry config (axes, center, radial segment count) is global, so it applies to whichever of these tools is active. Only the Brush options bar exposes the **Radial Symmetry** toggle and segment slider; the Pencil options bar exposes just the horizontal/vertical toggles (radial set from the Brush still applies to pencil/eraser strokes), and the Eraser inherits the active config without its own toggles.
 - **Cmd/Meta+click** on the canvas while any symmetry mode (horizontal, vertical, or radial with 2+ segments) is active moves the symmetry center to the click point without painting a dab. Lets the user reposition the mirror axis directly from the canvas without opening a settings panel.
 
 ---


### PR DESCRIPTION
## Summary

Scheduled FEATURES.md accuracy/exhaustiveness pass. Two real, verified discrepancies found between the catalog and the actual code:

- **Radial brush symmetry was undocumented.** The shared symmetry model (`getMirroredPoints` / `mirrorBatchPoints` in `src/tools/symmetry.ts`) supports **2–32 evenly-rotated segments** and takes precedence over the H/V mirrors when active. It's exposed via the **Radial Symmetry** control in the Brush options bar (`BrushOptions.tsx`, clamped 0–32 in `tool-settings-store.ts`) and applies to brush, pencil, and eraser strokes (config is global). FEATURES.md previously listed only horizontal / vertical / both.
- **Brush Taper range was understated.** `BrushModal.tsx` sets the Taper slider max via `docScaledMax(docWidth, docHeight, 2000)` (same as Size) — so it's `1.5 × longest-document-side`, capped at 5000 px, not a flat 2000. Now noted as auto-scaled like Size.

Everything else in the catalog audited as accurate (all 23 tools, 14 adjustment nodes, filters, menu commands, shortcuts, and modifier-key behaviors check out against the code — including the gradient cmd-drag 15° snap, hold-to-smooth, and shift-click straight lines).

## Notes
- Branched fresh from `origin/main` rather than the prior `docs-features-*` working branch, which had drifted behind main.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)