### PR TITLE
perf(compositor): specialize blend shader per blend mode

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/compositor.rs
+++ b/engine-rs/crates/lopsy-wasm/src/compositor.rs
@@ -184,7 +184,7 @@ pub fn composite(engine: &mut EngineInner) -> Result<(), String> {
                             true,
                             None,
                             group_mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)),
-                        );
+                        )?;
                     }
                     active_group_id = None;
                     // Re-bind composite FBO for subsequent layers
@@ -315,9 +315,9 @@ pub fn composite(engine: &mut EngineInner) -> Result<(), String> {
             if is_group_child {
                 let gs_tex = engine.group_scratch_texture.ok_or("group scratch texture not allocated")?;
                 let gs_fbo = engine.group_scratch_fbo.ok_or("group scratch FBO not allocated")?;
-                blend_onto_target(engine, &src_tex, opacity, blend_mode, layer_x, layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo);
+                blend_onto_target(engine, &src_tex, opacity, blend_mode, layer_x, layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo)?;
             } else {
-                blend_onto_composite(engine, &src_tex, opacity, blend_mode, layer_x, layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+                blend_onto_composite(engine, &src_tex, opacity, blend_mode, layer_x, layer_y, src_w, src_h, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)))?;
             }
         }
 
@@ -332,9 +332,9 @@ pub fn composite(engine: &mut EngineInner) -> Result<(), String> {
                     if is_group_child {
                         let gs_tex = engine.group_scratch_texture.ok_or("group scratch texture not allocated")?;
                         let gs_fbo = engine.group_scratch_fbo.ok_or("group scratch FBO not allocated")?;
-                        blend_onto_target(engine, &stroke_tex, combined_opacity, 0, layer_x, layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo);
+                        blend_onto_target(engine, &stroke_tex, combined_opacity, 0, layer_x, layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo)?;
                     } else {
-                        blend_onto_composite(engine, &stroke_tex, combined_opacity, 0, layer_x, layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+                        blend_onto_composite(engine, &stroke_tex, combined_opacity, 0, layer_x, layer_y, sw, sh, true, None, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)))?;
                     }
                 }
             }
@@ -403,7 +403,8 @@ pub fn composite(engine: &mut EngineInner) -> Result<(), String> {
 // Effect rendering helpers
 // ---------------------------------------------------------------------------
 
-/// Blend a source texture onto the composite using the blend shader.
+/// Blend a source texture onto the composite using the blend shader
+/// variant specialized for `blend_mode`.
 fn blend_onto_composite(
     engine: &mut EngineInner,
     src_tex: &web_sys::WebGlTexture,
@@ -416,22 +417,21 @@ fn blend_onto_composite(
     premultiplied: bool,
     overlay: Option<&ColorOverlayDesc>,
     mask_tex: Option<(&web_sys::WebGlTexture, u32, u32)>,
-) {
+) -> Result<(), String> {
     let doc_w = engine.doc_width as f32;
     let doc_h = engine.doc_height as f32;
 
-    engine.gl.use_program(Some(&engine.shaders.blend.program));
+    let shader = engine.shaders.blend_for_mode(&engine.gl, blend_mode)?;
+    engine.gl.use_program(Some(&shader.program));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(src_tex));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
     if let Some(comp_tex) = engine.texture_pool.get(engine.composite_texture) {
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(comp_tex));
     }
-    let shader = &engine.shaders.blend;
     if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
     if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), opacity); }
-    if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), blend_mode); }
     if let Some(loc) = shader.location(&engine.gl, "u_hasBrushTexture") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), layer_x, layer_y); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), tw as f32, th as f32); }
@@ -482,6 +482,7 @@ fn blend_onto_composite(
     }
     if let Some(loc) = engine.shaders.blit.location(&engine.gl, "u_tex") { engine.gl.uniform1i(Some(&loc), 0); }
     engine.draw_fullscreen_quad();
+    Ok(())
 }
 
 /// Same as `blend_onto_composite` but blits to an arbitrary target FBO/texture
@@ -501,22 +502,21 @@ fn blend_onto_target(
     mask_tex: Option<(&web_sys::WebGlTexture, u32, u32)>,
     dst_texture: TextureHandle,
     dst_fbo: FramebufferHandle,
-) {
+) -> Result<(), String> {
     let doc_w = engine.doc_width as f32;
     let doc_h = engine.doc_height as f32;
 
-    engine.gl.use_program(Some(&engine.shaders.blend.program));
+    let shader = engine.shaders.blend_for_mode(&engine.gl, blend_mode)?;
+    engine.gl.use_program(Some(&shader.program));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(src_tex));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
     if let Some(dst_tex) = engine.texture_pool.get(dst_texture) {
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(dst_tex));
     }
-    let shader = &engine.shaders.blend;
     if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
     if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), opacity); }
-    if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), blend_mode); }
     if let Some(loc) = shader.location(&engine.gl, "u_hasBrushTexture") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), layer_x, layer_y); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), tw as f32, th as f32); }
@@ -558,6 +558,7 @@ fn blend_onto_target(
     }
     if let Some(loc) = engine.shaders.blit.location(&engine.gl, "u_tex") { engine.gl.uniform1i(Some(&loc), 0); }
     engine.draw_fullscreen_quad();
+    Ok(())
 }
 
 /// Render the mask as a translucent blue overlay on top of the composite.
@@ -573,18 +574,17 @@ fn render_mask_overlay(
     let doc_w = engine.doc_width as f32;
     let doc_h = engine.doc_height as f32;
 
-    engine.gl.use_program(Some(&engine.shaders.blend.program));
+    engine.gl.use_program(Some(&engine.shaders.blend_normal.program));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(mask_tex));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
     if let Some(comp_tex) = engine.texture_pool.get(engine.composite_texture) {
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(comp_tex));
     }
-    let shader = &engine.shaders.blend;
+    let shader = &engine.shaders.blend_normal;
     if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
     if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), 1.0); }
-    if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), layer_x, layer_y); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), mask_w as f32, mask_h as f32); }
     if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
@@ -625,18 +625,17 @@ fn render_quick_mask_overlay(engine: &mut EngineInner) {
     let doc_w = engine.doc_width as f32;
     let doc_h = engine.doc_height as f32;
 
-    engine.gl.use_program(Some(&engine.shaders.blend.program));
+    engine.gl.use_program(Some(&engine.shaders.blend_normal.program));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&mask_tex));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE1);
     if let Some(comp_tex) = engine.texture_pool.get(engine.composite_texture) {
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(comp_tex));
     }
-    let shader = &engine.shaders.blend;
+    let shader = &engine.shaders.blend_normal;
     if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
     if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), 1.0); }
-    if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), 0.0, 0.0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), w as f32, h as f32); }
     if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
@@ -678,8 +677,8 @@ fn blend_effect_onto_composite(engine: &mut EngineInner) {
     let doc_w = engine.doc_width as f32;
     let doc_h = engine.doc_height as f32;
 
-    // Use the blend shader: src=effect, dst=composite → render into scratch_b
-    let shader = &engine.shaders.blend;
+    // Use the Normal-mode blend shader: src=effect, dst=composite → render into scratch_b
+    let shader = &engine.shaders.blend_normal;
     engine.gl.use_program(Some(&shader.program));
     engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
     engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&effect_tex));
@@ -688,7 +687,6 @@ fn blend_effect_onto_composite(engine: &mut EngineInner) {
     if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
     if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), 1.0); }
-    if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), 0.0, 0.0); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
     if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
@@ -1326,7 +1324,7 @@ pub fn composite_for_export(engine: &mut EngineInner) -> Result<Vec<u8>, String>
                         apply_adjustments_to_texture(engine, gs_tex, gs_fbo, &adj);
                     }
                     if let Some(gs_gl) = engine.texture_pool.get(gs_tex).cloned() {
-                        blend_onto_composite(engine, &gs_gl, 1.0, 0, 0.0, 0.0, doc_w, doc_h, true, None, None);
+                        blend_onto_composite(engine, &gs_gl, 1.0, 0, 0.0, 0.0, doc_w, doc_h, true, None, None)?;
                     }
                     active_group_id = None;
                     engine.fbo_pool.bind(&engine.gl, engine.composite_fbo);
@@ -1390,9 +1388,9 @@ pub fn composite_for_export(engine: &mut EngineInner) -> Result<Vec<u8>, String>
             if is_group_child {
                 let gs_tex = engine.group_scratch_texture.ok_or("group scratch texture not allocated")?;
                 let gs_fbo = engine.group_scratch_fbo.ok_or("group scratch FBO not allocated")?;
-                blend_onto_target(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo);
+                blend_onto_target(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo)?;
             } else {
-                blend_onto_composite(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+                blend_onto_composite(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)))?;
             }
         }
 
@@ -1453,7 +1451,7 @@ pub fn composite_for_export_u16(engine: &mut EngineInner) -> Result<Vec<u16>, St
                         apply_adjustments_to_texture(engine, gs_tex, gs_fbo, &adj);
                     }
                     if let Some(gs_gl) = engine.texture_pool.get(gs_tex).cloned() {
-                        blend_onto_composite(engine, &gs_gl, 1.0, 0, 0.0, 0.0, doc_w, doc_h, true, None, None);
+                        blend_onto_composite(engine, &gs_gl, 1.0, 0, 0.0, 0.0, doc_w, doc_h, true, None, None)?;
                     }
                     active_group_id = None;
                     engine.fbo_pool.bind(&engine.gl, engine.composite_fbo);
@@ -1517,9 +1515,9 @@ pub fn composite_for_export_u16(engine: &mut EngineInner) -> Result<Vec<u16>, St
             if is_group_child {
                 let gs_tex = engine.group_scratch_texture.ok_or("group scratch texture not allocated")?;
                 let gs_fbo = engine.group_scratch_fbo.ok_or("group scratch FBO not allocated")?;
-                blend_onto_target(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo);
+                blend_onto_target(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)), gs_tex, gs_fbo)?;
             } else {
-                blend_onto_composite(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)));
+                blend_onto_composite(engine, &src_tex, *opacity, *blend_mode, *layer_x, *layer_y, tw, th, false, overlay_desc, mask_arg.as_ref().map(|(t, w, h)| (&**t, *w, *h)))?;
             }
         }
 
@@ -1564,7 +1562,7 @@ pub fn composite_single_layer(engine: &mut EngineInner, layer_id: &str) -> Resul
         // Layer content with color overlay (use Normal blend, not the layer's blend mode)
         let overlay_desc = effects.color_overlay.as_ref().filter(|o| o.enabled);
         if let Some(src_tex) = engine.texture_pool.get(tex_handle).cloned() {
-            blend_onto_composite(engine, &src_tex, opacity, 0, layer_x, layer_y, tw, th, false, overlay_desc, None);
+            blend_onto_composite(engine, &src_tex, opacity, 0, layer_x, layer_y, tw, th, false, overlay_desc, None)?;
         }
 
         // On-top effects

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
@@ -186,12 +186,46 @@ fn preprocess_frag(src: &str) -> String {
     src.replace("//#include hsl", HSL_COMMON)
 }
 
+/// Injects `#define NAME VALUE` lines into a GLSL source. The `#version`
+/// directive must stay on the first line, so the defines are spliced in
+/// immediately after it (or prepended when there is no `#version`).
+fn inject_defines(src: &str, defines: &[(&str, &str)]) -> String {
+    if defines.is_empty() {
+        return src.to_string();
+    }
+    let mut block = String::new();
+    for (name, value) in defines {
+        block.push_str("#define ");
+        block.push_str(name);
+        block.push(' ');
+        block.push_str(value);
+        block.push('\n');
+    }
+    match src.find('\n') {
+        Some(pos) if src.starts_with("#version") => {
+            format!("{}\n{}{}", &src[..pos], block, &src[pos + 1..])
+        }
+        _ => format!("{block}{src}"),
+    }
+}
+
 pub fn compile_program(
     gl: &WebGl2RenderingContext,
     vert_src: &str,
     frag_src: &str,
 ) -> Result<ShaderProgram, String> {
-    let frag_src = preprocess_frag(frag_src);
+    compile_program_with_defines(gl, vert_src, frag_src, &[])
+}
+
+/// Compiles a program with compile-time `#define`s injected into the
+/// fragment source, for building specialized variants of one GLSL file.
+pub fn compile_program_with_defines(
+    gl: &WebGl2RenderingContext,
+    vert_src: &str,
+    frag_src: &str,
+    defines: &[(&str, &str)],
+) -> Result<ShaderProgram, String> {
+    let frag_src = inject_defines(&preprocess_frag(frag_src), defines);
     let vert = compile_shader(gl, vert_src, WebGl2RenderingContext::VERTEX_SHADER)?;
     let frag = compile_shader(gl, &frag_src, WebGl2RenderingContext::FRAGMENT_SHADER)?;
     let program = link_program(gl, &vert, &frag)?;
@@ -383,5 +417,40 @@ impl ShaderPrograms {
             // Text
             text_glyph: compile_program(gl, v, TEXT_GLYPH_FRAG)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inject_defines;
+
+    #[test]
+    fn injects_defines_after_version_directive() {
+        let src = "#version 300 es\nprecision highp float;\nvoid main() {}\n";
+        let out = inject_defines(src, &[("BLEND_MODE", "7")]);
+        assert_eq!(
+            out,
+            "#version 300 es\n#define BLEND_MODE 7\nprecision highp float;\nvoid main() {}\n"
+        );
+    }
+
+    #[test]
+    fn injects_multiple_defines_in_order() {
+        let src = "#version 300 es\nvoid main() {}\n";
+        let out = inject_defines(src, &[("A", "1"), ("B", "2")]);
+        assert_eq!(out, "#version 300 es\n#define A 1\n#define B 2\nvoid main() {}\n");
+    }
+
+    #[test]
+    fn prepends_defines_when_no_version_directive() {
+        let src = "precision highp float;\nvoid main() {}\n";
+        let out = inject_defines(src, &[("BLEND_MODE", "3")]);
+        assert_eq!(out, "#define BLEND_MODE 3\nprecision highp float;\nvoid main() {}\n");
+    }
+
+    #[test]
+    fn empty_defines_returns_source_unchanged() {
+        let src = "#version 300 es\nvoid main() {}\n";
+        assert_eq!(inject_defines(src, &[]), src);
     }
 }

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shader.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlShader, WebGlUniformLocation};
 
 pub const FULLSCREEN_QUAD_VERT: &str = r#"#version 300 es
@@ -237,7 +238,14 @@ pub fn compile_program_with_defines(
 pub struct ShaderPrograms {
     // Core
     pub blit: ShaderProgram,
-    pub blend: ShaderProgram,
+    /// Blend program specialized for Normal mode (BLEND_MODE 0). Compiled at
+    /// startup since nearly every composite pass uses it; the other modes are
+    /// compiled lazily via `blend_for_mode`.
+    pub blend_normal: Rc<ShaderProgram>,
+    /// Lazily compiled blend program variants, keyed by blend mode. Each
+    /// variant is its own `ShaderProgram` with its own uniform-location
+    /// cache — locations must never be shared across program variants.
+    blend_variants: RefCell<HashMap<i32, Rc<ShaderProgram>>>,
     pub composite: ShaderProgram,
     pub final_blit: ShaderProgram,
     pub flip: ShaderProgram,
@@ -324,14 +332,47 @@ pub struct ShaderPrograms {
     pub text_glyph: ShaderProgram,
 }
 
+/// Compiles the blend shader specialized for a single blend mode.
+fn compile_blend_variant(gl: &WebGl2RenderingContext, mode: i32) -> Result<ShaderProgram, String> {
+    compile_program_with_defines(
+        gl,
+        FULLSCREEN_QUAD_VERT,
+        BLEND_FRAG,
+        &[("BLEND_MODE", &mode.to_string())],
+    )
+}
+
 impl ShaderPrograms {
+    /// Returns the blend program specialized for `mode`, compiling and
+    /// caching it on first use. Compiling all variants at startup would
+    /// jank initial load, and most documents only ever use a few modes.
+    /// Unknown modes fall back to Normal, matching the old uniform-driven
+    /// shader's final `return s;` fallback.
+    pub fn blend_for_mode(&self, gl: &WebGl2RenderingContext, mode: i32) -> Result<Rc<ShaderProgram>, String> {
+        let max_mode = lopsy_core::color::BlendMode::ALL.len() as i32 - 1;
+        let mode = if (0..=max_mode).contains(&mode) { mode } else { 0 };
+        if let Some(program) = self.blend_variants.borrow().get(&mode) {
+            return Ok(Rc::clone(program));
+        }
+        let program = Rc::new(compile_blend_variant(gl, mode)?);
+        self.blend_variants.borrow_mut().insert(mode, Rc::clone(&program));
+        Ok(program)
+    }
+
     pub fn compile_all(gl: &WebGl2RenderingContext) -> Result<Self, String> {
         let v = FULLSCREEN_QUAD_VERT;
+
+        // Normal mode is seeded eagerly: it was compiled at startup before
+        // specialization too, so this keeps startup cost unchanged while
+        // letting fixed Normal-mode passes grab it infallibly.
+        let blend_normal = Rc::new(compile_blend_variant(gl, 0)?);
+        let blend_variants = RefCell::new(HashMap::from([(0, Rc::clone(&blend_normal))]));
 
         Ok(Self {
             // Core
             blit: compile_program(gl, v, BLIT_FRAG)?,
-            blend: compile_program(gl, v, BLEND_FRAG)?,
+            blend_normal,
+            blend_variants,
             composite: compile_program(gl, v, COMPOSITE_FRAG)?,
             final_blit: compile_program(gl, v, FINAL_BLIT_FRAG)?,
             flip: compile_program(gl, v, FLIP_FRAG)?,

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/blend.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/blend.glsl
@@ -1,11 +1,17 @@
 #version 300 es
 precision highp float;
 
+// BLEND_MODE is injected as a compile-time #define by shader.rs
+// (compile_program_with_defines) — one program variant per blend mode,
+// so the mode is selected at compile time instead of per pixel.
+#ifndef BLEND_MODE
+#define BLEND_MODE 0
+#endif
+
 in vec2 v_uv;
 uniform sampler2D u_srcTex;
 uniform sampler2D u_dstTex;
 uniform float u_opacity;
-uniform int u_blendMode;
 uniform vec2 u_srcOffset;  // layer position in document pixels
 uniform vec2 u_srcSize;    // layer texture size in pixels
 uniform vec2 u_docSize;    // document size in pixels
@@ -42,65 +48,72 @@ vec3 setLum(vec3 c, float l) {
 float sat(vec3 c) { return max(max(c.r, c.g), c.b) - min(min(c.r, c.g), c.b); }
 
 vec3 blendMode(vec3 s, vec3 d) {
-    if (u_blendMode == 0) return s; // Normal
-    if (u_blendMode == 1) return s * d; // Multiply
-    if (u_blendMode == 2) return s + d - s * d; // Screen
-    if (u_blendMode == 3) { // Overlay
-        return vec3(
-            d.r < 0.5 ? 2.0*s.r*d.r : 1.0-2.0*(1.0-s.r)*(1.0-d.r),
-            d.g < 0.5 ? 2.0*s.g*d.g : 1.0-2.0*(1.0-s.g)*(1.0-d.g),
-            d.b < 0.5 ? 2.0*s.b*d.b : 1.0-2.0*(1.0-s.b)*(1.0-d.b)
-        );
-    }
-    if (u_blendMode == 4) return min(s, d); // Darken
-    if (u_blendMode == 5) return max(s, d); // Lighten
-    if (u_blendMode == 6) { // ColorDodge
-        return vec3(
-            s.r >= 1.0 ? 1.0 : min(1.0, d.r / (1.0 - s.r)),
-            s.g >= 1.0 ? 1.0 : min(1.0, d.g / (1.0 - s.g)),
-            s.b >= 1.0 ? 1.0 : min(1.0, d.b / (1.0 - s.b))
-        );
-    }
-    if (u_blendMode == 7) { // ColorBurn
-        return vec3(
-            s.r <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.r) / s.r),
-            s.g <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.g) / s.g),
-            s.b <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.b) / s.b)
-        );
-    }
-    if (u_blendMode == 8) { // HardLight
-        return vec3(
-            s.r < 0.5 ? 2.0*s.r*d.r : 1.0-2.0*(1.0-s.r)*(1.0-d.r),
-            s.g < 0.5 ? 2.0*s.g*d.g : 1.0-2.0*(1.0-s.g)*(1.0-d.g),
-            s.b < 0.5 ? 2.0*s.b*d.b : 1.0-2.0*(1.0-s.b)*(1.0-d.b)
-        );
-    }
-    if (u_blendMode == 9) { // SoftLight (W3C)
-        vec3 dd = mix(sqrt(d), ((16.0*d - 12.0)*d + 4.0)*d, step(d, vec3(0.25)));
-        return mix(
-            d - (1.0 - 2.0*s) * d * (1.0 - d),
-            d + (2.0*s - 1.0) * (dd - d),
-            step(vec3(0.5), s)
-        );
-    }
-    if (u_blendMode == 10) return abs(s - d); // Difference
-    if (u_blendMode == 11) return s + d - 2.0*s*d; // Exclusion
-    if (u_blendMode == 12) { // Hue
-        vec3 shsl = rgb2hsl(s);
-        vec3 dhsl = rgb2hsl(d);
-        return setLum(hsl2rgb(vec3(shsl.x, dhsl.y, 0.5)), lum(d));
-    }
-    if (u_blendMode == 13) { // Saturation
-        float ss = sat(s);
-        return setLum(hsl2rgb(vec3(rgb2hsl(d).x, ss > 0.0 ? ss : rgb2hsl(d).y, 0.5)), lum(d));
-    }
-    if (u_blendMode == 14) { // Color
-        return setLum(s, lum(d));
-    }
-    if (u_blendMode == 15) { // Luminosity
-        return setLum(d, lum(s));
-    }
-    return s;
+#if BLEND_MODE == 1
+    return s * d; // Multiply
+#elif BLEND_MODE == 2
+    return s + d - s * d; // Screen
+#elif BLEND_MODE == 3
+    // Overlay
+    return vec3(
+        d.r < 0.5 ? 2.0*s.r*d.r : 1.0-2.0*(1.0-s.r)*(1.0-d.r),
+        d.g < 0.5 ? 2.0*s.g*d.g : 1.0-2.0*(1.0-s.g)*(1.0-d.g),
+        d.b < 0.5 ? 2.0*s.b*d.b : 1.0-2.0*(1.0-s.b)*(1.0-d.b)
+    );
+#elif BLEND_MODE == 4
+    return min(s, d); // Darken
+#elif BLEND_MODE == 5
+    return max(s, d); // Lighten
+#elif BLEND_MODE == 6
+    // ColorDodge
+    return vec3(
+        s.r >= 1.0 ? 1.0 : min(1.0, d.r / (1.0 - s.r)),
+        s.g >= 1.0 ? 1.0 : min(1.0, d.g / (1.0 - s.g)),
+        s.b >= 1.0 ? 1.0 : min(1.0, d.b / (1.0 - s.b))
+    );
+#elif BLEND_MODE == 7
+    // ColorBurn
+    return vec3(
+        s.r <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.r) / s.r),
+        s.g <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.g) / s.g),
+        s.b <= 0.0 ? 0.0 : max(0.0, 1.0 - (1.0 - d.b) / s.b)
+    );
+#elif BLEND_MODE == 8
+    // HardLight
+    return vec3(
+        s.r < 0.5 ? 2.0*s.r*d.r : 1.0-2.0*(1.0-s.r)*(1.0-d.r),
+        s.g < 0.5 ? 2.0*s.g*d.g : 1.0-2.0*(1.0-s.g)*(1.0-d.g),
+        s.b < 0.5 ? 2.0*s.b*d.b : 1.0-2.0*(1.0-s.b)*(1.0-d.b)
+    );
+#elif BLEND_MODE == 9
+    // SoftLight (W3C)
+    vec3 dd = mix(sqrt(d), ((16.0*d - 12.0)*d + 4.0)*d, step(d, vec3(0.25)));
+    return mix(
+        d - (1.0 - 2.0*s) * d * (1.0 - d),
+        d + (2.0*s - 1.0) * (dd - d),
+        step(vec3(0.5), s)
+    );
+#elif BLEND_MODE == 10
+    return abs(s - d); // Difference
+#elif BLEND_MODE == 11
+    return s + d - 2.0*s*d; // Exclusion
+#elif BLEND_MODE == 12
+    // Hue
+    vec3 shsl = rgb2hsl(s);
+    vec3 dhsl = rgb2hsl(d);
+    return setLum(hsl2rgb(vec3(shsl.x, dhsl.y, 0.5)), lum(d));
+#elif BLEND_MODE == 13
+    // Saturation
+    float ss = sat(s);
+    return setLum(hsl2rgb(vec3(rgb2hsl(d).x, ss > 0.0 ? ss : rgb2hsl(d).y, 0.5)), lum(d));
+#elif BLEND_MODE == 14
+    // Color
+    return setLum(s, lum(d));
+#elif BLEND_MODE == 15
+    // Luminosity
+    return setLum(d, lum(s));
+#else
+    return s; // Normal (0) — also the fallback the old uniform branch had
+#endif
 }
 
 void main() {

--- a/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
+++ b/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
@@ -214,7 +214,7 @@ pub fn merge_layers(
     engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_a);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);
     {
-        let shader = &engine.shaders.blend;
+        let shader = &engine.shaders.blend_normal;
         engine.gl.use_program(Some(&shader.program));
         engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&bottom_tex));
@@ -224,7 +224,6 @@ pub fn merge_layers(
         if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
         if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), bottom_desc.opacity); }
-        if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") {
             engine.gl.uniform2f(Some(&loc), bottom_desc.x as f32, bottom_desc.y as f32);
         }
@@ -245,7 +244,7 @@ pub fn merge_layers(
     engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_b);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);
     {
-        let shader = &engine.shaders.blend;
+        let shader = engine.shaders.blend_for_mode(&engine.gl, top_desc.blend_mode as i32)?;
         engine.gl.use_program(Some(&shader.program));
         engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&top_tex));
@@ -255,7 +254,6 @@ pub fn merge_layers(
         if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
         if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), top_desc.opacity); }
-        if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), top_desc.blend_mode as i32); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") {
             engine.gl.uniform2f(Some(&loc), top_desc.x as f32, top_desc.y as f32);
         }
@@ -1105,7 +1103,7 @@ pub fn composite_float(
     // correctly without the UV-scale mismatch that doc-sized scratch textures cause.
     engine.gl.disable(WebGl2RenderingContext::BLEND);
     engine.render_to_texture(&layer_tex, fw as i32, fh as i32, |engine| {
-        let shader = &engine.shaders.blend;
+        let shader = &engine.shaders.blend_normal;
         engine.gl.use_program(Some(&shader.program));
         engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&float_tex));
@@ -1115,7 +1113,6 @@ pub fn composite_float(
         if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
         if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), 1.0); }
-        if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), dx as f32, dy as f32); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), fw as f32, fh as f32); }
         if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), fw as f32, fh as f32); }
@@ -1409,7 +1406,7 @@ fn composite_float_transformed(
     // Step 2: Blend tmp (transformed float, fw×fh) onto base → layer texture.
     // Both tmp and base_tex are fw×fh, so v_uv correctly addresses them.
     engine.render_to_texture(&layer_tex, fw as i32, fh as i32, |engine| {
-        let shader = &engine.shaders.blend;
+        let shader = &engine.shaders.blend_normal;
         engine.gl.use_program(Some(&shader.program));
         engine.gl.active_texture(WebGl2RenderingContext::TEXTURE0);
         engine.gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&tmp_tex));
@@ -1419,7 +1416,6 @@ fn composite_float_transformed(
         if let Some(loc) = shader.location(&engine.gl, "u_srcTex") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_dstTex") { engine.gl.uniform1i(Some(&loc), 1); }
         if let Some(loc) = shader.location(&engine.gl, "u_opacity") { engine.gl.uniform1f(Some(&loc), 1.0); }
-        if let Some(loc) = shader.location(&engine.gl, "u_blendMode") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcOffset") { engine.gl.uniform2f(Some(&loc), 0.0, 0.0); }
         if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), fw as f32, fh as f32); }
         if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), fw as f32, fh as f32); }


### PR DESCRIPTION
## Motivation

`blend.glsl` selected the blend mode with a 16-way `if (u_blendMode == N)` cascade inside the fragment shader, so **every composited pixel paid the full per-pixel branch cost** — on every layer, every frame. On a 4000x4000 canvas with 20 layers that is hundreds of millions of avoidable branch evaluations per frame.

## Approach

- **Compile-time `#define` injection** (`feat(gpu)` commit): `inject_defines` + `compile_program_with_defines` in `gpu/shader.rs` splice `#define NAME VALUE` lines immediately after the `#version` directive, so one GLSL source can be compiled into specialized program variants. Covered by unit tests.
- **Lazy per-mode program cache** (`perf(compositor)` commit): `blendMode()` in `blend.glsl` now selects the mode with preprocessor `#if BLEND_MODE == N` branches; the `u_blendMode` uniform is gone. `ShaderPrograms::blend_for_mode(gl, mode)` compiles a variant on first use and caches it in a `RefCell<HashMap<i32, Rc<ShaderProgram>>>` — compiling all 16 at startup would jank initial load, and most documents only use a few modes. The Normal variant is seeded eagerly (it was compiled at startup before, so startup cost is unchanged) and exposed as `blend_normal` for the fixed Normal-mode passes (mask/quick-mask overlays, effect compositing, float compositing, merge bottom layer). Each variant is its own `ShaderProgram` with its own uniform-location cache, so locations are never shared across programs. Out-of-range modes clamp to Normal, matching the old shader's final `return s;` fallback.

`main()` in `blend.glsl` — mask sampling, mask-overlay mode, un-premultiply, color overlay, opacity, and the Porter-Duff composite — is unchanged, so every variant preserves masking, opacity, premultiplication, and clipping/group behavior.

## Verification

In `engine-rs/`:

- `cargo fmt --check` — **fails, pre-existing**: 1191 diff hunks on `main` itself (rustfmt is not enforced; CI has no fmt step). The new code follows the surrounding files' prevailing style.
- `cargo clippy --workspace --all-targets` — **fails, pre-existing**: deny-level `clippy::never_loop` in `lopsy-core/src/dng/ljpeg.rs` (untouched by this branch, last modified in #172; fails identically on `main`). Scoped run on the changed crate, `cargo clippy -p lopsy-wasm --all-targets --no-deps`, **passes** with zero warnings in the new/modified code (remaining warnings are pre-existing `too_many_arguments` etc.).
- `cargo test --workspace` — **passes** (263 tests, including the 4 new `inject_defines` tests).

Repo root:

- `npm run wasm:build` — **passes**.
- `npm run typecheck` — **passes** (0 errors).
- `npm run lint` — **passes** (0 errors; 523 pre-existing warnings).
- `npm run test` — **passes** (103 files, 1025 tests).

E2E (Playwright) blend/compositing batch run previously in this worktree — **passed** (`test-results/.last-run.json`: status `passed`, no failed tests), covering `group-mask.spec.ts`, `pass-through-blend.spec.ts`, and `quick-mask.spec.ts` (group mask apply, pass-through vs normal group blending with adjustments and opacity, quick-mask paint/enter/exit and selection round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)