### PR TITLE
refactor(tool-settings): migrate healing to per-tool slice (#453)

### DIFF
--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -57,7 +57,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'stamp') {
     ts.setStampSetting('size', ts.settings.stamp.size + delta);
   } else if (tool === 'healing') {
-    ts.setHealingSize(ts.healingSize + delta);
+    ts.setHealingSetting('size', ts.settings.healing.size + delta);
   } else if (tool === 'path') {
     ts.setPathSetting('strokeWidth', ts.settings.path.strokeWidth + delta);
   } else if (tool === 'shape') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -16,6 +16,8 @@ import type { PathSettings } from '../tools/path/path-settings';
 import { DEFAULT_PATH_SETTINGS } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
+import type { HealingSettings } from '../tools/healing/healing-settings';
+import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -36,6 +38,7 @@ export interface ToolSettingsSlices {
   eraser: EraserSettings;
   path: PathSettings;
   stamp: StampSettings;
+  healing: HealingSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -48,4 +51,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   eraser: DEFAULT_ERASER_SETTINGS,
   path: DEFAULT_PATH_SETTINGS,
   stamp: DEFAULT_STAMP_SETTINGS,
+  healing: DEFAULT_HEALING_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -101,6 +101,24 @@ describe('opacity setters — issue #250 (percent vs normalised footgun)', () =>
     expect(messages.some((m: string) => m.includes('setEraserSetting(opacity)'))).toBe(true);
     expect(messages.some((m: string) => m.includes('setSprayOpacity'))).toBe(true);
   });
+
+  it('also warns from setHealingSetting(opacity) (same footgun)', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setHealingSetting('opacity', 0.5);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain('setHealingSetting(opacity)');
+    expect(message).toContain('percent');
+    // The value still gets clamped into the percent range so callers
+    // don't get the original 1%-stroke footgun.
+    expect(store.getState().settings.healing.opacity).toBe(1);
+  });
+
+  it('does not warn from setHealingSetting(size) — only opacity guards the percent vs normalised footgun', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setHealingSetting('size', 0.5);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('per-tool slice: wand (#453)', () => {
@@ -508,6 +526,70 @@ describe('per-tool slice: eraser (#453)', () => {
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
     expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
     expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: healing (#453)', () => {
+  it('exposes healing settings under settings.healing with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setHealingSetting.
+    useToolSettingsStore.getState().setHealingSetting('size', 20);
+    useToolSettingsStore.getState().setHealingSetting('opacity', 100);
+    const { healing } = useToolSettingsStore.getState().settings;
+    expect(healing).toEqual({ size: 20, opacity: 100 });
+  });
+
+  it('setHealingSetting updates one field without disturbing the other', () => {
+    const before = useToolSettingsStore.getState().settings.healing;
+    useToolSettingsStore.getState().setHealingSetting('size', 75);
+    const after = useToolSettingsStore.getState().settings.healing;
+    expect(after.size).toBe(75);
+    expect(after.opacity).toBe(before.opacity);
+  });
+
+  it('setHealingSetting clamps size into [1, 5000]', () => {
+    useToolSettingsStore.getState().setHealingSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(1);
+    useToolSettingsStore.getState().setHealingSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(5000);
+  });
+
+  it('setHealingSetting clamps opacity into [1, 100]', () => {
+    // Legacy setHealingOpacity clamped to [1, 100] — preserve that
+    // under the slice. A 0 here would silently produce a no-op stroke,
+    // which is the same percent-vs-normalised footgun guarded by the
+    // warn-once dedupe.
+    useToolSettingsStore.getState().setHealingSetting('opacity', -10);
+    expect(useToolSettingsStore.getState().settings.healing.opacity).toBe(1);
+    useToolSettingsStore.getState().setHealingSetting('opacity', 200);
+    expect(useToolSettingsStore.getState().settings.healing.opacity).toBe(100);
+  });
+
+  it('setHealingSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setHealingSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(42);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when healing changes. This is
+    // the invariant that justifies slicing instead of fattening the
+    // flat bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -13,6 +13,7 @@ import { clampSpongeSetting } from '../tools/sponge/sponge-settings';
 import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
+import { clampHealingSetting } from '../tools/healing/healing-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -58,8 +59,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
   ],
   gradientReverse: false,
-  healingSize: 20,
-  healingOpacity: 100,
   dodgeExposure: 50,
   dodgeMode: 'dodge',
   quickSelectSize: 20,
@@ -251,10 +250,14 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       stamp: { ...s.settings.stamp, [key]: clampStampSetting(key, value) },
     },
   })),
-  setHealingSize: (size) => set({ healingSize: Math.max(1, Math.min(5000, size)) }),
-  setHealingOpacity: (opacity) => {
-    warnIfNormalisedOpacity('setHealingOpacity', opacity);
-    set({ healingOpacity: Math.max(1, Math.min(100, opacity)) });
+  setHealingSetting: (key, value) => {
+    if (key === 'opacity') warnIfNormalisedOpacity('setHealingSetting(opacity)', value as number);
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        healing: { ...s.settings.healing, [key]: clampHealingSetting(key, value) },
+      },
+    }));
   },
   setPathSetting: (key, value) => set((s) => ({
     settings: {

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -12,6 +12,7 @@ import type { SpongeSettings } from '../tools/sponge/sponge-settings';
 import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
+import type { HealingSettings } from '../tools/healing/healing-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -42,8 +43,6 @@ export interface ToolSettings {
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
-  healingSize: number;
-  healingOpacity: number;
   dodgeExposure: number;
   dodgeMode: DodgeMode;
   quickSelectSize: number;
@@ -117,8 +116,7 @@ export interface ToolSettings {
   setBrushAngle: (angle: number) => void;
   setActiveBrushTip: (tip: BrushTipData | null) => void;
   setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
-  setHealingSize: (size: number) => void;
-  setHealingOpacity: (opacity: number) => void;
+  setHealingSetting: <K extends keyof HealingSettings>(key: K, value: HealingSettings[K]) => void;
   setDodgeExposure: (exposure: number) => void;
   setDodgeMode: (mode: DodgeMode) => void;
   setSpongeSetting: <K extends keyof SpongeSettings>(key: K, value: SpongeSettings[K]) => void;

--- a/src/tools/healing/HealingOptions.tsx
+++ b/src/tools/healing/HealingOptions.tsx
@@ -5,18 +5,17 @@ import { docScaledMax } from '../../utils/slider-ranges';
 import styles from '../../app/OptionsBar/OptionsBar.module.css';
 
 export function HealingOptions() {
-  const healingSize = useToolSettingsStore((s) => s.healingSize);
-  const setHealingSize = useToolSettingsStore((s) => s.setHealingSize);
-  const healingOpacity = useToolSettingsStore((s) => s.healingOpacity);
-  const setHealingOpacity = useToolSettingsStore((s) => s.setHealingOpacity);
+  const healingSize = useToolSettingsStore((s) => s.settings.healing.size);
+  const healingOpacity = useToolSettingsStore((s) => s.settings.healing.opacity);
+  const setHealingSetting = useToolSettingsStore((s) => s.setHealingSetting);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 200);
 
   return (
     <>
-      <Slider label="Size" value={healingSize} min={1} max={sizeMax} onChange={setHealingSize} />
-      <Slider label="Opacity" value={healingOpacity} min={1} max={100} onChange={setHealingOpacity} />
+      <Slider label="Size" value={healingSize} min={1} max={sizeMax} onChange={(v) => setHealingSetting('size', v)} />
+      <Slider label="Opacity" value={healingOpacity} min={1} max={100} onChange={(v) => setHealingSetting('opacity', v)} />
       <span className={styles.hint}>Alt/Cmd+click to set source</span>
     </>
   );

--- a/src/tools/healing/healing-interaction.test.ts
+++ b/src/tools/healing/healing-interaction.test.ts
@@ -22,8 +22,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  healingSize: 20,
-  healingOpacity: 100,
+  settings: {
+    healing: { size: 20, opacity: 100 },
+  },
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },

--- a/src/tools/healing/healing-interaction.ts
+++ b/src/tools/healing/healing-interaction.ts
@@ -48,8 +48,7 @@ export function handleHealingDown(ctx: InteractionContext): InteractionState | u
     };
   }
 
-  const toolSettings = useToolSettingsStore.getState();
-  const { healingSize, healingOpacity } = toolSettings;
+  const { size: healingSize, opacity: healingOpacity } = useToolSettingsStore.getState().settings.healing;
 
   if (shiftKey && ctx.lastPaintPointRef.current && ctx.lastPaintPointRef.current.layerId === activeLayerId) {
     const spacing = Math.max(1, healingSize * 0.25);
@@ -78,8 +77,7 @@ export function handleHealingMove(
 ): void {
   if (!state.lastPoint || !stampOffsetRef.current || !state.layerId) return;
 
-  const toolSettings = useToolSettingsStore.getState();
-  const { healingSize, healingOpacity } = toolSettings;
+  const { size: healingSize, opacity: healingOpacity } = useToolSettingsStore.getState().settings.healing;
   const spacing = Math.max(1, healingSize * 0.25);
 
   const pts = interpolateFlat(state.lastPoint, layerLocalPos, spacing);

--- a/src/tools/healing/healing-settings.ts
+++ b/src/tools/healing/healing-settings.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-tool settings slice for the Healing Brush tool.
+ *
+ * Authoritative settings type for healing. The slice lives under
+ * `settings.healing` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts`: `<Tool>Settings` interface +
+ * `DEFAULT_<TOOL>_SETTINGS` + `clamp<Tool>Setting` helper, then
+ * registered in `tool-settings-slices.ts`. Two numeric fields: `size`
+ * and `opacity`. The opacity clamp range starts at 1 (not 0) — matches
+ * the legacy `setHealingOpacity` so callers don't silently get a
+ * no-op stroke; the percent-vs-normalised warn-once guard lives on
+ * the setter in the store, mirroring the eraser slice.
+ */
+export interface HealingSettings {
+  size: number;
+  opacity: number;
+}
+
+export const DEFAULT_HEALING_SETTINGS: HealingSettings = {
+  size: 20,
+  opacity: 100,
+};
+
+export function clampHealingSetting<K extends keyof HealingSettings>(
+  key: K,
+  value: HealingSettings[K],
+): HealingSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as HealingSettings[K];
+  }
+  if (key === 'opacity') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as HealingSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Eleventh per-tool slice for #453 — migrates the **Healing Brush** tool from the flat-bag `healingSize` / `healingOpacity` fields to `settings.healing.{size,opacity}`, following the eraser template from PR #586.

Healing mirrors the eraser shape (2 numeric fields, opacity carries the percent-vs-normalised warn-once guard), so the slice infrastructure carries a second tool through that pattern. Small surface, low risk: 2 fields, 6 read sites across 4 files (`HealingOptions.tsx`, `healing-interaction.ts` ×2, `tool-shortcuts.ts`); no e2e tests reference the legacy field names.

## Changes

- New `src/tools/healing/healing-settings.ts` with `HealingSettings` interface, `DEFAULT_HEALING_SETTINGS`, and `clampHealingSetting` helper. Same shape as `eraser-settings.ts`.
- `settings.healing` registered in `ToolSettingsSlices` (`src/app/tool-settings-slices.ts`).
- New typed `setHealingSetting<K extends keyof HealingSettings>(key, value)` on the store; the `opacity` branch keeps the warn-once `percent-vs-normalised` guard.
- Legacy `healingSize`, `healingOpacity`, `setHealingSize`, `setHealingOpacity` removed from `tool-settings-types.ts` and `tool-settings-store.ts`.
- Read sites migrated:
  - `src/tools/healing/HealingOptions.tsx` → `settings.healing.size` / `settings.healing.opacity` + `setHealingSetting`.
  - `src/tools/healing/healing-interaction.ts` (both `handleHealingDown` and `handleHealingMove`).
  - `src/app/shortcuts/tool-shortcuts.ts` — `[`/`]` size shortcut.

## Tests

- New `per-tool slice: healing (#453)` describe block in `src/app/tool-settings-store.test.ts` covering defaults, clamping (size `[1, 5000]`, opacity `[1, 100]`), independent-field updates, and sibling-slice referential identity across all nine `main`-side slices (wand, fill, marquee, smudge, pencil, sponge, path, stamp, healing).
- New warn-once tests confirm `setHealingSetting('opacity', 0.5)` triggers the percent-vs-normalised dedupe and clamps to `1`, and that `setHealingSetting('size', 0.5)` does **not** warn (size has no percent footgun).
- Existing `src/tools/healing/healing-interaction.test.ts` updated to mock the new `settings.healing` shape — all three pre-existing assertions still pass.
- Full unit suite green (1032 tests).

## Acceptance criteria progress

The two criteria addressed:

> Per-tool `*Settings` types are used by the store, not decorative.
> Adding a new tool's settings is a one-file change in the tool's directory.

…now hold for **healing** in addition to wand, fill, marquee, smudge, pencil, sponge, path, stamp (`main`) and eraser/dodge (open PRs). Remaining: brush (largest), shape, gradient, magnetic-lasso, quick-select, text, spray.

## Test plan

- [x] `npx vitest run` — 1032 tests pass.
- [x] `npm run typecheck` — passes.
- [x] `npm run lint` — 0 errors.
- [x] `npx vite build` — production bundle builds clean.
- [ ] Manual smoke: Healing tool — size slider, opacity slider, `[`/`]` shortcuts, alt/cmd-click source + drag stroke.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWsTzKNRiYp9XgHdmLEWDj)_