### PR TITLE
test: add unit tests for untested tool interaction handlers

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -59,13 +59,20 @@ const ALLOWLIST = {
   'src/test-setup.ts': 1,
   'src/test/canvas-mock.ts': 3,
   'src/tools/brush/brush-from-selection.test.ts': 3,
+  'src/tools/crop/perspective-crop-interaction.test.ts': 1,
   'src/tools/crop/perspective-crop.test.ts': 3,             // see #441 (delete with prod file)
+  'src/tools/fill/fill-interaction.test.ts': 3,
   'src/tools/gradient/gradient-interaction.test.ts': 2,
+  'src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts': 4,
   'src/tools/magnetic-lasso/magnetic-lasso.test.ts': 2,
+  'src/tools/marquee/marquee-strategy.test.ts': 8,
   'src/tools/move/move.test.ts': 1,
   'src/tools/path/boolean-ops.test.ts': 11,
+  'src/tools/quick-select/quick-select-interaction.test.ts': 3,
   'src/tools/quick-select/quick-select.test.ts': 3,
+  'src/tools/text/text-interaction.test.ts': 5,
   'src/tools/transform/transform.test.ts': 2,
+  'src/tools/wand/wand-strategy.test.ts': 4,
   'src/utils/bmp-encoder.test.ts': 2,
 
   // ──────────────────────────────────────────────────────────────────────

--- a/src/tools/crop/crop-interaction.test.ts
+++ b/src/tools/crop/crop-interaction.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  uploadLayerPixels: vi.fn(),
+}));
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => null,
+}));
+
+vi.mock('../../engine-wasm/gpu-pixel-access', () => ({
+  readLayerAsImageData: vi.fn(),
+}));
+
+interface CropRect { x: number; y: number; width: number; height: number }
+interface Quad {
+  topLeft: { x: number; y: number };
+  topRight: { x: number; y: number };
+  bottomRight: { x: number; y: number };
+  bottomLeft: { x: number; y: number };
+}
+
+const uiState = {
+  cropRect: null as CropRect | null,
+  setCropRect: vi.fn((r: CropRect | null) => { uiState.cropRect = r; }),
+  perspectiveCropQuad: null as Quad | null,
+  setPerspectiveCropQuad: vi.fn((q: Quad | null) => { uiState.perspectiveCropQuad = q; }),
+  perspectiveCropDragging: null as number | null,
+  setPerspectiveCropDragging: vi.fn((idx: number | null) => { uiState.perspectiveCropDragging = idx; }),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const editorState = {
+  document: { width: 200, height: 100, layers: [] as unknown[] },
+  viewport: { zoom: 1 },
+  cropCanvas: vi.fn(),
+  notifyRender: vi.fn(),
+  pushHistory: vi.fn(),
+  fitToView: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState, setState: vi.fn() },
+}));
+
+const ts = {
+  cropMode: 'rect' as 'rect' | 'perspective',
+  aspectRatioLocked: false,
+  aspectRatioW: 1,
+  aspectRatioH: 1,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleCropDown, handleCropMove, handleCropUp } from './crop-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 20, y: 30 },
+    layerPos: { x: 20, y: 30 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 20, y: 30 },
+    layerId: 'layer-1',
+    tool: 'crop',
+    startPoint: { x: 20, y: 30 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  uiState.cropRect = null;
+  uiState.setCropRect.mockClear();
+  uiState.perspectiveCropQuad = null;
+  uiState.setPerspectiveCropQuad.mockClear();
+  uiState.perspectiveCropDragging = null;
+  uiState.setPerspectiveCropDragging.mockClear();
+  editorState.cropCanvas.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.cropMode = 'rect';
+  ts.aspectRatioLocked = false;
+});
+
+describe('crop down', () => {
+  it('clears any previous crop rect and anchors the drag at the click point', () => {
+    const state = handleCropDown(makeCtx({ canvasPos: { x: 20, y: 30 } }));
+    expect(uiState.setCropRect).toHaveBeenCalledWith(null);
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'crop',
+      startPoint: { x: 20, y: 30 },
+      layerStartX: 0,
+      layerStartY: 0,
+    });
+  });
+
+  it('delegates to the perspective handler in perspective mode', () => {
+    ts.cropMode = 'perspective';
+    const state = handleCropDown(makeCtx());
+    // The perspective handler seeds the quad from the full document.
+    expect(uiState.setPerspectiveCropQuad).toHaveBeenCalledWith({
+      topLeft: { x: 0, y: 0 },
+      topRight: { x: 200, y: 0 },
+      bottomRight: { x: 200, y: 100 },
+      bottomLeft: { x: 0, y: 100 },
+    });
+    expect(uiState.setCropRect).not.toHaveBeenCalled();
+    expect(state.tool).toBe('crop');
+  });
+});
+
+describe('crop move', () => {
+  it('sets the crop rect from start to cursor', () => {
+    handleCropMove(makeState({ startPoint: { x: 20, y: 30 } }), { x: 60, y: 70 });
+    expect(uiState.setCropRect).toHaveBeenCalledWith({ x: 20, y: 30, width: 40, height: 40 });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('normalizes a reversed drag', () => {
+    handleCropMove(makeState({ startPoint: { x: 60, y: 70 } }), { x: 20, y: 30 });
+    expect(uiState.setCropRect).toHaveBeenCalledWith({ x: 20, y: 30, width: 40, height: 40 });
+  });
+
+  it('clamps the rect to the document bounds', () => {
+    handleCropMove(makeState({ startPoint: { x: 150, y: 50 } }), { x: 500, y: 500 });
+    expect(uiState.setCropRect).toHaveBeenCalledWith({ x: 150, y: 50, width: 50, height: 50 });
+  });
+
+  it('clamps negative cursor coordinates to the canvas origin', () => {
+    handleCropMove(makeState({ startPoint: { x: 30, y: 30 } }), { x: -50, y: -50 });
+    expect(uiState.setCropRect).toHaveBeenCalledWith({ x: 0, y: 0, width: 30, height: 30 });
+  });
+
+  it('applies a locked aspect ratio (wide ratio shrinks the height)', () => {
+    ts.aspectRatioLocked = true;
+    ts.aspectRatioW = 2;
+    ts.aspectRatioH = 1;
+    handleCropMove(makeState({ startPoint: { x: 0, y: 0 } }), { x: 100, y: 100 });
+    const calls = uiState.setCropRect.mock.calls;
+    const rect = calls[calls.length - 1]![0] as CropRect;
+    expect(rect.width / rect.height).toBeCloseTo(2);
+    expect(rect.width).toBe(100);
+    expect(rect.height).toBe(50);
+  });
+
+  it('does not set a rect for a zero-size drag', () => {
+    handleCropMove(makeState({ startPoint: { x: 20, y: 30 } }), { x: 20, y: 30 });
+    expect(uiState.setCropRect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a start point', () => {
+    handleCropMove(makeState({ startPoint: null }), { x: 60, y: 70 });
+    expect(uiState.setCropRect).not.toHaveBeenCalled();
+  });
+
+  it('routes to the perspective handler in perspective mode', () => {
+    ts.cropMode = 'perspective';
+    uiState.perspectiveCropQuad = {
+      topLeft: { x: 0, y: 0 },
+      topRight: { x: 200, y: 0 },
+      bottomRight: { x: 200, y: 100 },
+      bottomLeft: { x: 0, y: 100 },
+    };
+    uiState.perspectiveCropDragging = 1;
+    handleCropMove(makeState(), { x: 150, y: 20 });
+    expect(uiState.setCropRect).not.toHaveBeenCalled();
+    expect(uiState.setPerspectiveCropQuad).toHaveBeenCalledWith(
+      expect.objectContaining({ topRight: { x: 150, y: 20 } }),
+    );
+  });
+});
+
+describe('crop up', () => {
+  it('applies the crop and clears the rect', () => {
+    uiState.cropRect = { x: 10, y: 10, width: 50, height: 40 };
+    handleCropUp(makeState());
+    expect(editorState.cropCanvas).toHaveBeenCalledWith({ x: 10, y: 10, width: 50, height: 40 });
+    expect(uiState.setCropRect).toHaveBeenLastCalledWith(null);
+  });
+
+  it('discards a degenerate rect without cropping', () => {
+    uiState.cropRect = { x: 10, y: 10, width: 1, height: 1 };
+    handleCropUp(makeState());
+    expect(editorState.cropCanvas).not.toHaveBeenCalled();
+    expect(uiState.setCropRect).toHaveBeenLastCalledWith(null);
+  });
+
+  it('ignores up events from other tools', () => {
+    uiState.cropRect = { x: 10, y: 10, width: 50, height: 40 };
+    handleCropUp(makeState({ tool: 'brush' }));
+    expect(editorState.cropCanvas).not.toHaveBeenCalled();
+    expect(uiState.setCropRect).not.toHaveBeenCalled();
+  });
+
+  it('releases the perspective drag in perspective mode', () => {
+    ts.cropMode = 'perspective';
+    uiState.cropRect = { x: 10, y: 10, width: 50, height: 40 };
+    handleCropUp(makeState());
+    expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(null);
+    expect(editorState.cropCanvas).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/crop/perspective-crop-interaction.test.ts
+++ b/src/tools/crop/perspective-crop-interaction.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const uploadLayerPixels = vi.fn();
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  uploadLayerPixels: (...args: unknown[]) => uploadLayerPixels(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const readLayerAsImageData = vi.fn();
+vi.mock('../../engine-wasm/gpu-pixel-access', () => ({
+  readLayerAsImageData: (...args: unknown[]) => readLayerAsImageData(...args),
+}));
+
+import type { Quad } from './perspective-crop';
+
+const uiState = {
+  perspectiveCropQuad: null as Quad | null,
+  setPerspectiveCropQuad: vi.fn((q: Quad | null) => { uiState.perspectiveCropQuad = q; }),
+  perspectiveCropDragging: null as number | null,
+  setPerspectiveCropDragging: vi.fn((idx: number | null) => { uiState.perspectiveCropDragging = idx; }),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+interface MockLayer {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+const editorState = {
+  document: { width: 200, height: 100, layers: [] as MockLayer[] },
+  viewport: { zoom: 1 },
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+  fitToView: vi.fn(),
+  renderVersion: 0,
+};
+const setState = vi.fn((updater: unknown) => {
+  const update = typeof updater === 'function'
+    ? (updater as (s: typeof editorState) => Partial<typeof editorState>)(editorState)
+    : updater as Partial<typeof editorState>;
+  Object.assign(editorState, update);
+});
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: {
+    getState: () => editorState,
+    setState: (updater: unknown) => setState(updater),
+  },
+}));
+
+import {
+  handlePerspectiveCropDown,
+  handlePerspectiveCropMove,
+  handlePerspectiveCropUp,
+  commitPerspectiveCrop,
+} from './perspective-crop-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function fullDocQuad(): Quad {
+  return {
+    topLeft: { x: 0, y: 0 },
+    topRight: { x: 200, y: 0 },
+    bottomRight: { x: 200, y: 100 },
+    bottomLeft: { x: 0, y: 100 },
+  };
+}
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 50, y: 50 },
+    layerPos: { x: 50, y: 50 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 50, y: 50 },
+    layerId: 'layer-1',
+    tool: 'crop',
+    startPoint: { x: 50, y: 50 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  uploadLayerPixels.mockClear();
+  readLayerAsImageData.mockReset();
+  uiState.perspectiveCropQuad = null;
+  uiState.setPerspectiveCropQuad.mockClear();
+  uiState.perspectiveCropDragging = null;
+  uiState.setPerspectiveCropDragging.mockClear();
+  editorState.document = { width: 200, height: 100, layers: [] };
+  editorState.viewport = { zoom: 1 };
+  editorState.pushHistory.mockClear();
+  editorState.fitToView.mockClear();
+  setState.mockClear();
+});
+
+describe('perspective crop down', () => {
+  it('seeds the quad from the full document on first use', () => {
+    const state = handlePerspectiveCropDown(makeCtx());
+    expect(uiState.setPerspectiveCropQuad).toHaveBeenCalledWith(fullDocQuad());
+    expect(state).toMatchObject({ drawing: true, tool: 'crop', startPoint: { x: 50, y: 50 } });
+  });
+
+  it('keeps an existing quad instead of reseeding', () => {
+    const custom: Quad = {
+      topLeft: { x: 10, y: 10 },
+      topRight: { x: 90, y: 10 },
+      bottomRight: { x: 90, y: 60 },
+      bottomLeft: { x: 10, y: 60 },
+    };
+    uiState.perspectiveCropQuad = custom;
+    handlePerspectiveCropDown(makeCtx());
+    expect(uiState.setPerspectiveCropQuad).not.toHaveBeenCalled();
+    expect(uiState.perspectiveCropQuad).toEqual(custom);
+  });
+
+  it('grabs a corner handle when clicking within the hit radius', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    handlePerspectiveCropDown(makeCtx({ canvasPos: { x: 195, y: 4 } }));
+    expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(1); // topRight
+  });
+
+  it('does not grab anything when clicking far from all corners', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    handlePerspectiveCropDown(makeCtx({ canvasPos: { x: 100, y: 50 } }));
+    expect(uiState.setPerspectiveCropDragging).not.toHaveBeenCalled();
+  });
+
+  it('scales the hit radius with zoom (zoomed in shrinks the doc-space radius)', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    editorState.viewport = { zoom: 4 }; // radius becomes 2 doc px
+    handlePerspectiveCropDown(makeCtx({ canvasPos: { x: 195, y: 4 } }));
+    expect(uiState.setPerspectiveCropDragging).not.toHaveBeenCalled();
+
+    editorState.viewport = { zoom: 0.5 }; // radius becomes 16 doc px
+    handlePerspectiveCropDown(makeCtx({ canvasPos: { x: 188, y: 10 } }));
+    expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('perspective crop move', () => {
+  it('moves only the dragged corner to the cursor', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    uiState.perspectiveCropDragging = 2; // bottomRight
+    handlePerspectiveCropMove(makeState(), { x: 150, y: 80 });
+    expect(uiState.perspectiveCropQuad).toEqual({
+      ...fullDocQuad(),
+      bottomRight: { x: 150, y: 80 },
+    });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('allows dragging a corner to negative coordinates', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    uiState.perspectiveCropDragging = 0; // topLeft
+    handlePerspectiveCropMove(makeState(), { x: -20, y: -10 });
+    expect(uiState.perspectiveCropQuad!.topLeft).toEqual({ x: -20, y: -10 });
+  });
+
+  it('does nothing when no corner is being dragged', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    handlePerspectiveCropMove(makeState(), { x: 150, y: 80 });
+    expect(uiState.setPerspectiveCropQuad).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the gesture is not drawing', () => {
+    uiState.perspectiveCropQuad = fullDocQuad();
+    uiState.perspectiveCropDragging = 1;
+    handlePerspectiveCropMove(makeState({ drawing: false }), { x: 150, y: 80 });
+    expect(uiState.setPerspectiveCropQuad).not.toHaveBeenCalled();
+  });
+});
+
+describe('perspective crop up', () => {
+  it('releases the dragged corner', () => {
+    uiState.perspectiveCropDragging = 3;
+    handlePerspectiveCropUp(makeState());
+    expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('commitPerspectiveCrop', () => {
+  function axisAlignedQuad(): Quad {
+    return {
+      topLeft: { x: 20, y: 10 },
+      topRight: { x: 120, y: 10 },
+      bottomRight: { x: 120, y: 60 },
+      bottomLeft: { x: 20, y: 60 },
+    };
+  }
+
+  function grayImage(w: number, h: number): ImageData {
+    const img = new ImageData(w, h);
+    img.data.fill(128);
+    return img;
+  }
+
+  it('does nothing without a quad', () => {
+    commitPerspectiveCrop();
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an engine', () => {
+    uiState.perspectiveCropQuad = axisAlignedQuad();
+    engine = null;
+    commitPerspectiveCrop();
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+  });
+
+  it('warps raster layers, resizes the document, and resets the quad', () => {
+    uiState.perspectiveCropQuad = axisAlignedQuad();
+    editorState.document.layers = [
+      { id: 'layer-1', type: 'raster', x: 0, y: 0, width: 200, height: 100 },
+      { id: 'text-1', type: 'text', x: 5, y: 5 },
+    ];
+    readLayerAsImageData.mockReturnValue(grayImage(200, 100));
+
+    commitPerspectiveCrop();
+
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Perspective Crop');
+    // Only the raster layer is read back and re-uploaded.
+    expect(readLayerAsImageData).toHaveBeenCalledTimes(1);
+    expect(readLayerAsImageData).toHaveBeenCalledWith('layer-1');
+    expect(uploadLayerPixels).toHaveBeenCalledTimes(1);
+    const up = uploadLayerPixels.mock.calls[0]!;
+    // (engine, layerId, bytes, width, height, x, y) — output rect is 100x50 at origin
+    expect(up[1]).toBe('layer-1');
+    expect(up[3]).toBe(100);
+    expect(up[4]).toBe(50);
+    expect(up[5]).toBe(0);
+    expect(up[6]).toBe(0);
+    // An interior sample of the axis-aligned warp preserves the source color.
+    const bytes = up[2] as Uint8Array;
+    const center = (25 * 100 + 50) * 4;
+    expect(bytes[center]).toBe(128);
+
+    // Document resized to the inferred output size.
+    expect(editorState.document.width).toBe(100);
+    expect(editorState.document.height).toBe(50);
+    const raster = editorState.document.layers.find((l) => l.id === 'layer-1')!;
+    expect(raster).toMatchObject({ x: 0, y: 0, width: 100, height: 50 });
+    // Non-raster layer untouched.
+    expect(editorState.document.layers.find((l) => l.id === 'text-1')).toMatchObject({ x: 5, y: 5 });
+
+    expect(editorState.fitToView).toHaveBeenCalledTimes(1);
+    expect(uiState.setPerspectiveCropQuad).toHaveBeenLastCalledWith(null);
+    expect(uiState.setPerspectiveCropDragging).toHaveBeenLastCalledWith(null);
+  });
+
+  it('translates the quad into layer-local space for offset layers', () => {
+    // Layer shifted by (20, 10): the same quad now starts at the layer origin,
+    // so the warped output samples the layer's own top-left pixel.
+    uiState.perspectiveCropQuad = axisAlignedQuad();
+    editorState.document.layers = [
+      { id: 'layer-1', type: 'raster', x: 20, y: 10, width: 100, height: 50 },
+    ];
+    const img = grayImage(100, 50);
+    // Mark the layer-local origin pixel red.
+    img.data[0] = 255;
+    img.data[1] = 0;
+    img.data[2] = 0;
+    img.data[3] = 255;
+    readLayerAsImageData.mockReturnValue(img);
+
+    commitPerspectiveCrop();
+
+    const bytes = uploadLayerPixels.mock.calls[0]![2] as Uint8Array;
+    // Output pixel (0,0) maps to layer-local (0,0) — the red marker.
+    expect(bytes[0]).toBe(255);
+    expect(bytes[1]).toBe(0);
+  });
+
+  it('skips raster layers whose pixels cannot be read', () => {
+    uiState.perspectiveCropQuad = axisAlignedQuad();
+    editorState.document.layers = [
+      { id: 'layer-1', type: 'raster', x: 0, y: 0, width: 200, height: 100 },
+    ];
+    readLayerAsImageData.mockReturnValue(null);
+    commitPerspectiveCrop();
+    expect(uploadLayerPixels).not.toHaveBeenCalled();
+    // Document still resizes.
+    expect(editorState.document.width).toBe(100);
+    // Layer keeps its original geometry.
+    expect(editorState.document.layers[0]).toMatchObject({ x: 0, y: 0, width: 200, height: 100 });
+  });
+});

--- a/src/tools/dodge/dodge-interaction.test.ts
+++ b/src/tools/dodge/dodge-interaction.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const beginDodgeBurnStroke = vi.fn();
+const applyDodgeBurnDabBatch = vi.fn();
+const endDodgeBurnStroke = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  beginDodgeBurnStroke: (...args: unknown[]) => beginDodgeBurnStroke(...args),
+  applyDodgeBurnDabBatch: (...args: unknown[]) => applyDodgeBurnDabBatch(...args),
+  endDodgeBurnStroke: (...args: unknown[]) => endDodgeBurnStroke(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const setPendingDodgeStroke = vi.fn();
+const clearPendingDodgeStroke = vi.fn();
+vi.mock('../../app/interactions/pending-stroke', () => ({
+  setPendingDodgeStroke: (...args: unknown[]) => setPendingDodgeStroke(...args),
+  clearPendingDodgeStroke: (...args: unknown[]) => clearPendingDodgeStroke(...args),
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  dodgeMode: 'dodge' as 'dodge' | 'burn',
+  dodgeExposure: 50,
+  brushSize: 20,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleDodgeDown, handleDodgeMove, handleDodgeUp } from './dodge-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 10, y: 10 },
+    layerPos: { x: 10, y: 10 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 10, y: 10 },
+    layerId: 'layer-1',
+    tool: 'dodge',
+    startPoint: null,
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  beginDodgeBurnStroke.mockClear();
+  applyDodgeBurnDabBatch.mockClear();
+  endDodgeBurnStroke.mockClear();
+  setPendingDodgeStroke.mockClear();
+  clearPendingDodgeStroke.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.dodgeMode = 'dodge';
+  ts.dodgeExposure = 50;
+  ts.brushSize = 20;
+});
+
+describe('dodge down', () => {
+  it('begins a dodge stroke and dabs once at the layer point', () => {
+    const state = handleDodgeDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Dodge');
+    expect(beginDodgeBurnStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 0);
+    expect(setPendingDodgeStroke).toHaveBeenCalledWith('layer-1');
+    const [, , pts, size, hardness, exposure] = applyDodgeBurnDabBatch.mock.calls[0]! as
+      [unknown, string, Float64Array, number, number, number];
+    expect(Array.from(pts)).toEqual([10, 10]);
+    expect(size).toBe(20);
+    expect(hardness).toBe(0.5);
+    expect(exposure).toBeCloseTo(0.5);
+    expect(state).toMatchObject({ drawing: true, tool: 'dodge', lastPoint: { x: 10, y: 10 } });
+  });
+
+  it('burn mode uses mode 1 and the Burn history label', () => {
+    ts.dodgeMode = 'burn';
+    handleDodgeDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Burn');
+    expect(beginDodgeBurnStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 1);
+  });
+
+  it('shift-click connects from the last paint point on the same layer', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 20, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'layer-1' } },
+    });
+    handleDodgeDown(ctx);
+    const pts = applyDodgeBurnDabBatch.mock.calls[0]![2] as Float64Array;
+    // spacing = 20 * 0.25 = 5 over 20px => dabs at x = 5, 10, 15, 20
+    expect(Array.from(pts)).toEqual([5, 0, 10, 0, 15, 0, 20, 0]);
+  });
+
+  it('shift-click from another layer dabs only at the click point', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 20, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'other' } },
+    });
+    handleDodgeDown(ctx);
+    const pts = applyDodgeBurnDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([20, 0]);
+  });
+
+  it('returns a state without touching the GPU when no engine exists', () => {
+    engine = null;
+    const state = handleDodgeDown(makeCtx());
+    expect(state.tool).toBe('dodge');
+    expect(beginDodgeBurnStroke).not.toHaveBeenCalled();
+    expect(applyDodgeBurnDabBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('dodge move', () => {
+  it('interpolates dabs at quarter-size spacing and advances lastPoint', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleDodgeMove(state, { x: 10, y: 0 });
+    const pts = applyDodgeBurnDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([5, 0, 10, 0]);
+    expect(state.lastPoint).toEqual({ x: 10, y: 0 });
+  });
+
+  it('passes the current exposure setting on every move', () => {
+    ts.dodgeExposure = 80;
+    handleDodgeMove(makeState({ lastPoint: { x: 0, y: 0 } }), { x: 10, y: 0 });
+    expect(applyDodgeBurnDabBatch.mock.calls[0]![5]).toBeCloseTo(0.8);
+  });
+
+  it('does nothing without a lastPoint', () => {
+    handleDodgeMove(makeState({ lastPoint: null }), { x: 10, y: 0 });
+    expect(applyDodgeBurnDabBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('dodge up', () => {
+  it('ends the stroke and clears the pending registry', () => {
+    handleDodgeUp(makeState());
+    expect(endDodgeBurnStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+    expect(clearPendingDodgeStroke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing without a layer id', () => {
+    handleDodgeUp(makeState({ layerId: null }));
+    expect(endDodgeBurnStroke).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an engine', () => {
+    engine = null;
+    handleDodgeUp(makeState());
+    expect(endDodgeBurnStroke).not.toHaveBeenCalled();
+    expect(clearPendingDodgeStroke).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/eyedropper/eyedropper-interaction.test.ts
+++ b/src/tools/eyedropper/eyedropper-interaction.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const sampleColor = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  sampleColor: (...args: unknown[]) => sampleColor(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const ts = {
+  setForegroundColor: vi.fn(),
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleEyedropperDown, handleEyedropperMove } from './eyedropper-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 25, y: 35 },
+    layerPos: { x: 25, y: 35 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: null,
+    layerId: 'layer-1',
+    tool: 'eyedropper',
+    startPoint: null,
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+describe('eyedropper interaction', () => {
+  beforeEach(() => {
+    sampleColor.mockReset();
+    ts.setForegroundColor.mockClear();
+    engine = { __engine: 'mock' };
+  });
+
+  it('samples the composite at the canvas position and sets the foreground color', () => {
+    sampleColor.mockReturnValue(new Uint8Array([10, 20, 30, 255]));
+    handleEyedropperDown(makeCtx());
+    expect(sampleColor).toHaveBeenCalledTimes(1);
+    const args = sampleColor.mock.calls[0]!;
+    expect(args[1]).toBe(25);
+    expect(args[2]).toBe(35);
+    expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 10, g: 20, b: 30, a: 1 });
+  });
+
+  it('normalizes alpha from 0..255 to 0..1', () => {
+    sampleColor.mockReturnValue(new Uint8Array([0, 0, 0, 128]));
+    handleEyedropperDown(makeCtx());
+    expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 0, g: 0, b: 0, a: 128 / 255 });
+  });
+
+  it('returns a drawing state carrying the layer offset for later moves', () => {
+    sampleColor.mockReturnValue(new Uint8Array([1, 2, 3, 255]));
+    const layer = { id: 'layer-1', x: 100, y: 200, visible: true } as unknown as InteractionContext['activeLayer'];
+    const state = handleEyedropperDown(makeCtx({ activeLayer: layer }));
+    expect(state.tool).toBe('eyedropper');
+    expect(state.drawing).toBe(true);
+    expect(state.layerStartX).toBe(100);
+    expect(state.layerStartY).toBe(200);
+    expect(state.lastPoint).toEqual({ x: 25, y: 35 });
+  });
+
+  it('does not set a color when the engine returns a short result', () => {
+    sampleColor.mockReturnValue(new Uint8Array([1, 2]));
+    handleEyedropperDown(makeCtx());
+    expect(ts.setForegroundColor).not.toHaveBeenCalled();
+  });
+
+  it('does not set a color when no engine is available', () => {
+    engine = null;
+    handleEyedropperDown(makeCtx());
+    expect(sampleColor).not.toHaveBeenCalled();
+    expect(ts.setForegroundColor).not.toHaveBeenCalled();
+  });
+
+  it('move samples at layer-local position translated back to canvas space', () => {
+    sampleColor.mockReturnValue(new Uint8Array([5, 6, 7, 255]));
+    handleEyedropperMove(makeState({ layerStartX: 100, layerStartY: 200 }), { x: 10, y: 15 });
+    const args = sampleColor.mock.calls[0]!;
+    expect(args[1]).toBe(110);
+    expect(args[2]).toBe(215);
+    expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 5, g: 6, b: 7, a: 1 });
+  });
+
+  it('move with negative coordinates still forwards them to the sampler', () => {
+    sampleColor.mockReturnValue(new Uint8Array(0));
+    handleEyedropperMove(makeState(), { x: -5, y: -8 });
+    const args = sampleColor.mock.calls[0]!;
+    expect(args[1]).toBe(-5);
+    expect(args[2]).toBe(-8);
+    expect(ts.setForegroundColor).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/fill/fill-interaction.test.ts
+++ b/src/tools/fill/fill-interaction.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const floodFill = vi.fn();
+const applyFillToLayer = vi.fn();
+const readLayerPixelsForFill = vi.fn();
+const fillQuickMask = vi.fn();
+const fillMask = vi.fn();
+const uploadLayerMask = vi.fn();
+const readMaskTexture = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  floodFill: (...args: unknown[]) => floodFill(...args),
+  applyFillToLayer: (...args: unknown[]) => applyFillToLayer(...args),
+  readLayerPixelsForFill: (...args: unknown[]) => readLayerPixelsForFill(...args),
+  fillQuickMask: (...args: unknown[]) => fillQuickMask(...args),
+  fillMask: (...args: unknown[]) => fillMask(...args),
+  uploadLayerMask: (...args: unknown[]) => uploadLayerMask(...args),
+  readMaskTexture: (...args: unknown[]) => readMaskTexture(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const clearJsPixelData = vi.fn();
+vi.mock('../../app/store/clear-js-pixel-data', () => ({
+  clearJsPixelData: (...args: unknown[]) => clearJsPixelData(...args),
+}));
+
+const DOC_W = 8;
+const DOC_H = 8;
+
+interface MockLayer {
+  id: string;
+  x: number;
+  y: number;
+  mask: { data: Uint8ClampedArray; width: number; height: number } | null;
+}
+
+const editorState = {
+  document: {
+    width: DOC_W,
+    height: DOC_H,
+    layers: [{ id: 'layer-1', x: 0, y: 0, mask: null }] as MockLayer[],
+  },
+  selection: {
+    active: false,
+    mask: null as Uint8ClampedArray | null,
+    bounds: null as { x: number; y: number; width: number; height: number } | null,
+    maskWidth: 0,
+    maskHeight: 0,
+  },
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+  updateLayerMaskData: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  maskMode: 'off' as 'off' | 'layerMask' | 'quickMask',
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  foregroundColor: { r: 200, g: 100, b: 50, a: 1 },
+  settings: { fill: { tolerance: 24, contiguous: true } },
+  addRecentColor: vi.fn(),
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleFillDown } from './fill-interaction';
+import type { InteractionContext } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 3.4, y: 3.6 },
+    layerPos: { x: 3.4, y: 3.6 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  floodFill.mockReset();
+  applyFillToLayer.mockClear();
+  readLayerPixelsForFill.mockReset();
+  fillQuickMask.mockClear();
+  fillMask.mockClear();
+  uploadLayerMask.mockClear();
+  readMaskTexture.mockReset();
+  clearJsPixelData.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  editorState.updateLayerMaskData.mockClear();
+  ts.addRecentColor.mockClear();
+  uiState.maskMode = 'off';
+  editorState.document.layers = [{ id: 'layer-1', x: 0, y: 0, mask: null }];
+  editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+  readLayerPixelsForFill.mockReturnValue(new Uint8Array(DOC_W * DOC_H * 4));
+  floodFill.mockReturnValue(new Uint8Array(DOC_W * DOC_H).fill(255));
+});
+
+describe('bucket fill — normal mode', () => {
+  it('flood-fills from the click point and applies the result to the layer', () => {
+    handleFillDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Bucket Fill');
+    expect(ts.addRecentColor).toHaveBeenCalledWith(ts.foregroundColor);
+
+    expect(floodFill).toHaveBeenCalledTimes(1);
+    const ff = floodFill.mock.calls[0]!;
+    // (pixels, docW, docH, x, y, r, g, b, a255, tolerance, contiguous)
+    expect(ff[1]).toBe(DOC_W);
+    expect(ff[2]).toBe(DOC_H);
+    expect(ff[3]).toBe(3); // round(3.4)
+    expect(ff[4]).toBe(4); // round(3.6)
+    expect(ff[5]).toBe(200);
+    expect(ff[6]).toBe(100);
+    expect(ff[7]).toBe(50);
+    expect(ff[8]).toBe(255);
+    expect(ff[9]).toBe(24);
+    expect(ff[10]).toBe(true);
+
+    expect(applyFillToLayer).toHaveBeenCalledTimes(1);
+    const af = applyFillToLayer.mock.calls[0]!;
+    // (engine, layerId, r, g, b, a, mask, docW, docH)
+    expect(af[1]).toBe('layer-1');
+    expect(af[2]).toBeCloseTo(200 / 255);
+    expect(af[3]).toBeCloseTo(100 / 255);
+    expect(af[4]).toBeCloseTo(50 / 255);
+    expect(af[5]).toBe(1);
+    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('translates layer-local click coordinates into document space', () => {
+    editorState.document.layers = [{ id: 'layer-1', x: 2, y: 3, mask: null }];
+    handleFillDown(makeCtx({ layerPos: { x: 1, y: 1 } }));
+    const ff = floodFill.mock.calls[0]!;
+    expect(ff[3]).toBe(3); // 1 + layer.x
+    expect(ff[4]).toBe(4); // 1 + layer.y
+  });
+
+  it('aborts when clicking outside an active selection', () => {
+    const selMask = new Uint8ClampedArray(DOC_W * DOC_H); // nothing selected at click
+    editorState.selection = {
+      active: true,
+      mask: selMask,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    handleFillDown(makeCtx());
+    expect(floodFill).not.toHaveBeenCalled();
+    expect(applyFillToLayer).not.toHaveBeenCalled();
+  });
+
+  it('intersects the flood mask with the active selection', () => {
+    const selMask = new Uint8ClampedArray(DOC_W * DOC_H);
+    // Select only the top half (rows 0..3), which includes the click at (3,4)? No —
+    // include row 4 so the click point itself is selected.
+    for (let y = 0; y <= 4; y++) {
+      for (let x = 0; x < DOC_W; x++) selMask[y * DOC_W + x] = 255;
+    }
+    editorState.selection = {
+      active: true,
+      mask: selMask,
+      bounds: { x: 0, y: 0, width: DOC_W, height: 5 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    handleFillDown(makeCtx());
+    const fillMaskArg = applyFillToLayer.mock.calls[0]![6] as Uint8Array;
+    expect(fillMaskArg[4 * DOC_W + 3]).toBe(255); // inside selection
+    expect(fillMaskArg[6 * DOC_W + 3]).toBe(0); // flood hit it, selection vetoed it
+  });
+
+  it('does nothing after pushing history when no engine is available', () => {
+    engine = null;
+    handleFillDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Bucket Fill');
+    expect(floodFill).not.toHaveBeenCalled();
+    expect(applyFillToLayer).not.toHaveBeenCalled();
+  });
+});
+
+describe('bucket fill — quick mask mode', () => {
+  it('fills the quick mask texture instead of the layer', () => {
+    uiState.maskMode = 'quickMask';
+    handleFillDown(makeCtx({ canvasPos: { x: 5.6, y: 2.2 } }));
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Quick Mask Fill');
+    expect(fillQuickMask).toHaveBeenCalledTimes(1);
+    const args = fillQuickMask.mock.calls[0]!;
+    // (engine, x, y, tolerance, contiguous, mode)
+    expect(args[1]).toBe(6); // round(5.6)
+    expect(args[2]).toBe(2); // round(2.2)
+    expect(args[3]).toBe(24);
+    expect(args[4]).toBe(true);
+    expect(args[5]).toBe(0);
+    expect(floodFill).not.toHaveBeenCalled();
+    expect(applyFillToLayer).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an engine', () => {
+    uiState.maskMode = 'quickMask';
+    engine = null;
+    handleFillDown(makeCtx());
+    expect(fillQuickMask).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).not.toHaveBeenCalled();
+  });
+});
+
+describe('bucket fill — layer mask mode', () => {
+  it('uploads the current mask, fills it black, and reads the result back', () => {
+    uiState.maskMode = 'layerMask';
+    const maskData = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
+    editorState.document.layers = [
+      { id: 'layer-1', x: 0, y: 0, mask: { data: maskData, width: DOC_W, height: DOC_H } },
+    ];
+    const updated = new Uint8Array(DOC_W * DOC_H).fill(127);
+    readMaskTexture.mockReturnValue(updated);
+
+    handleFillDown(makeCtx({ layerPos: { x: 4.4, y: 4.6 } }));
+
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Mask Fill');
+    expect(uploadLayerMask).toHaveBeenCalledTimes(1);
+    const up = uploadLayerMask.mock.calls[0]!;
+    expect(up[1]).toBe('layer-1');
+    expect(up[3]).toBe(DOC_W);
+    expect(up[4]).toBe(DOC_H);
+
+    expect(fillMask).toHaveBeenCalledTimes(1);
+    const fm = fillMask.mock.calls[0]!;
+    // (engine, layerId, x, y, tolerance, contiguous, mode=1 fill-black)
+    expect(fm[2]).toBe(4);
+    expect(fm[3]).toBe(5);
+    expect(fm[6]).toBe(1);
+
+    expect(editorState.updateLayerMaskData).toHaveBeenCalledTimes(1);
+    const [layerId, newMask] = editorState.updateLayerMaskData.mock.calls[0]! as [string, Uint8ClampedArray];
+    expect(layerId).toBe('layer-1');
+    expect(newMask[0]).toBe(127);
+    expect(floodFill).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a normal bucket fill when the layer has no mask', () => {
+    uiState.maskMode = 'layerMask';
+    handleFillDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Bucket Fill');
+    expect(fillMask).not.toHaveBeenCalled();
+    expect(floodFill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/lasso/lasso-strategy.test.ts
+++ b/src/tools/lasso/lasso-strategy.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The strategy graph (selection-handlers) imports every selection strategy,
+// so the wasm-bridge mock must cover all names in that import graph. The
+// selection-mask builders throw so selection-handlers falls back to the
+// pure TS implementations — the test asserts on real mask contents.
+vi.mock('../../engine-wasm/wasm-bridge', () => {
+  const wasmThrow = (): never => {
+    throw new Error('wasm unavailable in test');
+  };
+  return {
+    createRectSelection: wasmThrow,
+    createEllipseSelection: wasmThrow,
+    selectionBounds: wasmThrow,
+    createPolygonMask: wasmThrow,
+    setSelectionMask: vi.fn(),
+    featherSelectionMask: vi.fn(),
+    readSelectionMask: vi.fn(),
+    hasFloat: vi.fn(() => false),
+    dropFloat: vi.fn(),
+    floodFill: vi.fn(),
+    floodFillGraduated: vi.fn(),
+    readLayerPixelsForFill: vi.fn(),
+    magneticLassoBegin: vi.fn(),
+    magneticLassoSnap: vi.fn(),
+    magneticLassoSnapPoint: vi.fn(),
+    magneticLassoEnd: vi.fn(),
+  };
+});
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => null,
+}));
+
+const editorState = {
+  document: { width: 12, height: 12, layers: [] as unknown[] },
+  selection: { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 },
+  setSelection: vi.fn(),
+  clearSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  lassoPoints: [] as Array<{ x: number; y: number }>,
+  setLassoPoints: vi.fn((pts: Array<{ x: number; y: number }>) => { uiState.lassoPoints = pts; }),
+  clearLassoPoints: vi.fn(() => { uiState.lassoPoints = []; }),
+  setTransform: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  settings: { marquee: { feather: 0 }, wand: { tolerance: 32, contiguous: true, graduated: false } },
+  aspectRatioLocked: false,
+  aspectRatioW: 1,
+  aspectRatioH: 1,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { lassoStrategy } from './lasso-strategy';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+import type { SelectionUpContext } from '../../app/interactions/selection-strategy';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 2, y: 2 },
+    layerPos: { x: 2, y: 2 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: null,
+    layerId: 'layer-1',
+    tool: 'lasso',
+    startPoint: { x: 2, y: 2 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+const upCtx: SelectionUpContext = {
+  screenToCanvas: (sx, sy) => ({ x: sx, y: sy }),
+  containerRef: { current: null },
+  event: { clientX: 0, clientY: 0 },
+};
+
+describe('lasso strategy', () => {
+  beforeEach(() => {
+    uiState.lassoPoints = [];
+    uiState.setLassoPoints.mockClear();
+    uiState.clearLassoPoints.mockClear();
+    uiState.setTransform.mockClear();
+    editorState.setSelection.mockClear();
+    editorState.clearSelection.mockClear();
+    ts.settings.marquee.feather = 0;
+  });
+
+  it('onDown starts the lasso trace at the click point', () => {
+    const state = lassoStrategy.onDown(makeCtx({ canvasPos: { x: 3, y: 4 } }), 'lasso');
+    expect(uiState.setLassoPoints).toHaveBeenCalledWith([{ x: 3, y: 4 }]);
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'lasso',
+      startPoint: { x: 3, y: 4 },
+      layerStartX: 0,
+      layerStartY: 0,
+    });
+  });
+
+  it('onMove appends the cursor position to the trace', () => {
+    lassoStrategy.onDown(makeCtx({ canvasPos: { x: 1, y: 1 } }), 'lasso');
+    lassoStrategy.onMove!(makeState(), { x: 5, y: 1 }, false);
+    lassoStrategy.onMove!(makeState(), { x: 5, y: 5 }, false);
+    expect(uiState.lassoPoints).toEqual([
+      { x: 1, y: 1 },
+      { x: 5, y: 1 },
+      { x: 5, y: 5 },
+    ]);
+  });
+
+  it('onUp with a triangle commits a polygon selection mask', () => {
+    uiState.lassoPoints = [
+      { x: 0, y: 0 },
+      { x: 8, y: 0 },
+      { x: 8, y: 8 },
+    ];
+    lassoStrategy.onUp!(makeState(), { x: 8, y: 8 }, upCtx);
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [bounds, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+      number,
+      number,
+    ];
+    expect(w).toBe(12);
+    expect(h).toBe(12);
+    // Inside the triangle (below the diagonal x >= y).
+    expect(mask[2 * 12 + 6]).toBe(255);
+    // Outside the triangle (above the diagonal).
+    expect(mask[6 * 12 + 1]).toBe(0);
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.width).toBeGreaterThan(0);
+    expect(uiState.clearLassoPoints).toHaveBeenCalledTimes(1);
+  });
+
+  it('onUp with fewer than 3 points does not create a selection', () => {
+    uiState.lassoPoints = [
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+    ];
+    lassoStrategy.onUp!(makeState(), { x: 5, y: 5 }, upCtx);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    expect(uiState.clearLassoPoints).toHaveBeenCalledTimes(1);
+  });
+
+  it('onUp with a degenerate (zero-area) polygon clears the trace without selecting', () => {
+    uiState.lassoPoints = [
+      { x: 2, y: 2 },
+      { x: 2, y: 2 },
+      { x: 2, y: 2 },
+    ];
+    lassoStrategy.onUp!(makeState(), { x: 2, y: 2 }, upCtx);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    expect(uiState.clearLassoPoints).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts
+++ b/src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const magneticLassoBegin = vi.fn();
+const magneticLassoSnap = vi.fn();
+const magneticLassoSnapPoint = vi.fn();
+const magneticLassoEnd = vi.fn();
+
+// selection-handlers (imported by the strategy) pulls in every selection
+// strategy, so the mock must cover the whole graph. Mask helpers throw so
+// the pure TS fallbacks run and real mask contents can be asserted.
+vi.mock('../../engine-wasm/wasm-bridge', () => {
+  const wasmThrow = (): never => {
+    throw new Error('wasm unavailable in test');
+  };
+  return {
+    createRectSelection: wasmThrow,
+    createEllipseSelection: wasmThrow,
+    selectionBounds: wasmThrow,
+    createPolygonMask: wasmThrow,
+    setSelectionMask: vi.fn(),
+    featherSelectionMask: vi.fn(),
+    readSelectionMask: vi.fn(),
+    hasFloat: vi.fn(() => false),
+    dropFloat: vi.fn(),
+    floodFill: vi.fn(),
+    floodFillGraduated: vi.fn(),
+    readLayerPixelsForFill: vi.fn(),
+    magneticLassoBegin: (...args: unknown[]) => magneticLassoBegin(...args),
+    magneticLassoSnap: (...args: unknown[]) => magneticLassoSnap(...args),
+    magneticLassoSnapPoint: (...args: unknown[]) => magneticLassoSnapPoint(...args),
+    magneticLassoEnd: (...args: unknown[]) => magneticLassoEnd(...args),
+  };
+});
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const DOC_W = 12;
+const DOC_H = 12;
+
+const editorState = {
+  document: { width: DOC_W, height: DOC_H, layers: [] as unknown[] },
+  selection: { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 },
+  setSelection: vi.fn(),
+  clearSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  lassoPoints: [] as Array<{ x: number; y: number }>,
+  setLassoPoints: vi.fn((pts: Array<{ x: number; y: number }>) => { uiState.lassoPoints = pts; }),
+  clearLassoPoints: vi.fn(() => { uiState.lassoPoints = []; }),
+  setTransform: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  settings: { marquee: { feather: 0 } },
+  magneticLassoWidth: 10,
+  magneticLassoContrast: 10,
+  magneticLassoFrequency: 100,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { magneticLassoStrategy } from './magnetic-lasso-strategy';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+import type { SelectionUpContext } from '../../app/interactions/selection-strategy';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 0, y: 0 },
+    layerPos: { x: 0, y: 0 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 0, y: 0 },
+    layerId: 'layer-1',
+    tool: 'lasso-magnetic',
+    startPoint: { x: 0, y: 0 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+  };
+}
+
+const upCtx: SelectionUpContext = {
+  screenToCanvas: (sx, sy) => ({ x: sx, y: sy }),
+  containerRef: { current: null },
+  event: { clientX: 0, clientY: 0 },
+};
+
+/** Identity snap: a straight two-point segment, no edge attraction. */
+function straightSnap(...args: unknown[]): Float32Array {
+  const [, fromX, fromY, toX, toY] = args as [unknown, number, number, number, number];
+  return new Float32Array([fromX, fromY, toX, toY]);
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  magneticLassoBegin.mockReset();
+  magneticLassoSnap.mockReset();
+  magneticLassoSnapPoint.mockReset();
+  magneticLassoEnd.mockClear();
+  uiState.lassoPoints = [];
+  uiState.setLassoPoints.mockClear();
+  uiState.clearLassoPoints.mockClear();
+  editorState.setSelection.mockClear();
+  editorState.clearSelection.mockClear();
+  ts.magneticLassoFrequency = 100;
+  magneticLassoSnap.mockImplementation(straightSnap);
+  magneticLassoSnapPoint.mockImplementation((...args: unknown[]) => {
+    const [, x, y] = args as [unknown, number, number];
+    return new Float32Array([x, y]);
+  });
+  // Reset module-level trace state from any previous test.
+  magneticLassoStrategy.onUp!(makeState(), { x: 0, y: 0 }, upCtx);
+  magneticLassoEnd.mockClear();
+  uiState.clearLassoPoints.mockClear();
+  editorState.setSelection.mockClear();
+  uiState.setLassoPoints.mockClear();
+});
+
+describe('magnetic lasso onDown', () => {
+  it('returns undefined when no engine is available', () => {
+    engine = null;
+    expect(magneticLassoStrategy.onDown(makeCtx(), 'lasso-magnetic')).toBeUndefined();
+    expect(magneticLassoBegin).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the engine cannot begin a trace', () => {
+    magneticLassoBegin.mockImplementation(() => {
+      throw new Error('no layer');
+    });
+    expect(magneticLassoStrategy.onDown(makeCtx(), 'lasso-magnetic')).toBeUndefined();
+  });
+
+  it('begins a trace on the active layer with the start snapped to an edge', () => {
+    magneticLassoSnapPoint.mockReturnValue(new Float32Array([3, 4]));
+    const state = magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 1, y: 1 } }), 'lasso-magnetic');
+    expect(magneticLassoBegin.mock.calls[0]![1]).toBe('layer-1');
+    expect(uiState.setLassoPoints).toHaveBeenCalledWith([{ x: 3, y: 4 }]);
+    expect(state).toMatchObject({ drawing: true, tool: 'lasso-magnetic', startPoint: { x: 1, y: 1 } });
+  });
+
+  it('converts the contrast setting into a 1..255 threshold for the snapper', () => {
+    ts.magneticLassoContrast = 10;
+    magneticLassoStrategy.onDown(makeCtx(), 'lasso-magnetic');
+    // round(10 * 2.55) = 26
+    expect(magneticLassoSnapPoint.mock.calls[0]![4]).toBe(26);
+    expect(magneticLassoSnapPoint.mock.calls[0]![3]).toBe(10); // radius
+  });
+
+  it('falls back to the raw click point when snapping returns nothing', () => {
+    magneticLassoSnapPoint.mockReturnValue(new Float32Array(0));
+    magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 5, y: 6 } }), 'lasso-magnetic');
+    expect(uiState.setLassoPoints).toHaveBeenCalledWith([{ x: 5, y: 6 }]);
+  });
+});
+
+describe('magnetic lasso onMove', () => {
+  it('updates the live segment with the snapped polyline', () => {
+    magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
+    magneticLassoStrategy.onMove!(makeState(), { x: 4, y: 0 }, false);
+    expect(uiState.lassoPoints).toEqual([
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]);
+  });
+
+  it('auto-anchors when the live segment grows past the frequency length', () => {
+    ts.magneticLassoFrequency = 5;
+    magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
+    magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 0 }, false);
+    // The 8px segment exceeds frequency 5, so an anchor is committed at the
+    // cursor and the preview contains the committed segment.
+    expect(uiState.lassoPoints).toEqual([
+      { x: 0, y: 0 },
+      { x: 8, y: 0 },
+    ]);
+    magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 8 }, false);
+    expect(uiState.lassoPoints).toEqual([
+      { x: 0, y: 0 },
+      { x: 8, y: 0 },
+      { x: 8, y: 8 },
+    ]);
+  });
+
+  it('does nothing when no trace is active', () => {
+    magneticLassoStrategy.onMove!(makeState(), { x: 4, y: 4 }, false);
+    expect(uiState.setLassoPoints).not.toHaveBeenCalled();
+  });
+});
+
+describe('magnetic lasso onUp', () => {
+  it('closes the loop and commits a polygon selection', () => {
+    ts.magneticLassoFrequency = 5;
+    magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
+    magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 0 }, false);
+    magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 8 }, false);
+    magneticLassoStrategy.onUp!(makeState(), { x: 8, y: 8 }, upCtx);
+
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [bounds, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+      number,
+      number,
+    ];
+    expect(w).toBe(DOC_W);
+    expect(h).toBe(DOC_H);
+    // Triangle (0,0)-(8,0)-(8,8): inside is x >= y.
+    expect(mask[2 * DOC_W + 6]).toBe(255);
+    expect(mask[6 * DOC_W + 1]).toBe(0);
+    expect(bounds.width).toBeGreaterThan(0);
+    expect(magneticLassoEnd).toHaveBeenCalledTimes(1);
+    expect(uiState.clearLassoPoints).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the engine trace without selecting when the loop is degenerate', () => {
+    magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
+    magneticLassoStrategy.onUp!(makeState(), { x: 0, y: 0 }, upCtx);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    expect(magneticLassoEnd).toHaveBeenCalledTimes(1);
+    expect(uiState.clearLassoPoints).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second onUp without a new trace only clears the preview', () => {
+    magneticLassoStrategy.onDown(makeCtx(), 'lasso-magnetic');
+    magneticLassoStrategy.onUp!(makeState(), { x: 0, y: 0 }, upCtx);
+    magneticLassoEnd.mockClear();
+    editorState.setSelection.mockClear();
+    magneticLassoStrategy.onUp!(makeState(), { x: 0, y: 0 }, upCtx);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    // engine end is still called defensively, but no commit happens
+    expect(magneticLassoEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/marquee/marquee-strategy.test.ts
+++ b/src/tools/marquee/marquee-strategy.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const hasFloat = vi.fn((..._args: unknown[]) => false);
+const dropFloat = vi.fn();
+
+// selection-handlers (imported by the strategy) pulls in every selection
+// strategy, so the mock must cover the whole graph. Mask helpers throw so
+// the pure TS fallbacks run and real mask contents can be asserted.
+vi.mock('../../engine-wasm/wasm-bridge', () => {
+  const wasmThrow = (): never => {
+    throw new Error('wasm unavailable in test');
+  };
+  return {
+    createRectSelection: wasmThrow,
+    createEllipseSelection: wasmThrow,
+    selectionBounds: wasmThrow,
+    createPolygonMask: wasmThrow,
+    setSelectionMask: vi.fn(),
+    featherSelectionMask: vi.fn(),
+    readSelectionMask: vi.fn(),
+    hasFloat: (...args: unknown[]) => hasFloat(...args),
+    dropFloat: (...args: unknown[]) => dropFloat(...args),
+    floodFill: vi.fn(),
+    floodFillGraduated: vi.fn(),
+    readLayerPixelsForFill: vi.fn(),
+    magneticLassoBegin: vi.fn(),
+    magneticLassoSnap: vi.fn(),
+    magneticLassoSnapPoint: vi.fn(),
+    magneticLassoEnd: vi.fn(),
+  };
+});
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => ({ __engine: 'mock' }),
+}));
+
+const DOC_W = 100;
+const DOC_H = 100;
+
+const editorState = {
+  document: { width: DOC_W, height: DOC_H, layers: [] as unknown[] },
+  selection: {
+    active: false,
+    mask: null as Uint8ClampedArray | null,
+    bounds: null as { x: number; y: number; width: number; height: number } | null,
+    maskWidth: 0,
+    maskHeight: 0,
+  },
+  setSelection: vi.fn(),
+  clearSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  setTransform: vi.fn(),
+  showGrid: false,
+  snapToGrid: false,
+  gridSize: 10,
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  settings: { marquee: { feather: 0 } },
+  aspectRatioLocked: false,
+  aspectRatioW: 1,
+  aspectRatioH: 1,
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { marqueeStrategy } from './marquee-strategy';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+import type { SelectionUpContext } from '../../app/interactions/selection-strategy';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 10, y: 10 },
+    layerPos: { x: 10, y: 10 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: { offsetX: 0 } as never },
+    persistentTransformRef: { current: { maskWidth: 1 } as never },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: null,
+    layerId: 'layer-1',
+    tool: 'marquee-rect',
+    startPoint: { x: 10, y: 10 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+function makeUpCtx(clientX: number, clientY: number): SelectionUpContext {
+  return {
+    screenToCanvas: (sx, sy) => ({ x: sx, y: sy }),
+    containerRef: {
+      current: {
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      } as unknown as HTMLDivElement,
+    },
+    event: { clientX, clientY },
+  };
+}
+
+beforeEach(() => {
+  hasFloat.mockReset();
+  hasFloat.mockReturnValue(false);
+  dropFloat.mockClear();
+  editorState.setSelection.mockClear();
+  editorState.clearSelection.mockClear();
+  uiState.setTransform.mockClear();
+  editorState.document = { width: DOC_W, height: DOC_H, layers: [] };
+  editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+  uiState.showGrid = false;
+  uiState.snapToGrid = false;
+  ts.aspectRatioLocked = false;
+  ts.settings.marquee.feather = 0;
+});
+
+describe('marquee onDown', () => {
+  it('starts a fresh selection drag outside any existing selection', () => {
+    const ctx = makeCtx();
+    const state = marqueeStrategy.onDown(ctx, 'marquee-rect');
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'marquee-rect',
+      startPoint: { x: 10, y: 10 },
+      moveOriginalMask: null,
+    });
+    expect(uiState.setTransform).toHaveBeenCalledWith(null);
+    expect(ctx.floatingSelectionRef.current).toBeNull();
+    expect(ctx.persistentTransformRef.current).toBeNull();
+  });
+
+  it('starts a move gesture when clicking inside an existing selection', () => {
+    const mask = new Uint8ClampedArray(DOC_W * DOC_H);
+    mask[10 * DOC_W + 10] = 255;
+    editorState.selection = {
+      active: true,
+      mask,
+      bounds: { x: 10, y: 10, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    const state = marqueeStrategy.onDown(makeCtx(), 'marquee-rect');
+    expect(state?.moveOriginalMask).toBeInstanceOf(Uint8ClampedArray);
+    expect(state?.moveOriginalMask).not.toBe(mask); // defensive copy
+    expect(state?.moveOriginalBounds).toEqual({ x: 10, y: 10, width: 1, height: 1 });
+    expect(uiState.setTransform).not.toHaveBeenCalled();
+  });
+
+  it('drops any GPU float when starting a move inside a selection', () => {
+    const mask = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
+    editorState.selection = {
+      active: true,
+      mask,
+      bounds: { x: 0, y: 0, width: DOC_W, height: DOC_H },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    hasFloat.mockReturnValue(true);
+    marqueeStrategy.onDown(makeCtx(), 'marquee-rect');
+    expect(dropFloat).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not drop the float when none exists', () => {
+    const mask = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
+    editorState.selection = {
+      active: true,
+      mask,
+      bounds: { x: 0, y: 0, width: DOC_W, height: DOC_H },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    marqueeStrategy.onDown(makeCtx(), 'marquee-rect');
+    expect(dropFloat).not.toHaveBeenCalled();
+  });
+
+  it('clicking outside the mask area starts a fresh drag even with an active selection', () => {
+    const mask = new Uint8ClampedArray(DOC_W * DOC_H);
+    mask[50 * DOC_W + 50] = 255;
+    editorState.selection = {
+      active: true,
+      mask,
+      bounds: { x: 50, y: 50, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    const state = marqueeStrategy.onDown(makeCtx({ canvasPos: { x: 10, y: 10 } }), 'marquee-rect');
+    expect(state?.moveOriginalMask).toBeNull();
+    expect(uiState.setTransform).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('marquee onMove — creating a selection', () => {
+  it('builds a rect mask from start to cursor', () => {
+    marqueeStrategy.onMove!(makeState(), { x: 30, y: 25 }, false);
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [rect, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+      number,
+      number,
+    ];
+    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 15 });
+    expect(w).toBe(DOC_W);
+    expect(h).toBe(DOC_H);
+    expect(mask[12 * DOC_W + 12]).toBe(255); // inside
+    expect(mask[5 * DOC_W + 5]).toBe(0); // outside
+    expect(uiState.setTransform).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes a drag up-left of the start point', () => {
+    marqueeStrategy.onMove!(makeState({ startPoint: { x: 50, y: 50 } }), { x: 30, y: 40 }, false);
+    const [rect] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+    ];
+    expect(rect).toEqual({ x: 30, y: 40, width: 20, height: 10 });
+  });
+
+  it('does nothing for a zero-size drag', () => {
+    marqueeStrategy.onMove!(makeState(), { x: 10, y: 10 }, false);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('meta key constrains the selection to a square', () => {
+    marqueeStrategy.onMove!(makeState(), { x: 50, y: 20 }, true);
+    const [rect] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+    ];
+    expect(rect.width).toBe(rect.height);
+    expect(rect).toEqual({ x: 10, y: 10, width: 10, height: 10 });
+  });
+
+  it('honors a locked aspect ratio from tool settings', () => {
+    ts.aspectRatioLocked = true;
+    ts.aspectRatioW = 2;
+    ts.aspectRatioH = 1;
+    marqueeStrategy.onMove!(makeState(), { x: 50, y: 40 }, false);
+    const [rect] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+    ];
+    expect(rect.width / rect.height).toBeCloseTo(2);
+  });
+
+  it('builds an ellipse mask for the ellipse tool', () => {
+    marqueeStrategy.onMove!(makeState({ tool: 'marquee-ellipse' }), { x: 30, y: 30 }, false);
+    const [rect, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+    expect(mask[20 * DOC_W + 20]).toBe(255); // center of ellipse
+    expect(mask[10 * DOC_W + 10]).toBe(0); // bounding-box corner is outside
+  });
+
+  it('snaps start and end to the grid when grid snapping is on', () => {
+    uiState.showGrid = true;
+    uiState.snapToGrid = true;
+    uiState.gridSize = 10;
+    marqueeStrategy.onMove!(makeState({ startPoint: { x: 12, y: 12 } }), { x: 33, y: 28 }, false);
+    const [rect] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+    ];
+    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+  });
+});
+
+describe('marquee onMove — moving an existing selection', () => {
+  it('translates the mask and bounds by the drag delta', () => {
+    editorState.document = { width: 10, height: 10, layers: [] };
+    const src = new Uint8ClampedArray(10 * 10);
+    // 2x2 block at (2,2)
+    src[2 * 10 + 2] = 255;
+    src[2 * 10 + 3] = 255;
+    src[3 * 10 + 2] = 255;
+    src[3 * 10 + 3] = 255;
+    const state = makeState({
+      startPoint: { x: 0, y: 0 },
+      moveOriginalMask: src,
+      moveOriginalBounds: { x: 2, y: 2, width: 2, height: 2 },
+    });
+    marqueeStrategy.onMove!(state, { x: 3, y: 2 }, false);
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(bounds).toEqual({ x: 5, y: 4, width: 2, height: 2 });
+    expect(mask[4 * 10 + 5]).toBe(255); // (2,2) moved to (5,4)
+    expect(mask[2 * 10 + 2]).toBe(0); // old location cleared
+  });
+
+  it('clips mask content dragged outside the document', () => {
+    editorState.document = { width: 10, height: 10, layers: [] };
+    const src = new Uint8ClampedArray(10 * 10);
+    src[0] = 255; // pixel at (0,0)
+    const state = makeState({
+      startPoint: { x: 0, y: 0 },
+      moveOriginalMask: src,
+      moveOriginalBounds: { x: 0, y: 0, width: 1, height: 1 },
+    });
+    marqueeStrategy.onMove!(state, { x: -3, y: -3 }, false);
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(bounds).toEqual({ x: -3, y: -3, width: 1, height: 1 });
+    expect(mask.every((v) => v === 0)).toBe(true);
+  });
+});
+
+describe('marquee onUp', () => {
+  it('treats a sub-2px gesture as a click and clears the selection', () => {
+    marqueeStrategy.onUp!(makeState({ startPoint: { x: 10, y: 10 } }), { x: 11, y: 11 }, makeUpCtx(11, 11));
+    expect(editorState.clearSelection).toHaveBeenCalledTimes(1);
+    expect(uiState.setTransform).toHaveBeenCalledWith(null);
+  });
+
+  it('commits the selection after a real drag', () => {
+    const mask = new Uint8ClampedArray(DOC_W * DOC_H);
+    mask[12 * DOC_W + 12] = 255;
+    editorState.selection = {
+      active: true,
+      mask,
+      bounds: { x: 12, y: 12, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    marqueeStrategy.onUp!(makeState({ startPoint: { x: 10, y: 10 } }), { x: 40, y: 40 }, makeUpCtx(40, 40));
+    expect(editorState.clearSelection).not.toHaveBeenCalled();
+    // feather = 0 commits the mask straight through
+    expect(editorState.setSelection).toHaveBeenCalledWith(
+      { x: 12, y: 12, width: 1, height: 1 }, mask, DOC_W, DOC_H,
+    );
+  });
+
+  it('does nothing when finishing a selection move', () => {
+    const state = makeState({
+      moveOriginalMask: new Uint8ClampedArray(4),
+      moveOriginalBounds: { x: 0, y: 0, width: 2, height: 2 },
+    });
+    marqueeStrategy.onUp!(state, { x: 50, y: 50 }, makeUpCtx(50, 50));
+    expect(editorState.clearSelection).not.toHaveBeenCalled();
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/path/path-interaction.test.ts
+++ b/src/tools/path/path-interaction.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const commitCurrentPath = vi.fn();
+vi.mock('../../app/interactions/path-stroke', () => ({
+  commitCurrentPath: (...args: unknown[]) => commitCurrentPath(...args),
+}));
+
+import type { PathAnchor } from './path';
+
+interface MockPath {
+  id: string;
+  anchors: PathAnchor[];
+  closed: boolean;
+}
+
+const editorState = {
+  selectedPathId: null as string | null,
+  paths: [] as MockPath[],
+  viewport: { zoom: 1 },
+  updatePathAnchors: vi.fn((id: string, anchors: PathAnchor[], closed: boolean) => {
+    const path = editorState.paths.find((p) => p.id === id);
+    if (path) {
+      path.anchors = anchors;
+      path.closed = closed;
+    }
+  }),
+  selectPath: vi.fn((id: string | null) => { editorState.selectedPathId = id; }),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+interface DraggingHandle {
+  anchorIndex: number;
+  handle: 'in' | 'out';
+}
+
+const uiState = {
+  pathDraft: null as { anchors: PathAnchor[] } | null,
+  addPathAnchor: vi.fn((a: PathAnchor) => {
+    if (!uiState.pathDraft) uiState.pathDraft = { anchors: [] };
+    uiState.pathDraft.anchors.push(a);
+  }),
+  updateLastPathAnchor: vi.fn((a: PathAnchor) => {
+    if (uiState.pathDraft && uiState.pathDraft.anchors.length > 0) {
+      uiState.pathDraft.anchors[uiState.pathDraft.anchors.length - 1] = a;
+    }
+  }),
+  closePath: vi.fn(),
+  editingAnchorIndex: null as number | null,
+  setEditingAnchorIndex: vi.fn((idx: number | null) => { uiState.editingAnchorIndex = idx; }),
+  convertingAnchorToSpline: false,
+  setConvertingAnchorToSpline: vi.fn((v: boolean) => { uiState.convertingAnchorToSpline = v; }),
+  draggingHandle: null as DraggingHandle | null,
+  setDraggingHandle: vi.fn((h: DraggingHandle | null) => { uiState.draggingHandle = h; }),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+import { handlePathDown, handlePathMove, handlePathUp } from './path-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 50, y: 50 },
+    layerPos: { x: 50, y: 50 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 50, y: 50 },
+    layerId: 'layer-1',
+    tool: 'path',
+    startPoint: { x: 50, y: 50 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+function anchor(x: number, y: number): PathAnchor {
+  return { point: { x, y }, handleIn: null, handleOut: null };
+}
+
+// The double-click detector uses module-level Date.now() state. Advance the
+// mocked clock by 10s before each test so clicks never bleed across tests.
+let now = 1_000_000;
+
+beforeEach(() => {
+  now += 10_000;
+  vi.spyOn(Date, 'now').mockImplementation(() => now);
+  commitCurrentPath.mockClear();
+  editorState.selectedPathId = null;
+  editorState.paths = [];
+  editorState.viewport = { zoom: 1 };
+  editorState.updatePathAnchors.mockClear();
+  editorState.selectPath.mockClear();
+  uiState.pathDraft = null;
+  uiState.addPathAnchor.mockClear();
+  uiState.updateLastPathAnchor.mockClear();
+  uiState.closePath.mockClear();
+  uiState.editingAnchorIndex = null;
+  uiState.setEditingAnchorIndex.mockClear();
+  uiState.convertingAnchorToSpline = false;
+  uiState.setConvertingAnchorToSpline.mockClear();
+  uiState.draggingHandle = null;
+  uiState.setDraggingHandle.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('path creation mode', () => {
+  it('first click places an anchor at the layer position', () => {
+    const state = handlePathDown(makeCtx({ layerPos: { x: 10, y: 20 } }));
+    expect(uiState.addPathAnchor).toHaveBeenCalledWith({
+      point: { x: 10, y: 20 },
+      handleIn: null,
+      handleOut: null,
+    });
+    expect(state).toMatchObject({ drawing: true, tool: 'path', startPoint: { x: 10, y: 20 } });
+  });
+
+  it('clicking near the first anchor with 2+ anchors closes the path', () => {
+    uiState.pathDraft = { anchors: [anchor(10, 10), anchor(60, 10)] };
+    const result = handlePathDown(makeCtx({ layerPos: { x: 13, y: 13 } }));
+    expect(result).toBeUndefined();
+    expect(uiState.closePath).toHaveBeenCalledTimes(1);
+    expect(commitCurrentPath).toHaveBeenCalledTimes(1);
+    expect(uiState.addPathAnchor).not.toHaveBeenCalled();
+  });
+
+  it('clicking exactly 8px away from the first anchor does not close', () => {
+    uiState.pathDraft = { anchors: [anchor(10, 10), anchor(60, 10)] };
+    handlePathDown(makeCtx({ layerPos: { x: 18, y: 10 } }));
+    expect(uiState.closePath).not.toHaveBeenCalled();
+    expect(uiState.addPathAnchor).toHaveBeenCalledTimes(1);
+  });
+
+  it('with a single anchor the path cannot close yet', () => {
+    uiState.pathDraft = { anchors: [anchor(10, 10)] };
+    handlePathDown(makeCtx({ layerPos: { x: 11, y: 11 } }));
+    expect(uiState.closePath).not.toHaveBeenCalled();
+    expect(uiState.addPathAnchor).toHaveBeenCalledTimes(1);
+  });
+
+  it('dragging past 2px pulls out symmetric handles on the new anchor', () => {
+    handlePathMove(makeState({ startPoint: { x: 10, y: 10 } }), { x: 15, y: 13 });
+    expect(uiState.updateLastPathAnchor).toHaveBeenCalledWith({
+      point: { x: 10, y: 10 },
+      handleOut: { x: 15, y: 13 },
+      handleIn: { x: 5, y: 7 },
+    });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('a sub-2px drag does not create handles', () => {
+    handlePathMove(makeState({ startPoint: { x: 10, y: 10 } }), { x: 11, y: 11 });
+    expect(uiState.updateLastPathAnchor).not.toHaveBeenCalled();
+  });
+
+  it('move without a start point is ignored', () => {
+    handlePathMove(makeState({ startPoint: null }), { x: 100, y: 100 });
+    expect(uiState.updateLastPathAnchor).not.toHaveBeenCalled();
+  });
+});
+
+describe('path edit mode', () => {
+  function selectPathWith(anchors: PathAnchor[], closed = false): void {
+    editorState.selectedPathId = 'path-1';
+    editorState.paths = [{ id: 'path-1', anchors, closed }];
+  }
+
+  it('clicking a handle starts a handle drag', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 40, y: 40 }, handleOut: { x: 60, y: 60 } },
+      anchor(100, 50),
+    ]);
+    const state = handlePathDown(makeCtx({ canvasPos: { x: 60, y: 60 } }));
+    expect(uiState.setDraggingHandle).toHaveBeenCalledWith({ anchorIndex: 0, handle: 'out' });
+    expect(uiState.setEditingAnchorIndex).toHaveBeenCalledWith(0);
+    expect(state).toMatchObject({ drawing: true, tool: 'path' });
+  });
+
+  it('clicking an anchor begins an anchor drag without converting', () => {
+    selectPathWith([anchor(50, 50), anchor(100, 50)]);
+    const state = handlePathDown(makeCtx({ canvasPos: { x: 51, y: 51 } }));
+    expect(uiState.setEditingAnchorIndex).toHaveBeenCalledWith(0);
+    expect(uiState.setConvertingAnchorToSpline).toHaveBeenCalledWith(false);
+    expect(state?.drawing).toBe(true);
+  });
+
+  it('double-clicking a spline anchor strips its handles', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 30, y: 50 }, handleOut: { x: 70, y: 50 } },
+      anchor(100, 50),
+    ]);
+    handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 } }));
+    now += 100; // second click 100ms later — inside the 400ms window
+    handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 } }));
+    expect(editorState.paths[0]!.anchors[0]).toEqual({
+      point: { x: 50, y: 50 },
+      handleIn: null,
+      handleOut: null,
+    });
+    expect(uiState.setConvertingAnchorToSpline).toHaveBeenLastCalledWith(true);
+  });
+
+  it('two slow clicks do not count as a double click', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 30, y: 50 }, handleOut: { x: 70, y: 50 } },
+      anchor(100, 50),
+    ]);
+    handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 } }));
+    now += 500; // outside the 400ms window
+    handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 } }));
+    expect(editorState.paths[0]!.anchors[0]!.handleIn).toEqual({ x: 30, y: 50 });
+    expect(uiState.setConvertingAnchorToSpline).toHaveBeenLastCalledWith(false);
+  });
+
+  it('meta-click converts immediately without waiting for a double click', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 30, y: 50 }, handleOut: { x: 70, y: 50 } },
+      anchor(100, 50),
+    ]);
+    handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 }, metaKey: true }));
+    expect(editorState.paths[0]!.anchors[0]!.handleIn).toBeNull();
+    expect(uiState.setConvertingAnchorToSpline).toHaveBeenCalledWith(true);
+  });
+
+  it('clicking a segment splits it at the midpoint', () => {
+    selectPathWith([anchor(0, 50), anchor(100, 50)]);
+    const result = handlePathDown(makeCtx({ canvasPos: { x: 50, y: 50 } }));
+    expect(result).toBeUndefined();
+    expect(editorState.paths[0]!.anchors).toHaveLength(3);
+    expect(editorState.paths[0]!.anchors[1]!.point).toEqual({ x: 50, y: 50 });
+  });
+
+  it('clicking empty space deselects the path', () => {
+    selectPathWith([anchor(0, 0), anchor(10, 0)]);
+    const result = handlePathDown(makeCtx({ canvasPos: { x: 200, y: 200 } }));
+    expect(result).toBeUndefined();
+    expect(editorState.selectPath).toHaveBeenCalledWith(null);
+    expect(uiState.setEditingAnchorIndex).toHaveBeenCalledWith(null);
+  });
+
+  it('scales the hit threshold with zoom', () => {
+    selectPathWith([anchor(50, 50), anchor(100, 50)]);
+    editorState.viewport = { zoom: 4 }; // threshold becomes 2px
+    handlePathDown(makeCtx({ canvasPos: { x: 55, y: 50 } }));
+    // 5px away at threshold 2 — no anchor hit; the click lands on the segment.
+    expect(uiState.setEditingAnchorIndex).not.toHaveBeenCalledWith(0);
+  });
+
+  it('dragging an anchor moves its point and translates its handles', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 40, y: 50 }, handleOut: { x: 60, y: 50 } },
+    ]);
+    uiState.editingAnchorIndex = 0;
+    handlePathMove(makeState(), { x: 70, y: 80 });
+    expect(editorState.paths[0]!.anchors[0]).toEqual({
+      point: { x: 70, y: 80 },
+      handleIn: { x: 60, y: 80 },
+      handleOut: { x: 80, y: 80 },
+    });
+  });
+
+  it('a sub-1px anchor drag is ignored', () => {
+    selectPathWith([anchor(50, 50)]);
+    uiState.editingAnchorIndex = 0;
+    handlePathMove(makeState(), { x: 50.5, y: 50.5 });
+    expect(editorState.updatePathAnchors).not.toHaveBeenCalled();
+  });
+
+  it('dragging a handle moves only that handle', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: { x: 40, y: 50 }, handleOut: { x: 60, y: 50 } },
+    ]);
+    uiState.editingAnchorIndex = 0;
+    uiState.draggingHandle = { anchorIndex: 0, handle: 'in' };
+    handlePathMove(makeState(), { x: 30, y: 30 });
+    expect(editorState.paths[0]!.anchors[0]).toEqual({
+      point: { x: 50, y: 50 },
+      handleIn: { x: 30, y: 30 },
+      handleOut: { x: 60, y: 50 },
+    });
+  });
+
+  it('handle drags translate layer-local input into canvas space', () => {
+    selectPathWith([
+      { point: { x: 50, y: 50 }, handleIn: null, handleOut: { x: 60, y: 50 } },
+    ]);
+    uiState.editingAnchorIndex = 0;
+    uiState.draggingHandle = { anchorIndex: 0, handle: 'out' };
+    handlePathMove(makeState({ layerStartX: 100, layerStartY: 200 }), { x: 10, y: 10 });
+    expect(editorState.paths[0]!.anchors[0]!.handleOut).toEqual({ x: 110, y: 210 });
+  });
+
+  it('convert-to-spline drag pulls out symmetric handles', () => {
+    selectPathWith([anchor(50, 50)]);
+    uiState.editingAnchorIndex = 0;
+    uiState.convertingAnchorToSpline = true;
+    handlePathMove(makeState(), { x: 60, y: 55 });
+    expect(editorState.paths[0]!.anchors[0]).toEqual({
+      point: { x: 50, y: 50 },
+      handleOut: { x: 60, y: 55 },
+      handleIn: { x: 40, y: 45 },
+    });
+  });
+
+  it('convert-to-spline ignores tiny drags', () => {
+    selectPathWith([anchor(50, 50)]);
+    uiState.editingAnchorIndex = 0;
+    uiState.convertingAnchorToSpline = true;
+    handlePathMove(makeState(), { x: 51, y: 51 });
+    expect(editorState.updatePathAnchors).not.toHaveBeenCalled();
+  });
+});
+
+describe('path up', () => {
+  it('clears all transient edit state', () => {
+    uiState.editingAnchorIndex = 2;
+    uiState.convertingAnchorToSpline = true;
+    uiState.draggingHandle = { anchorIndex: 2, handle: 'out' };
+    handlePathUp();
+    expect(uiState.setEditingAnchorIndex).toHaveBeenCalledWith(null);
+    expect(uiState.setConvertingAnchorToSpline).toHaveBeenCalledWith(false);
+    expect(uiState.setDraggingHandle).toHaveBeenCalledWith(null);
+  });
+
+  it('leaves untouched state alone when nothing was being edited', () => {
+    handlePathUp();
+    expect(uiState.setEditingAnchorIndex).not.toHaveBeenCalled();
+    expect(uiState.setConvertingAnchorToSpline).not.toHaveBeenCalled();
+    expect(uiState.setDraggingHandle).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/quick-select/quick-select-interaction.test.ts
+++ b/src/tools/quick-select/quick-select-interaction.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const readLayerPixelsForFill = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  readLayerPixelsForFill: (...args: unknown[]) => readLayerPixelsForFill(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const DOC_W = 12;
+const DOC_H = 12;
+
+const editorState = {
+  document: { width: DOC_W, height: DOC_H, layers: [] as unknown[] },
+  selection: {
+    active: false,
+    mask: null as Uint8ClampedArray | null,
+    bounds: null as { x: number; y: number; width: number; height: number } | null,
+    maskWidth: 0,
+    maskHeight: 0,
+  },
+  setSelection: vi.fn(),
+  clearSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  setTransform: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  quickSelectSize: 3,
+  quickSelectTolerance: 32,
+  quickSelectEdgeStrength: 0,
+  quickSelectMode: 'add' as 'add' | 'subtract',
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import {
+  handleQuickSelectDown,
+  handleQuickSelectMove,
+  handleQuickSelectUp,
+} from './quick-select-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+/**
+ * 12x12 RGBA image split into two flat-color regions:
+ * rows 0..5 red, rows 6..11 blue. The sharp horizontal boundary keeps the
+ * flood fill from leaking across regions at any tolerance below ~147.
+ */
+function twoBandImage(): Uint8Array {
+  const px = new Uint8Array(DOC_W * DOC_H * 4);
+  for (let y = 0; y < DOC_H; y++) {
+    for (let x = 0; x < DOC_W; x++) {
+      const i = (y * DOC_W + x) * 4;
+      if (y < 6) {
+        px[i] = 255;
+      } else {
+        px[i + 2] = 255;
+      }
+      px[i + 3] = 255;
+    }
+  }
+  return px;
+}
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 2, y: 2 },
+    layerPos: { x: 2, y: 2 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 2, y: 2 },
+    layerId: 'layer-1',
+    tool: 'quick-select',
+    startPoint: { x: 2, y: 2 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+function lastSetSelectionMask(): Uint8ClampedArray {
+  const calls = editorState.setSelection.mock.calls;
+  const call = calls[calls.length - 1]!;
+  return call[1] as Uint8ClampedArray;
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  readLayerPixelsForFill.mockReset();
+  readLayerPixelsForFill.mockReturnValue(twoBandImage());
+  editorState.setSelection.mockClear();
+  editorState.clearSelection.mockClear();
+  editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+  uiState.setTransform.mockClear();
+  ts.quickSelectMode = 'add';
+  ts.quickSelectTolerance = 32;
+  // Clear the module-level stroke session from any previous test.
+  handleQuickSelectUp();
+});
+
+describe('quick select down', () => {
+  it('returns undefined when no engine is available', () => {
+    engine = null;
+    expect(handleQuickSelectDown(makeCtx())).toBeUndefined();
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the GPU readback fails', () => {
+    readLayerPixelsForFill.mockImplementation(() => {
+      throw new Error('readback failed');
+    });
+    expect(handleQuickSelectDown(makeCtx())).toBeUndefined();
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('seeds the selection with the clicked color region', () => {
+    const state = handleQuickSelectDown(makeCtx({ canvasPos: { x: 2, y: 2 } }));
+    expect(state).toMatchObject({ drawing: true, tool: 'quick-select' });
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [bounds, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+      number,
+      number,
+    ];
+    expect(w).toBe(DOC_W);
+    expect(h).toBe(DOC_H);
+    // Whole red band selected, blue band untouched.
+    expect(bounds).toEqual({ x: 0, y: 0, width: DOC_W, height: 6 });
+    expect(mask[2 * DOC_W + 2]).toBe(255);
+    expect(mask[11 * DOC_W + 2]).toBe(0);
+    expect(uiState.setTransform).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves a prior selection when adding', () => {
+    const prior = new Uint8ClampedArray(DOC_W * DOC_H);
+    prior[10 * DOC_W + 10] = 255; // a blue-region pixel selected earlier
+    editorState.selection = {
+      active: true,
+      mask: prior,
+      bounds: { x: 10, y: 10, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    handleQuickSelectDown(makeCtx({ canvasPos: { x: 2, y: 2 } }));
+    const mask = lastSetSelectionMask();
+    expect(mask[10 * DOC_W + 10]).toBe(255); // prior selection kept
+    expect(mask[2 * DOC_W + 2]).toBe(255); // red region added
+  });
+
+  it('subtract mode removes the clicked region from a prior selection', () => {
+    ts.quickSelectMode = 'subtract';
+    const prior = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
+    editorState.selection = {
+      active: true,
+      mask: prior,
+      bounds: { x: 0, y: 0, width: DOC_W, height: DOC_H },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    handleQuickSelectDown(makeCtx({ canvasPos: { x: 2, y: 2 } }));
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(mask[2 * DOC_W + 2]).toBe(0); // red region removed
+    expect(mask[10 * DOC_W + 10]).toBe(255); // blue region still selected
+    expect(bounds).toEqual({ x: 0, y: 6, width: DOC_W, height: 6 });
+  });
+
+  it('clears the selection when subtracting leaves nothing', () => {
+    ts.quickSelectMode = 'subtract';
+    const prior = new Uint8ClampedArray(DOC_W * DOC_H);
+    for (let y = 0; y < 6; y++) {
+      for (let x = 0; x < DOC_W; x++) prior[y * DOC_W + x] = 255;
+    }
+    editorState.selection = {
+      active: true,
+      mask: prior,
+      bounds: { x: 0, y: 0, width: DOC_W, height: 6 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    handleQuickSelectDown(makeCtx({ canvasPos: { x: 2, y: 2 } }));
+    expect(editorState.clearSelection).toHaveBeenCalledTimes(1);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+});
+
+describe('quick select move', () => {
+  it('grows the stroke mask into newly visited regions', () => {
+    handleQuickSelectDown(makeCtx({ canvasPos: { x: 2, y: 2 } }));
+    editorState.setSelection.mockClear();
+    handleQuickSelectMove(makeState(), { x: 2, y: 9 });
+    const mask = lastSetSelectionMask();
+    expect(mask[2 * DOC_W + 2]).toBe(255); // red band from the down
+    expect(mask[9 * DOC_W + 2]).toBe(255); // blue band from the move
+  });
+
+  it('does nothing without an active session', () => {
+    handleQuickSelectMove(makeState(), { x: 5, y: 5 });
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('does nothing after the stroke is finished', () => {
+    handleQuickSelectDown(makeCtx());
+    handleQuickSelectUp();
+    editorState.setSelection.mockClear();
+    handleQuickSelectMove(makeState(), { x: 2, y: 9 });
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/shape/shape-interaction.test.ts
+++ b/src/tools/shape/shape-interaction.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const renderShape = vi.fn();
+const renderShapeExpanded = vi.fn();
+const saveShapePreview = vi.fn();
+const endShapePreview = vi.fn();
+const getLayerEngineBounds = vi.fn((..._args: unknown[]): Int32Array => new Int32Array(0));
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  renderShape: (...args: unknown[]) => renderShape(...args),
+  renderShapeExpanded: (...args: unknown[]) => renderShapeExpanded(...args),
+  saveShapePreview: (...args: unknown[]) => saveShapePreview(...args),
+  endShapePreview: (...args: unknown[]) => endShapePreview(...args),
+  getLayerEngineBounds: (...args: unknown[]) => getLayerEngineBounds(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const clearJsPixelData = vi.fn();
+vi.mock('../../app/store/clear-js-pixel-data', () => ({
+  clearJsPixelData: (...args: unknown[]) => clearJsPixelData(...args),
+}));
+
+const pixelDataManagerRemove = vi.fn();
+vi.mock('../../engine/pixel-data-manager', () => ({
+  pixelDataManager: { remove: (...args: unknown[]) => pixelDataManagerRemove(...args) },
+}));
+
+interface MockLayer {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+const DOC_W = 200;
+const DOC_H = 200;
+
+const editorState = {
+  document: {
+    width: DOC_W,
+    height: DOC_H,
+    layers: [{ id: 'layer-1', type: 'raster', x: 0, y: 0, width: DOC_W, height: DOC_H }] as MockLayer[],
+  },
+  dirtyLayerIds: new Set<string>(),
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+  undo: vi.fn(),
+  addPath: vi.fn(),
+};
+const setState = vi.fn((update: Partial<typeof editorState>) => {
+  Object.assign(editorState, update);
+});
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: {
+    getState: () => editorState,
+    setState: (update: Partial<typeof editorState>) => setState(update),
+  },
+}));
+
+import type { ShapeSizeClick } from '../../app/ui-store';
+
+const uiState = {
+  setPendingShapeClick: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+import type { Color } from '../../types';
+
+const ts = {
+  shapeMode: 'ellipse' as 'ellipse' | 'polygon',
+  shapeOutput: 'pixels' as 'pixels' | 'path',
+  shapeFillColor: { r: 255, g: 0, b: 0, a: 1 } as Color | null,
+  shapeStrokeColor: { r: 0, g: 0, b: 255, a: 0.5 } as Color | null,
+  shapeStrokeWidth: 2,
+  shapePolygonSides: 5,
+  shapeCornerRadius: 0,
+  aspectRatioLocked: false,
+  aspectRatioW: 1,
+  aspectRatioH: 1,
+  addRecentColor: vi.fn(),
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import {
+  handleShapeDown,
+  handleShapeMove,
+  handleShapeUp,
+  confirmShapeSize,
+} from './shape-interaction';
+import type { PathAnchor } from '../path/path';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 50, y: 50 },
+    layerPos: { x: 50, y: 50 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 50, y: 50 },
+    layerId: 'layer-1',
+    tool: 'shape',
+    startPoint: { x: 50, y: 50 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  renderShape.mockClear();
+  renderShapeExpanded.mockClear();
+  saveShapePreview.mockClear();
+  endShapePreview.mockClear();
+  getLayerEngineBounds.mockReset();
+  // Default: engine bounds match the layer exactly, so no sync is needed.
+  getLayerEngineBounds.mockReturnValue(new Int32Array([0, 0, DOC_W, DOC_H]));
+  clearJsPixelData.mockClear();
+  pixelDataManagerRemove.mockClear();
+  editorState.document = {
+    width: DOC_W,
+    height: DOC_H,
+    layers: [{ id: 'layer-1', type: 'raster', x: 0, y: 0, width: DOC_W, height: DOC_H }],
+  };
+  editorState.dirtyLayerIds = new Set<string>();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  editorState.undo.mockClear();
+  editorState.addPath.mockClear();
+  setState.mockClear();
+  uiState.setPendingShapeClick.mockClear();
+  ts.shapeMode = 'ellipse';
+  ts.shapeOutput = 'pixels';
+  ts.shapeFillColor = { r: 255, g: 0, b: 0, a: 1 };
+  ts.shapeStrokeColor = { r: 0, g: 0, b: 255, a: 0.5 };
+  ts.shapeStrokeWidth = 2;
+  ts.shapePolygonSides = 5;
+  ts.shapeCornerRadius = 0;
+  ts.aspectRatioLocked = false;
+  ts.addRecentColor.mockClear();
+});
+
+describe('shape down', () => {
+  it('pushes history, snapshots the preview, and anchors at the layer point', () => {
+    const layer = { id: 'layer-1', x: 30, y: 40, visible: true } as unknown as InteractionContext['activeLayer'];
+    const state = handleShapeDown(makeCtx({ layerPos: { x: 15, y: 25 }, activeLayer: layer }));
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Shape');
+    expect(saveShapePreview).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+    expect(ts.addRecentColor).toHaveBeenCalledWith({ r: 255, g: 0, b: 0, a: 1 });
+    expect(ts.addRecentColor).toHaveBeenCalledWith({ r: 0, g: 0, b: 255, a: 0.5 });
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'shape',
+      startPoint: { x: 15, y: 25 },
+      layerStartX: 30,
+      layerStartY: 40,
+    });
+  });
+
+  it('does not record recent colors when fill and stroke are disabled', () => {
+    ts.shapeFillColor = null;
+    ts.shapeStrokeColor = null;
+    handleShapeDown(makeCtx());
+    expect(ts.addRecentColor).not.toHaveBeenCalled();
+  });
+
+  it('still returns a state without snapshotting when no engine exists', () => {
+    engine = null;
+    const state = handleShapeDown(makeCtx());
+    expect(saveShapePreview).not.toHaveBeenCalled();
+    expect(state.tool).toBe('shape');
+  });
+});
+
+describe('shape move', () => {
+  it('renders an ellipse centered at the start point with drag-derived size', () => {
+    handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 70 });
+    expect(renderShape).toHaveBeenCalledTimes(1);
+    const args = renderShape.mock.calls[0]!;
+    // (engine, layerId, mode, cx, cy, w, h, fill rgba, stroke rgba, sw, sides, cornerRadius)
+    expect(args[1]).toBe('layer-1');
+    expect(args[2]).toBe(0); // ellipse
+    expect(args[3]).toBe(50);
+    expect(args[4]).toBe(50);
+    expect(args[5]).toBe(60); // rx 30 * 2
+    expect(args[6]).toBe(40); // ry 20 * 2
+    expect(args[7]).toBe(1); // fill r
+    expect(args[8]).toBe(0);
+    expect(args[9]).toBe(0);
+    expect(args[10]).toBe(1); // fill a
+    expect(args[11]).toBe(0); // stroke r
+    expect(args[14]).toBe(0.5); // stroke a
+    expect(args[15]).toBe(2); // stroke width
+    expect(args[16]).toBe(5); // sides
+    expect(args[17]).toBe(0); // corner radius
+    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('translates the center into document space for an offset layer', () => {
+    handleShapeMove(
+      makeState({ startPoint: { x: 50, y: 50 }, layerStartX: 100, layerStartY: 200 }),
+      { x: 80, y: 70 },
+    );
+    const args = renderShape.mock.calls[0]!;
+    expect(args[3]).toBe(150);
+    expect(args[4]).toBe(250);
+  });
+
+  it('renders polygons with mode 1', () => {
+    ts.shapeMode = 'polygon';
+    handleShapeMove(makeState(), { x: 80, y: 70 });
+    expect(renderShape.mock.calls[0]![2]).toBe(1);
+  });
+
+  it('meta key constrains the shape to a circle', () => {
+    handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 60 }, true);
+    const args = renderShape.mock.calls[0]!;
+    // rx 30, ry 10 constrained to ratio 1 => both radii become 10.
+    expect(args[5]).toBe(20);
+    expect(args[6]).toBe(20);
+  });
+
+  it('honors a locked aspect ratio from tool settings', () => {
+    ts.aspectRatioLocked = true;
+    ts.aspectRatioW = 2;
+    ts.aspectRatioH = 1;
+    handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 90, y: 60 });
+    const args = renderShape.mock.calls[0]!;
+    // rx 40 / ry 10 = 4 > 2, so rx shrinks to ry * 2 = 20.
+    expect(args[5]).toBe(40);
+    expect(args[6]).toBe(20);
+  });
+
+  it('caps the corner radius at half the smaller dimension', () => {
+    ts.shapeCornerRadius = 50;
+    handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 60 });
+    // w 60, h 20 => cap is 10.
+    expect(renderShape.mock.calls[0]![17]).toBe(10);
+  });
+
+  it('renders a transparent fill when the fill color is disabled', () => {
+    ts.shapeFillColor = null;
+    handleShapeMove(makeState(), { x: 80, y: 70 });
+    const args = renderShape.mock.calls[0]!;
+    expect(args[7]).toBe(0);
+    expect(args[10]).toBe(0); // fill alpha 0
+  });
+
+  it('ignores sub-pixel drags', () => {
+    handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 50.5, y: 80 });
+    expect(renderShape).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an engine', () => {
+    engine = null;
+    handleShapeMove(makeState(), { x: 80, y: 70 });
+    expect(renderShape).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a start point', () => {
+    handleShapeMove(makeState({ startPoint: null }), { x: 80, y: 70 });
+    expect(renderShape).not.toHaveBeenCalled();
+  });
+});
+
+describe('shape up — click vs drag', () => {
+  it('a sub-4px gesture undoes the preview and asks for an explicit size', () => {
+    handleShapeUp(
+      makeState({ startPoint: { x: 50, y: 50 }, layerStartX: 7, layerStartY: 9 }),
+      { x: 52, y: 52 },
+    );
+    expect(endShapePreview).toHaveBeenCalledTimes(1);
+    expect(editorState.undo).toHaveBeenCalledTimes(1);
+    expect(uiState.setPendingShapeClick).toHaveBeenCalledWith({
+      center: { x: 50, y: 50 },
+      layerId: 'layer-1',
+      layerX: 7,
+      layerY: 9,
+    });
+    expect(renderShapeExpanded).not.toHaveBeenCalled();
+  });
+
+  it('a click in path-output mode undoes without opening the size modal', () => {
+    ts.shapeOutput = 'path';
+    handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 51, y: 51 });
+    expect(editorState.undo).toHaveBeenCalledTimes(1);
+    expect(uiState.setPendingShapeClick).not.toHaveBeenCalled();
+    expect(editorState.addPath).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a start point', () => {
+    handleShapeUp(makeState({ startPoint: null }), { x: 80, y: 70 });
+    expect(endShapePreview).not.toHaveBeenCalled();
+    expect(editorState.undo).not.toHaveBeenCalled();
+  });
+});
+
+describe('shape up — committing pixels', () => {
+  it('a drag fully inside the document keeps the preview render as-is', () => {
+    handleShapeUp(makeState({ startPoint: { x: 100, y: 100 } }), { x: 130, y: 120 });
+    expect(endShapePreview).toHaveBeenCalledTimes(1);
+    expect(editorState.undo).not.toHaveBeenCalled();
+    expect(renderShapeExpanded).not.toHaveBeenCalled();
+    expect(getLayerEngineBounds).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+    expect(uiState.setPendingShapeClick).not.toHaveBeenCalled();
+  });
+
+  it('re-renders expanded when the shape overflows the document bounds', () => {
+    // Center (20, 100) with rx 40 + stroke 2 extends past the left edge.
+    handleShapeUp(makeState({ startPoint: { x: 20, y: 100 } }), { x: 60, y: 120 });
+    expect(renderShapeExpanded).toHaveBeenCalledTimes(1);
+    const args = renderShapeExpanded.mock.calls[0]!;
+    expect(args[1]).toBe('layer-1');
+    expect(args[3]).toBe(20); // doc-space cx
+    expect(args[4]).toBe(100);
+    expect(args[5]).toBe(80); // rx 40 * 2
+    expect(args[6]).toBe(40); // ry 20 * 2
+  });
+
+  it('syncs moved layer bounds from the engine after the commit', () => {
+    getLayerEngineBounds.mockReturnValue(new Int32Array([-5, -3, 210, 208]));
+    handleShapeUp(makeState({ startPoint: { x: 100, y: 100 } }), { x: 130, y: 120 });
+    expect(setState).toHaveBeenCalledTimes(1);
+    const layer = editorState.document.layers.find((l) => l.id === 'layer-1')!;
+    expect(layer).toMatchObject({ x: -5, y: -3, width: 210, height: 208 });
+    expect(pixelDataManagerRemove).toHaveBeenCalledWith('layer-1');
+    expect(editorState.dirtyLayerIds.has('layer-1')).toBe(true);
+  });
+
+  it('leaves the store untouched when the engine bounds already match', () => {
+    handleShapeUp(makeState({ startPoint: { x: 100, y: 100 } }), { x: 130, y: 120 });
+    expect(setState).not.toHaveBeenCalled();
+    expect(pixelDataManagerRemove).not.toHaveBeenCalled();
+  });
+
+  it('applies the meta constraint when deciding overflow and committing', () => {
+    // Unconstrained rx 95 would overflow; constrained to ry 10 it fits.
+    handleShapeUp(makeState({ startPoint: { x: 100, y: 100 } }), { x: 195, y: 110 }, true);
+    expect(renderShapeExpanded).not.toHaveBeenCalled();
+  });
+
+  it('skips all engine work when no engine is available', () => {
+    engine = null;
+    handleShapeUp(makeState({ startPoint: { x: 100, y: 100 } }), { x: 130, y: 120 });
+    expect(endShapePreview).not.toHaveBeenCalled();
+    expect(getLayerEngineBounds).not.toHaveBeenCalled();
+    expect(renderShapeExpanded).not.toHaveBeenCalled();
+  });
+});
+
+describe('shape up — path output', () => {
+  beforeEach(() => {
+    ts.shapeOutput = 'path';
+  });
+
+  it('undoes the raster preview and adds a closed ellipse path', () => {
+    handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 70 });
+    expect(editorState.undo).toHaveBeenCalledTimes(1);
+    expect(editorState.addPath).toHaveBeenCalledTimes(1);
+    const [anchors, closed] = editorState.addPath.mock.calls[0]! as [PathAnchor[], boolean];
+    expect(closed).toBe(true);
+    expect(anchors).toHaveLength(4);
+    // Ellipse centered (50,50), rx 30, ry 20: top, right, bottom, left.
+    expect(anchors[0]!.point).toEqual({ x: 50, y: 30 });
+    expect(anchors[1]!.point).toEqual({ x: 80, y: 50 });
+    expect(anchors[2]!.point).toEqual({ x: 50, y: 70 });
+    expect(anchors[3]!.point).toEqual({ x: 20, y: 50 });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('emits the path in document space for an offset layer', () => {
+    handleShapeUp(
+      makeState({ startPoint: { x: 50, y: 50 }, layerStartX: 100, layerStartY: 200 }),
+      { x: 80, y: 70 },
+    );
+    const [anchors] = editorState.addPath.mock.calls[0]! as [PathAnchor[]];
+    expect(anchors[0]!.point).toEqual({ x: 150, y: 230 });
+  });
+
+  it('adds a polygon path with one anchor per side', () => {
+    ts.shapeMode = 'polygon';
+    ts.shapePolygonSides = 3;
+    handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 70 });
+    const [anchors] = editorState.addPath.mock.calls[0]! as [PathAnchor[]];
+    expect(anchors).toHaveLength(3);
+    // First vertex points straight up from the center.
+    expect(anchors[0]!.point.x).toBeCloseTo(50);
+    expect(anchors[0]!.point.y).toBeCloseTo(30);
+    expect(anchors[0]!.handleIn).toBeNull();
+  });
+
+  it('drops a path that the meta constraint collapsed to nothing', () => {
+    // Horizontal drag with meta: ry 0 forces rx to 0 as well.
+    handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 55, y: 50 }, true);
+    expect(editorState.undo).toHaveBeenCalledTimes(1);
+    expect(editorState.addPath).not.toHaveBeenCalled();
+  });
+});
+
+describe('confirmShapeSize', () => {
+  const click: ShapeSizeClick = {
+    center: { x: 30, y: 20 },
+    layerId: 'layer-1',
+    layerX: 5,
+    layerY: 7,
+  };
+
+  it('renders the shape at the click center with the requested dimensions', () => {
+    confirmShapeSize(60, 40, click);
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Shape');
+    expect(ts.addRecentColor).toHaveBeenCalledWith({ r: 255, g: 0, b: 0, a: 1 });
+    expect(renderShapeExpanded).toHaveBeenCalledTimes(1);
+    const args = renderShapeExpanded.mock.calls[0]!;
+    expect(args[1]).toBe('layer-1');
+    expect(args[3]).toBe(35); // 30 + layerX 5
+    expect(args[4]).toBe(27); // 20 + layerY 7
+    expect(args[5]).toBe(60);
+    expect(args[6]).toBe(40);
+    expect(getLayerEngineBounds).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('caps the corner radius at half the smaller dimension', () => {
+    ts.shapeCornerRadius = 100;
+    confirmShapeSize(60, 40, click);
+    expect(renderShapeExpanded.mock.calls[0]![17]).toBe(20);
+  });
+
+  it('pushes history but renders nothing without an engine', () => {
+    engine = null;
+    confirmShapeSize(60, 40, click);
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Shape');
+    expect(renderShapeExpanded).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/smudge/smudge-interaction.test.ts
+++ b/src/tools/smudge/smudge-interaction.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const applySmudgeDab = vi.fn();
+const applySmudgeDabBatch = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  applySmudgeDab: (...args: unknown[]) => applySmudgeDab(...args),
+  applySmudgeDabBatch: (...args: unknown[]) => applySmudgeDabBatch(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  settings: { smudge: { size: 40, strength: 50 } },
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleSmudgeDown, handleSmudgeMove } from './smudge-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 10, y: 10 },
+    layerPos: { x: 10, y: 10 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 10, y: 10 },
+    layerId: 'layer-1',
+    tool: 'smudge',
+    startPoint: null,
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  applySmudgeDab.mockClear();
+  applySmudgeDabBatch.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.settings.smudge = { size: 40, strength: 50 };
+});
+
+describe('smudge down', () => {
+  it('applies a no-op first dab where prev equals current position', () => {
+    const state = handleSmudgeDown(makeCtx({ layerPos: { x: 12, y: 34 } }));
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Smudge');
+    expect(applySmudgeDab).toHaveBeenCalledTimes(1);
+    const args = applySmudgeDab.mock.calls[0]!;
+    // (engine, layerId, prevX, prevY, x, y, size, strength)
+    expect(args[2]).toBe(12);
+    expect(args[3]).toBe(34);
+    expect(args[4]).toBe(12);
+    expect(args[5]).toBe(34);
+    expect(args[6]).toBe(40);
+    expect(args[7]).toBeCloseTo(0.5);
+    expect(state).toMatchObject({ drawing: true, tool: 'smudge', lastPoint: { x: 12, y: 34 } });
+  });
+
+  it('shift-click pulls the smudge along the full line from the last paint point', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 20, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'layer-1' } },
+    });
+    handleSmudgeDown(ctx);
+    expect(applySmudgeDab).not.toHaveBeenCalled();
+    const pts = applySmudgeDabBatch.mock.calls[0]![2] as Float64Array;
+    // Leading pair is the stroke origin, then dabs at spacing 10: x=10, 20.
+    expect(Array.from(pts)).toEqual([0, 0, 10, 0, 20, 0]);
+  });
+
+  it('shift-click from another layer behaves like a fresh dab', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 20, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'other' } },
+    });
+    handleSmudgeDown(ctx);
+    expect(applySmudgeDab).toHaveBeenCalledTimes(1);
+    expect(applySmudgeDabBatch).not.toHaveBeenCalled();
+  });
+
+  it('returns a state without painting when no engine is available', () => {
+    engine = null;
+    const state = handleSmudgeDown(makeCtx());
+    expect(state.tool).toBe('smudge');
+    expect(applySmudgeDab).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).not.toHaveBeenCalled();
+  });
+});
+
+describe('smudge move', () => {
+  it('prepends the previous point so the smudge drags continuously', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleSmudgeMove(state, { x: 30, y: 0 });
+    const pts = applySmudgeDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([0, 0, 10, 0, 20, 0, 30, 0]);
+    expect(state.lastPoint).toEqual({ x: 30, y: 0 });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('short moves still carry the prev point plus the destination', () => {
+    const state = makeState({ lastPoint: { x: 5, y: 5 } });
+    handleSmudgeMove(state, { x: 7, y: 5 });
+    const pts = applySmudgeDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([5, 5, 7, 5]);
+  });
+
+  it('passes the strength as a 0..1 fraction', () => {
+    ts.settings.smudge.strength = 80;
+    handleSmudgeMove(makeState({ lastPoint: { x: 0, y: 0 } }), { x: 10, y: 0 });
+    expect(applySmudgeDabBatch.mock.calls[0]![4]).toBeCloseTo(0.8);
+  });
+
+  it('does nothing without a lastPoint', () => {
+    handleSmudgeMove(makeState({ lastPoint: null }), { x: 10, y: 0 });
+    expect(applySmudgeDabBatch).not.toHaveBeenCalled();
+  });
+
+  it('tracks the point without painting when no engine is available', () => {
+    engine = null;
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleSmudgeMove(state, { x: 10, y: 0 });
+    expect(applySmudgeDabBatch).not.toHaveBeenCalled();
+    expect(state.lastPoint).toEqual({ x: 10, y: 0 });
+  });
+});

--- a/src/tools/sponge/sponge-interaction.test.ts
+++ b/src/tools/sponge/sponge-interaction.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const beginSpongeStroke = vi.fn();
+const applySpongeDabBatch = vi.fn();
+const endSpongeStroke = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  beginSpongeStroke: (...args: unknown[]) => beginSpongeStroke(...args),
+  applySpongeDabBatch: (...args: unknown[]) => applySpongeDabBatch(...args),
+  endSpongeStroke: (...args: unknown[]) => endSpongeStroke(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const setPendingSpongeStroke = vi.fn();
+const clearPendingSpongeStroke = vi.fn();
+vi.mock('../../app/interactions/pending-stroke', () => ({
+  setPendingSpongeStroke: (...args: unknown[]) => setPendingSpongeStroke(...args),
+  clearPendingSpongeStroke: (...args: unknown[]) => clearPendingSpongeStroke(...args),
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  settings: { sponge: { mode: 'saturate' as 'saturate' | 'desaturate', strength: 100, size: 40 } },
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleSpongeDown, handleSpongeMove, handleSpongeUp } from './sponge-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 5, y: 7, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 20, y: 20 },
+    layerPos: { x: 15, y: 13 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 15, y: 13 },
+    layerId: 'layer-1',
+    tool: 'sponge',
+    startPoint: null,
+    layerStartX: 5,
+    layerStartY: 7,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  beginSpongeStroke.mockClear();
+  applySpongeDabBatch.mockClear();
+  endSpongeStroke.mockClear();
+  setPendingSpongeStroke.mockClear();
+  clearPendingSpongeStroke.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.settings.sponge = { mode: 'saturate', strength: 100, size: 40 };
+});
+
+describe('sponge down', () => {
+  it('begins a saturate stroke and applies a single dab at the layer point', () => {
+    const state = handleSpongeDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Saturate');
+    expect(beginSpongeStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 0);
+    expect(setPendingSpongeStroke).toHaveBeenCalledWith('layer-1');
+    const [, , pts, size, hardness, strength] = applySpongeDabBatch.mock.calls[0]! as
+      [unknown, string, Float64Array, number, number, number];
+    expect(Array.from(pts)).toEqual([15, 13]);
+    expect(size).toBe(40);
+    expect(hardness).toBe(0.5);
+    // strength = (100/100)^2 * 0.25
+    expect(strength).toBeCloseTo(0.25);
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'sponge',
+      lastPoint: { x: 15, y: 13 },
+      layerStartX: 5,
+      layerStartY: 7,
+    });
+  });
+
+  it('uses mode 1 and a Desaturate history label in desaturate mode', () => {
+    ts.settings.sponge.mode = 'desaturate';
+    handleSpongeDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Desaturate');
+    expect(beginSpongeStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 1);
+  });
+
+  it('squares the strength setting (50% => 6.25% effective)', () => {
+    ts.settings.sponge.strength = 50;
+    handleSpongeDown(makeCtx());
+    const strength = applySpongeDabBatch.mock.calls[0]![5] as number;
+    expect(strength).toBeCloseTo(0.5 * 0.5 * 0.25);
+  });
+
+  it('shift-click draws a connecting line from the last paint point', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 100, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'layer-1' } },
+    });
+    handleSpongeDown(ctx);
+    const pts = applySpongeDabBatch.mock.calls[0]![2] as Float64Array;
+    // spacing = 40 * 0.25 = 10 over a 100px line => 10 interpolated dabs
+    expect(pts.length).toBe(20);
+    expect(pts[0]).toBeCloseTo(10);
+    expect(pts[pts.length - 2]).toBeCloseTo(100);
+    expect(pts[pts.length - 1]).toBeCloseTo(0);
+  });
+
+  it('shift-click on a different layer falls back to a single dab', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 100, y: 0 },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'other-layer' } },
+    });
+    handleSpongeDown(ctx);
+    const pts = applySpongeDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([100, 0]);
+  });
+
+  it('still returns an interaction state when no engine is available', () => {
+    engine = null;
+    const state = handleSpongeDown(makeCtx());
+    expect(state.drawing).toBe(true);
+    expect(beginSpongeStroke).not.toHaveBeenCalled();
+    expect(setPendingSpongeStroke).not.toHaveBeenCalled();
+  });
+});
+
+describe('sponge move', () => {
+  it('interpolates dabs from the previous point and advances lastPoint', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleSpongeMove(state, { x: 30, y: 0 });
+    const pts = applySpongeDabBatch.mock.calls[0]![2] as Float64Array;
+    // spacing 10 over 30px => 3 dabs at x = 10, 20, 30
+    expect(Array.from(pts)).toEqual([10, 0, 20, 0, 30, 0]);
+    expect(state.lastPoint).toEqual({ x: 30, y: 0 });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('emits the destination dab even for a short move', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleSpongeMove(state, { x: 2, y: 0 });
+    const pts = applySpongeDabBatch.mock.calls[0]![2] as Float64Array;
+    expect(Array.from(pts)).toEqual([2, 0]);
+  });
+
+  it('does nothing without a lastPoint', () => {
+    handleSpongeMove(makeState({ lastPoint: null }), { x: 30, y: 0 });
+    expect(applySpongeDabBatch).not.toHaveBeenCalled();
+  });
+
+  it('skips the GPU call but tracks the point when no engine is available', () => {
+    engine = null;
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleSpongeMove(state, { x: 30, y: 0 });
+    expect(applySpongeDabBatch).not.toHaveBeenCalled();
+    expect(state.lastPoint).toEqual({ x: 30, y: 0 });
+  });
+});
+
+describe('sponge up', () => {
+  it('ends the stroke and clears the pending-stroke registry', () => {
+    handleSpongeUp(makeState());
+    expect(endSpongeStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1');
+    expect(clearPendingSpongeStroke).toHaveBeenCalledTimes(1);
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('does nothing without a layer id', () => {
+    handleSpongeUp(makeState({ layerId: null }));
+    expect(endSpongeStroke).not.toHaveBeenCalled();
+    expect(clearPendingSpongeStroke).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an engine', () => {
+    engine = null;
+    handleSpongeUp(makeState());
+    expect(endSpongeStroke).not.toHaveBeenCalled();
+    expect(clearPendingSpongeStroke).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/spray/spray-interaction.test.ts
+++ b/src/tools/spray/spray-interaction.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const applyBrushDab = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  applyBrushDab: (...args: unknown[]) => applyBrushDab(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  spraySize: 40,
+  sprayDensity: 12,
+  sprayOpacity: 60,
+  sprayHardness: 30,
+  foregroundColor: { r: 255, g: 0, b: 0, a: 1 },
+  addRecentColor: vi.fn(),
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleSprayDown, handleSprayMove, handleSprayUp } from './spray-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 100, y: 100 },
+    layerPos: { x: 100, y: 100 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  engine = { __engine: 'mock' };
+  applyBrushDab.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.addRecentColor.mockClear();
+  ts.foregroundColor = { r: 255, g: 0, b: 0, a: 1 };
+  ts.sprayDensity = 12;
+  ts.spraySize = 40;
+});
+
+afterEach(() => {
+  // Always stop the module-level interval so it cannot leak across tests.
+  handleSprayUp();
+  vi.useRealTimers();
+});
+
+describe('spray down', () => {
+  it('pushes history and immediately emits one dab per density unit', () => {
+    const state = handleSprayDown(makeCtx());
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Spray');
+    expect(ts.addRecentColor).toHaveBeenCalledWith({ r: 255, g: 0, b: 0, a: 1 });
+    expect(applyBrushDab).toHaveBeenCalledTimes(12);
+    expect(state?.tool).toBe('spray');
+    expect(state?.lastPoint).toEqual({ x: 100, y: 100 });
+    expect(state?.strokeColor).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+  });
+
+  it('scatters dabs within the brush radius around the cursor', () => {
+    handleSprayDown(makeCtx({ layerPos: { x: 100, y: 100 } }));
+    const brushRadius = ts.spraySize / 2;
+    for (const call of applyBrushDab.mock.calls) {
+      const x = call[2] as number;
+      const y = call[3] as number;
+      const dist = Math.hypot(x - 100, y - 100);
+      expect(dist).toBeLessThanOrEqual(brushRadius + 0.001);
+    }
+  });
+
+  it('passes normalized color, hardness and capped opacity to each dab', () => {
+    handleSprayDown(makeCtx());
+    for (const call of applyBrushDab.mock.calls) {
+      expect(call[5]).toBeCloseTo(0.3); // hardness 30%
+      expect(call[6]).toBe(1); // r
+      expect(call[7]).toBe(0); // g
+      expect(call[8]).toBe(0); // b
+      expect(call[9]).toBe(1); // a
+      const opacity = call[10] as number;
+      expect(opacity).toBeGreaterThan(0);
+      expect(opacity).toBeLessThanOrEqual(0.6); // base opacity 60%
+    }
+  });
+
+  it('keeps spraying at the cursor while the pointer is held still', () => {
+    handleSprayDown(makeCtx());
+    applyBrushDab.mockClear();
+    vi.advanceTimersByTime(166);
+    expect(applyBrushDab).toHaveBeenCalledTimes(12);
+    vi.advanceTimersByTime(166 * 2);
+    expect(applyBrushDab).toHaveBeenCalledTimes(36);
+  });
+
+  it('returns a state without dabs or timer when no engine is available', () => {
+    engine = null;
+    const state = handleSprayDown(makeCtx());
+    expect(state?.tool).toBe('spray');
+    expect(applyBrushDab).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(applyBrushDab).not.toHaveBeenCalled();
+  });
+});
+
+describe('spray move', () => {
+  it('emits dab clusters along the drag path', () => {
+    const state = handleSprayDown(makeCtx({ layerPos: { x: 0, y: 0 } }))!;
+    applyBrushDab.mockClear();
+    // spacing = size * 0.3 = 12; a 36px drag => 3 interpolation steps
+    handleSprayMove(makeCtx({ layerPos: { x: 36, y: 0 } }), state);
+    expect(applyBrushDab).toHaveBeenCalledTimes(3 * 12);
+    expect(state.lastPoint).toEqual({ x: 36, y: 0 });
+  });
+
+  it('a short move only advances the anchor without spraying', () => {
+    const state = handleSprayDown(makeCtx({ layerPos: { x: 0, y: 0 } }))!;
+    applyBrushDab.mockClear();
+    handleSprayMove(makeCtx({ layerPos: { x: 5, y: 0 } }), state);
+    expect(applyBrushDab).not.toHaveBeenCalled();
+    expect(state.lastPoint).toEqual({ x: 5, y: 0 });
+  });
+
+  it('keeps using the color captured at stroke start', () => {
+    const state = handleSprayDown(makeCtx({ layerPos: { x: 0, y: 0 } }))!;
+    applyBrushDab.mockClear();
+    ts.foregroundColor = { r: 0, g: 255, b: 0, a: 1 };
+    handleSprayMove(makeCtx({ layerPos: { x: 36, y: 0 } }), state);
+    expect(applyBrushDab.mock.calls[0]![6]).toBe(1); // still red
+    expect(applyBrushDab.mock.calls[0]![7]).toBe(0);
+  });
+
+  it('does nothing when the stroke has no layer', () => {
+    const state = handleSprayDown(makeCtx({ layerPos: { x: 0, y: 0 } }))!;
+    applyBrushDab.mockClear();
+    handleSprayMove(makeCtx({ layerPos: { x: 36, y: 0 } }), { ...state, layerId: null } as InteractionState);
+    expect(applyBrushDab).not.toHaveBeenCalled();
+  });
+});
+
+describe('spray up', () => {
+  it('stops the held-position spray timer', () => {
+    handleSprayDown(makeCtx());
+    applyBrushDab.mockClear();
+    handleSprayUp();
+    vi.advanceTimersByTime(166 * 5);
+    expect(applyBrushDab).not.toHaveBeenCalled();
+  });
+
+  it('a new stroke after up restarts the interval spray', () => {
+    handleSprayDown(makeCtx());
+    handleSprayUp();
+    handleSprayDown(makeCtx());
+    applyBrushDab.mockClear();
+    vi.advanceTimersByTime(166);
+    expect(applyBrushDab).toHaveBeenCalledTimes(12);
+  });
+});

--- a/src/tools/stamp/stamp-interaction.test.ts
+++ b/src/tools/stamp/stamp-interaction.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const applyStampDab = vi.fn();
+const applyStampDabBatch = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  applyStampDab: (...args: unknown[]) => applyStampDab(...args),
+  applyStampDabBatch: (...args: unknown[]) => applyStampDabBatch(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const editorState = {
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  settings: { stamp: { size: 40 } },
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { handleStampDown, handleStampMove } from './stamp-interaction';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+import type { Point } from '../../types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 50, y: 50 },
+    layerPos: { x: 50, y: 50 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null as Point | null },
+    stampOffsetRef: { current: null as Point | null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 50, y: 50 },
+    layerId: 'layer-1',
+    tool: 'stamp',
+    startPoint: { x: 50, y: 50 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  applyStampDab.mockClear();
+  applyStampDabBatch.mockClear();
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  ts.settings.stamp.size = 40;
+});
+
+describe('stamp down — source picking', () => {
+  it('alt-click records the source point without painting', () => {
+    const ctx = makeCtx({ altKey: true, layerPos: { x: 10, y: 20 } });
+    const result = handleStampDown(ctx);
+    expect(result).toBeUndefined();
+    expect(ctx.stampSourceRef.current).toEqual({ x: 10, y: 20 });
+    expect(ctx.stampOffsetRef.current).toBeNull();
+    expect(applyStampDab).not.toHaveBeenCalled();
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+  });
+
+  it('meta-click also records the source point', () => {
+    const ctx = makeCtx({ metaKey: true, layerPos: { x: 3, y: 4 } });
+    handleStampDown(ctx);
+    expect(ctx.stampSourceRef.current).toEqual({ x: 3, y: 4 });
+  });
+
+  it('re-picking the source resets a previously locked offset', () => {
+    const ctx = makeCtx({
+      altKey: true,
+      layerPos: { x: 1, y: 1 },
+      stampOffsetRef: { current: { x: -5, y: -5 } },
+    });
+    handleStampDown(ctx);
+    expect(ctx.stampOffsetRef.current).toBeNull();
+  });
+
+  it('painting without a source does nothing', () => {
+    const result = handleStampDown(makeCtx());
+    expect(result).toBeUndefined();
+    expect(applyStampDab).not.toHaveBeenCalled();
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+  });
+});
+
+describe('stamp down — painting', () => {
+  it('first paint click locks the offset as source minus click and dabs once', () => {
+    const ctx = makeCtx({
+      layerPos: { x: 50, y: 60 },
+      stampSourceRef: { current: { x: 10, y: 20 } },
+    });
+    const state = handleStampDown(ctx);
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Clone Stamp');
+    expect(ctx.stampOffsetRef.current).toEqual({ x: -40, y: -40 });
+    expect(applyStampDab).toHaveBeenCalledTimes(1);
+    const args = applyStampDab.mock.calls[0]!;
+    // (engine, layerId, x, y, offsetX, offsetY, size)
+    expect(args[1]).toBe('layer-1');
+    expect(args[2]).toBe(50);
+    expect(args[3]).toBe(60);
+    expect(args[4]).toBe(-40);
+    expect(args[5]).toBe(-40);
+    expect(args[6]).toBe(40);
+    expect(state).toMatchObject({ drawing: true, tool: 'stamp', startPoint: { x: 50, y: 60 } });
+  });
+
+  it('subsequent clicks reuse the locked offset instead of recomputing it', () => {
+    const ctx = makeCtx({
+      layerPos: { x: 80, y: 80 },
+      stampSourceRef: { current: { x: 10, y: 20 } },
+      stampOffsetRef: { current: { x: -40, y: -40 } },
+    });
+    handleStampDown(ctx);
+    expect(ctx.stampOffsetRef.current).toEqual({ x: -40, y: -40 });
+    const args = applyStampDab.mock.calls[0]!;
+    expect(args[4]).toBe(-40);
+    expect(args[5]).toBe(-40);
+  });
+
+  it('shift-click clones along a line from the last paint point', () => {
+    const ctx = makeCtx({
+      shiftKey: true,
+      layerPos: { x: 20, y: 0 },
+      stampSourceRef: { current: { x: 0, y: 0 } },
+      stampOffsetRef: { current: { x: -5, y: -5 } },
+      lastPaintPointRef: { current: { point: { x: 0, y: 0 }, layerId: 'layer-1' } },
+    });
+    handleStampDown(ctx);
+    expect(applyStampDab).not.toHaveBeenCalled();
+    expect(applyStampDabBatch).toHaveBeenCalledTimes(1);
+    const [, , pts, ox, oy, size] = applyStampDabBatch.mock.calls[0]! as
+      [unknown, string, Float64Array, number, number, number];
+    // spacing = 40 * 0.25 = 10 over 20px => dabs at x = 10, 20
+    expect(Array.from(pts)).toEqual([10, 0, 20, 0]);
+    expect(ox).toBe(-5);
+    expect(oy).toBe(-5);
+    expect(size).toBe(40);
+  });
+
+  it('returns a state without painting when no engine is available', () => {
+    engine = null;
+    const ctx = makeCtx({ stampSourceRef: { current: { x: 0, y: 0 } } });
+    const state = handleStampDown(ctx);
+    expect(state?.tool).toBe('stamp');
+    expect(applyStampDab).not.toHaveBeenCalled();
+  });
+});
+
+describe('stamp move', () => {
+  it('interpolates dabs with the locked offset and advances lastPoint', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleStampMove(state, { x: 30, y: 0 }, { current: { x: -7, y: 9 } });
+    const [, , pts, ox, oy] = applyStampDabBatch.mock.calls[0]! as
+      [unknown, string, Float64Array, number, number];
+    expect(Array.from(pts)).toEqual([10, 0, 20, 0, 30, 0]);
+    expect(ox).toBe(-7);
+    expect(oy).toBe(9);
+    expect(state.lastPoint).toEqual({ x: 30, y: 0 });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('does nothing without a locked offset', () => {
+    const state = makeState({ lastPoint: { x: 0, y: 0 } });
+    handleStampMove(state, { x: 30, y: 0 }, { current: null });
+    expect(applyStampDabBatch).not.toHaveBeenCalled();
+    expect(state.lastPoint).toEqual({ x: 0, y: 0 });
+  });
+
+  it('does nothing without a lastPoint', () => {
+    handleStampMove(makeState({ lastPoint: null }), { x: 30, y: 0 }, { current: { x: 0, y: 0 } });
+    expect(applyStampDabBatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/text/text-interaction.test.ts
+++ b/src/tools/text/text-interaction.test.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const setTextLayerContent = vi.fn();
+const renderTextLayer = vi.fn((..._args: unknown[]): Float32Array => new Float32Array(0));
+const getRenderedTextPixels = vi.fn((..._args: unknown[]): Uint8Array => new Uint8Array(0));
+const uploadLayerPixels = vi.fn();
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  setTextLayerContent: (...args: unknown[]) => setTextLayerContent(...args),
+  renderTextLayer: (...args: unknown[]) => renderTextLayer(...args),
+  getRenderedTextPixels: (...args: unknown[]) => getRenderedTextPixels(...args),
+  uploadLayerPixels: (...args: unknown[]) => uploadLayerPixels(...args),
+}));
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const clearJsPixelData = vi.fn();
+vi.mock('../../app/store/clear-js-pixel-data', () => ({
+  clearJsPixelData: (...args: unknown[]) => clearJsPixelData(...args),
+}));
+
+import type { TextEditingState } from '../../app/ui-store';
+
+const uiState = {
+  textEditing: null as TextEditingState | null,
+  commitTextEditing: vi.fn(() => { uiState.textEditing = null; }),
+  startTextEditing: vi.fn((s: TextEditingState) => { uiState.textEditing = s; }),
+  setTextDrag: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+import type { Layer, TextLayer } from '../../types';
+
+const editorState = {
+  document: { width: 400, height: 300, layers: [] as Layer[] },
+  pushHistory: vi.fn(),
+  notifyRender: vi.fn(),
+  removeLayer: vi.fn(),
+  updateTextLayerProperties: vi.fn(),
+  setActiveLayer: vi.fn(),
+  addTextLayer: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const ts = {
+  foregroundColor: { r: 255, g: 128, b: 0, a: 1 },
+  textFontFamily: 'Inter',
+  textFontSize: 24,
+  textFontWeight: 400,
+  textFontStyle: 'normal' as 'normal' | 'italic',
+  textAlign: 'left' as 'left' | 'center' | 'right' | 'justify',
+  textUnderline: false,
+  textStrikethrough: false,
+  addRecentColor: vi.fn(),
+  setTextFontSize: vi.fn(),
+  setTextFontFamily: vi.fn(),
+  setTextFontWeight: vi.fn(),
+  setTextFontStyle: vi.fn(),
+  setTextAlign: vi.fn(),
+  setForegroundColor: vi.fn(),
+  setTextUnderline: vi.fn(),
+  setTextStrikethrough: vi.fn(),
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import {
+  handleTextDown,
+  handleTextMove,
+  handleTextUp,
+  commitTextEditing,
+} from './text-interaction';
+import { DEFAULT_EFFECTS } from '../../layers/layer-model';
+import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
+
+function makeTextLayer(overrides: Partial<TextLayer> = {}): TextLayer {
+  return {
+    id: 'text-1',
+    name: 'Text 1',
+    type: 'text',
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blendMode: 'normal',
+    x: 100,
+    y: 50,
+    clipToBelow: false,
+    effects: DEFAULT_EFFECTS,
+    mask: null,
+    text: 'Hello',
+    fontFamily: 'Inter',
+    fontSize: 24,
+    fontWeight: 400,
+    fontStyle: 'normal',
+    color: { r: 10, g: 20, b: 30, a: 1 },
+    lineHeight: 1.4,
+    letterSpacing: 0,
+    textAlign: 'left',
+    width: null,
+    underline: false,
+    strikethrough: false,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 10, y: 10 },
+    layerPos: { x: 10, y: 10 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  return {
+    drawing: true,
+    lastPoint: { x: 10, y: 10 },
+    layerId: 'layer-1',
+    tool: 'text',
+    startPoint: { x: 10, y: 10 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    ...overrides,
+  };
+}
+
+function editingState(overrides: Partial<TextEditingState> = {}): TextEditingState {
+  return {
+    layerId: 'text-1',
+    bounds: { x: 30, y: 40, width: null, height: null },
+    text: 'New text',
+    cursorPos: 8,
+    isNew: false,
+    originalVisible: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  engine = { __engine: 'mock' };
+  setTextLayerContent.mockClear();
+  renderTextLayer.mockReset();
+  renderTextLayer.mockReturnValue(new Float32Array(0));
+  getRenderedTextPixels.mockReset();
+  getRenderedTextPixels.mockReturnValue(new Uint8Array(0));
+  uploadLayerPixels.mockClear();
+  clearJsPixelData.mockClear();
+  uiState.textEditing = null;
+  uiState.commitTextEditing.mockClear();
+  uiState.startTextEditing.mockClear();
+  uiState.setTextDrag.mockClear();
+  editorState.document = { width: 400, height: 300, layers: [] };
+  editorState.pushHistory.mockClear();
+  editorState.notifyRender.mockClear();
+  editorState.removeLayer.mockClear();
+  editorState.updateTextLayerProperties.mockClear();
+  editorState.setActiveLayer.mockClear();
+  editorState.addTextLayer.mockClear();
+  ts.addRecentColor.mockClear();
+  ts.setTextFontSize.mockClear();
+  ts.setTextFontFamily.mockClear();
+  ts.setTextFontWeight.mockClear();
+  ts.setTextFontStyle.mockClear();
+  ts.setTextAlign.mockClear();
+  ts.setForegroundColor.mockClear();
+  ts.setTextUnderline.mockClear();
+  ts.setTextStrikethrough.mockClear();
+  ts.foregroundColor = { r: 255, g: 128, b: 0, a: 1 };
+});
+
+describe('text down — new text drag', () => {
+  it('anchors a text drag at the click point on blank canvas', () => {
+    const layer = { id: 'layer-1', x: 7, y: 9, visible: true } as unknown as InteractionContext['activeLayer'];
+    const state = handleTextDown(makeCtx({ canvasPos: { x: 25, y: 35 }, activeLayer: layer }));
+    expect(uiState.setTextDrag).toHaveBeenCalledWith({
+      startX: 25,
+      startY: 35,
+      currentX: 25,
+      currentY: 35,
+    });
+    expect(state).toMatchObject({
+      drawing: true,
+      tool: 'text',
+      startPoint: { x: 25, y: 35 },
+      layerStartX: 7,
+      layerStartY: 9,
+    });
+    expect(uiState.startTextEditing).not.toHaveBeenCalled();
+  });
+
+  it('commits an active editing session instead of starting a new one', () => {
+    uiState.textEditing = editingState({ layerId: 'ghost' });
+    const result = handleTextDown(makeCtx());
+    expect(result).toBeUndefined();
+    expect(uiState.commitTextEditing).toHaveBeenCalledTimes(1);
+    expect(uiState.setTextDrag).not.toHaveBeenCalled();
+    expect(uiState.startTextEditing).not.toHaveBeenCalled();
+  });
+});
+
+describe('text down — clicking an existing text layer', () => {
+  it('enters edit mode and pulls the layer typography into tool settings', () => {
+    const layer = makeTextLayer({
+      fontSize: 36,
+      fontFamily: 'Georgia',
+      fontWeight: 700,
+      fontStyle: 'italic',
+      textAlign: 'center',
+      underline: true,
+      strikethrough: true,
+    });
+    editorState.document.layers = [layer];
+    // Hit region: x 100..100+5*36*0.6, y 50..50+36*1.4
+    const result = handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    expect(result).toBeUndefined();
+    expect(ts.setTextFontSize).toHaveBeenCalledWith(36);
+    expect(ts.setTextFontFamily).toHaveBeenCalledWith('Georgia');
+    expect(ts.setTextFontWeight).toHaveBeenCalledWith(700);
+    expect(ts.setTextFontStyle).toHaveBeenCalledWith('italic');
+    expect(ts.setTextAlign).toHaveBeenCalledWith('center');
+    expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 10, g: 20, b: 30, a: 1 });
+    expect(ts.setTextUnderline).toHaveBeenCalledWith(true);
+    expect(ts.setTextStrikethrough).toHaveBeenCalledWith(true);
+    expect(editorState.setActiveLayer).toHaveBeenCalledWith('text-1');
+    expect(clearJsPixelData).toHaveBeenCalledWith('text-1');
+    expect(uiState.startTextEditing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layerId: 'text-1',
+        text: 'Hello',
+        cursorPos: 5,
+        isNew: false,
+        originalVisible: true,
+      }),
+    );
+    expect(uiState.setTextDrag).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('recovers the original click anchor via the engine layout offsets', () => {
+    editorState.document.layers = [makeTextLayer()];
+    // (width, height, offsetX, offsetY) from the Rust layout pass.
+    renderTextLayer.mockReturnValue(new Float32Array([80, 30, 6, 9]));
+    handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    const editing = uiState.startTextEditing.mock.calls[0]![0];
+    expect(editing.bounds.x).toBe(94); // 100 - 6
+    expect(editing.bounds.y).toBe(41); // 50 - 9
+    const props = JSON.parse(setTextLayerContent.mock.calls[0]![2] as string) as {
+      text: string;
+      areaWidth: number | null;
+    };
+    expect(props.text).toBe('Hello');
+    expect(props.areaWidth).toBeNull();
+  });
+
+  it('uses the raw layer position when no engine is available', () => {
+    engine = null;
+    editorState.document.layers = [makeTextLayer()];
+    handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    expect(setTextLayerContent).not.toHaveBeenCalled();
+    const editing = uiState.startTextEditing.mock.calls[0]![0];
+    expect(editing.bounds.x).toBe(100);
+    expect(editing.bounds.y).toBe(50);
+  });
+
+  it('skips the engine measurement for whitespace-only text', () => {
+    editorState.document.layers = [makeTextLayer({ text: ' ' })];
+    handleTextDown(makeCtx({ canvasPos: { x: 105, y: 60 } }));
+    expect(setTextLayerContent).not.toHaveBeenCalled();
+    expect(uiState.startTextEditing).toHaveBeenCalledWith(
+      expect.objectContaining({ bounds: expect.objectContaining({ x: 100, y: 50 }) }),
+    );
+  });
+
+  it('ignores invisible text layers and starts a drag instead', () => {
+    editorState.document.layers = [makeTextLayer({ visible: false })];
+    const state = handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    expect(state?.drawing).toBe(true);
+    expect(uiState.setTextDrag).toHaveBeenCalledTimes(1);
+    expect(uiState.startTextEditing).not.toHaveBeenCalled();
+  });
+
+  it('ignores locked text layers and starts a drag instead', () => {
+    editorState.document.layers = [makeTextLayer({ locked: true })];
+    const state = handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    expect(state?.drawing).toBe(true);
+    expect(uiState.startTextEditing).not.toHaveBeenCalled();
+  });
+
+  it('hits the topmost of two overlapping text layers', () => {
+    editorState.document.layers = [
+      makeTextLayer({ id: 'below' }),
+      makeTextLayer({ id: 'above' }),
+    ];
+    handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
+    expect(editorState.setActiveLayer).toHaveBeenCalledWith('above');
+  });
+});
+
+describe('text move', () => {
+  it('stretches the drag rectangle from the anchor to the cursor', () => {
+    handleTextMove(makeState({ startPoint: { x: 10, y: 20 } }), { x: 50, y: 60 });
+    expect(uiState.setTextDrag).toHaveBeenCalledWith({
+      startX: 10,
+      startY: 20,
+      currentX: 50,
+      currentY: 60,
+    });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('does nothing without a start point', () => {
+    handleTextMove(makeState({ startPoint: null }), { x: 50, y: 60 });
+    expect(uiState.setTextDrag).not.toHaveBeenCalled();
+  });
+});
+
+describe('text up', () => {
+  it('a click creates a point-text layer (no width) and opens editing', () => {
+    const state = makeState({ startPoint: { x: 40, y: 40 } });
+    handleTextUp(state, { x: 40, y: 40 });
+    expect(uiState.setTextDrag).toHaveBeenCalledWith(null);
+    expect(editorState.addTextLayer).toHaveBeenCalledTimes(1);
+    const added = editorState.addTextLayer.mock.calls[0]![0] as TextLayer;
+    expect(added).toMatchObject({
+      type: 'text',
+      x: 40,
+      y: 40,
+      width: null,
+      text: '',
+      visible: true,
+      fontFamily: 'Inter',
+      fontSize: 24,
+      name: 'Text 1',
+    });
+    expect(uiState.startTextEditing).toHaveBeenCalledWith({
+      layerId: added.id,
+      bounds: { x: 40, y: 40, width: null, height: null },
+      text: '',
+      cursorPos: 0,
+      isNew: true,
+      originalVisible: true,
+    });
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('a move of exactly the 4px threshold still counts as a click', () => {
+    handleTextUp(makeState({ startPoint: { x: 40, y: 40 } }), { x: 44, y: 44 });
+    const added = editorState.addTextLayer.mock.calls[0]![0] as TextLayer;
+    expect(added.width).toBeNull();
+    expect(added.x).toBe(40);
+  });
+
+  it('a drag past the threshold creates area text sized by the drag', () => {
+    handleTextUp(makeState({ startPoint: { x: 100, y: 80 } }), { x: 160, y: 120 });
+    const added = editorState.addTextLayer.mock.calls[0]![0] as TextLayer;
+    expect(added).toMatchObject({ x: 100, y: 80, width: 60 });
+    expect(uiState.startTextEditing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bounds: { x: 100, y: 80, width: 60, height: 40 },
+        isNew: true,
+      }),
+    );
+  });
+
+  it('normalizes a reversed drag to the top-left corner', () => {
+    handleTextUp(makeState({ startPoint: { x: 160, y: 120 } }), { x: 100, y: 80 });
+    const added = editorState.addTextLayer.mock.calls[0]![0] as TextLayer;
+    expect(added).toMatchObject({ x: 100, y: 80, width: 60 });
+  });
+
+  it('names new layers sequentially from the layer count', () => {
+    editorState.document.layers = [makeTextLayer(), makeTextLayer({ id: 'text-2' })];
+    handleTextUp(makeState({ startPoint: { x: 200, y: 200 } }), { x: 200, y: 200 });
+    const added = editorState.addTextLayer.mock.calls[0]![0] as TextLayer;
+    expect(added.name).toBe('Text 3');
+  });
+
+  it('does nothing without a start point', () => {
+    handleTextUp(makeState({ startPoint: null }), { x: 40, y: 40 });
+    expect(uiState.setTextDrag).not.toHaveBeenCalled();
+    expect(editorState.addTextLayer).not.toHaveBeenCalled();
+  });
+});
+
+describe('commitTextEditing', () => {
+  it('does nothing when no editing session is active', () => {
+    commitTextEditing();
+    expect(uiState.commitTextEditing).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).not.toHaveBeenCalled();
+  });
+
+  it('only re-renders when the edited layer no longer exists', () => {
+    uiState.textEditing = editingState({ layerId: 'ghost' });
+    commitTextEditing();
+    expect(uiState.commitTextEditing).toHaveBeenCalledTimes(1);
+    expect(editorState.removeLayer).not.toHaveBeenCalled();
+    expect(editorState.updateTextLayerProperties).not.toHaveBeenCalled();
+    expect(editorState.notifyRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a brand-new layer when no text was entered', () => {
+    editorState.document.layers = [makeTextLayer()];
+    uiState.textEditing = editingState({ text: '   ', isNew: true });
+    commitTextEditing();
+    expect(editorState.removeLayer).toHaveBeenCalledWith('text-1');
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+  });
+
+  it('restores visibility on an existing layer when text was cleared', () => {
+    editorState.document.layers = [makeTextLayer()];
+    uiState.textEditing = editingState({ text: '', isNew: false, originalVisible: false });
+    commitTextEditing();
+    expect(editorState.removeLayer).not.toHaveBeenCalled();
+    expect(editorState.updateTextLayerProperties).toHaveBeenCalledWith('text-1', { visible: false });
+  });
+
+  it('renders via the engine and positions the layer at bounds plus layout offset', () => {
+    editorState.document.layers = [makeTextLayer()];
+    uiState.textEditing = editingState({
+      bounds: { x: 30, y: 40, width: 200, height: null },
+      text: 'New text',
+    });
+    renderTextLayer.mockReturnValue(new Float32Array([120, 50, 4, 6]));
+    getRenderedTextPixels.mockReturnValue(new Uint8Array(120 * 50 * 4));
+
+    commitTextEditing();
+
+    const props = JSON.parse(setTextLayerContent.mock.calls[0]![2] as string) as {
+      text: string;
+      fontFamily: string;
+      fontSize: number;
+      color: number[];
+      areaWidth: number | null;
+      textAlign: string;
+    };
+    expect(props.text).toBe('New text');
+    expect(props.fontFamily).toBe('Inter');
+    expect(props.fontSize).toBe(24);
+    expect(props.color).toEqual([1, 128 / 255, 0, 1]);
+    expect(props.areaWidth).toBe(200);
+
+    // (engine, layerId, pixels, width, height, x, y)
+    const up = uploadLayerPixels.mock.calls[0]!;
+    expect(up[1]).toBe('text-1');
+    expect(up[3]).toBe(120);
+    expect(up[4]).toBe(50);
+    expect(up[5]).toBe(34); // 30 + offsetX 4
+    expect(up[6]).toBe(46); // 40 + offsetY 6
+
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Text');
+    expect(ts.addRecentColor).toHaveBeenCalledWith({ r: 255, g: 128, b: 0, a: 1 });
+    expect(editorState.updateTextLayerProperties).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({
+        text: 'New text',
+        x: 34,
+        y: 46,
+        width: 200,
+        visible: true,
+        color: { r: 255, g: 128, b: 0, a: 1 },
+      }),
+    );
+    expect(editorState.notifyRender).toHaveBeenCalled();
+  });
+
+  it('keeps the bounds position when the engine returns no pixels', () => {
+    editorState.document.layers = [makeTextLayer()];
+    uiState.textEditing = editingState({ bounds: { x: 30, y: 40, width: null, height: null } });
+    renderTextLayer.mockReturnValue(new Float32Array([120, 50, 4, 6]));
+    getRenderedTextPixels.mockReturnValue(new Uint8Array(0));
+    commitTextEditing();
+    expect(uploadLayerPixels).not.toHaveBeenCalled();
+    expect(editorState.updateTextLayerProperties).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({ x: 30, y: 40 }),
+    );
+  });
+
+  it('falls back to the layer position when no engine is available', () => {
+    engine = null;
+    editorState.document.layers = [makeTextLayer({ x: 12, y: 34 })];
+    uiState.textEditing = editingState();
+    commitTextEditing();
+    expect(setTextLayerContent).not.toHaveBeenCalled();
+    expect(editorState.updateTextLayerProperties).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({ x: 12, y: 34 }),
+    );
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Text');
+  });
+
+  it('skips the WASM render for path-bound text and pins it to the origin', () => {
+    editorState.document.layers = [makeTextLayer({ pathId: 'path-1' })];
+    uiState.textEditing = editingState();
+    commitTextEditing();
+    expect(setTextLayerContent).not.toHaveBeenCalled();
+    expect(uploadLayerPixels).not.toHaveBeenCalled();
+    expect(editorState.updateTextLayerProperties).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({ x: 0, y: 0 }),
+    );
+  });
+
+  it('clears the editing session first so a second commit is a no-op', () => {
+    editorState.document.layers = [makeTextLayer()];
+    uiState.textEditing = editingState();
+    commitTextEditing();
+    commitTextEditing();
+    expect(editorState.pushHistory).toHaveBeenCalledTimes(1);
+    expect(uiState.commitTextEditing).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/wand/wand-strategy.test.ts
+++ b/src/tools/wand/wand-strategy.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const floodFill = vi.fn();
+const floodFillGraduated = vi.fn();
+const readLayerPixelsForFill = vi.fn();
+
+// selection-handlers (imported by the strategy) pulls in every selection
+// strategy, so the mock must cover the whole graph. Mask helpers throw so
+// the pure TS fallbacks run and real mask contents can be asserted.
+vi.mock('../../engine-wasm/wasm-bridge', () => {
+  const wasmThrow = (): never => {
+    throw new Error('wasm unavailable in test');
+  };
+  return {
+    createRectSelection: wasmThrow,
+    createEllipseSelection: wasmThrow,
+    selectionBounds: wasmThrow,
+    createPolygonMask: wasmThrow,
+    setSelectionMask: vi.fn(),
+    featherSelectionMask: vi.fn(),
+    readSelectionMask: vi.fn(),
+    hasFloat: vi.fn(() => false),
+    dropFloat: vi.fn(),
+    floodFill: (...args: unknown[]) => floodFill(...args),
+    floodFillGraduated: (...args: unknown[]) => floodFillGraduated(...args),
+    readLayerPixelsForFill: (...args: unknown[]) => readLayerPixelsForFill(...args),
+    magneticLassoBegin: vi.fn(),
+    magneticLassoSnap: vi.fn(),
+    magneticLassoSnapPoint: vi.fn(),
+    magneticLassoEnd: vi.fn(),
+  };
+});
+
+let engine: { __engine: string } | null = { __engine: 'mock' };
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => engine,
+}));
+
+const DOC_W = 8;
+const DOC_H = 8;
+
+const editorState = {
+  document: { width: DOC_W, height: DOC_H, layers: [] as unknown[] },
+  selection: {
+    active: false,
+    mask: null as Uint8ClampedArray | null,
+    bounds: null as { x: number; y: number; width: number; height: number } | null,
+    maskWidth: 0,
+    maskHeight: 0,
+  },
+  setSelection: vi.fn(),
+  clearSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../../app/editor-store', () => ({
+  useEditorStore: { getState: () => editorState },
+}));
+
+const uiState = {
+  setTransform: vi.fn(),
+};
+vi.mock('../../app/ui-store', () => ({
+  useUIStore: { getState: () => uiState },
+}));
+
+const ts = {
+  settings: {
+    marquee: { feather: 0 },
+    wand: { tolerance: 40, contiguous: true, graduated: false },
+  },
+};
+vi.mock('../../app/tool-settings-store', () => ({
+  useToolSettingsStore: { getState: () => ts },
+}));
+
+import { wandStrategy } from './wand-strategy';
+import type { InteractionContext } from '../../app/interactions/interaction-types';
+
+function makeCtx(overrides: Partial<InteractionContext> = {}): InteractionContext {
+  const layer = { id: 'layer-1', x: 0, y: 0, visible: true } as unknown as InteractionContext['activeLayer'];
+  return {
+    canvasPos: { x: 2.4, y: 2.6 },
+    layerPos: { x: 2.4, y: 2.6 },
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    activeLayerId: 'layer-1',
+    activeLayer: layer,
+    clientX: 0,
+    clientY: 0,
+    stateRef: { current: {} } as unknown as InteractionContext['stateRef'],
+    floatingSelectionRef: { current: null },
+    persistentTransformRef: { current: null },
+    stampSourceRef: { current: null },
+    stampOffsetRef: { current: null },
+    lastPaintPointRef: { current: null },
+    ...overrides,
+  };
+}
+
+/** A wand result mask covering the 2x2 block at (2,2)..(3,3). */
+function wandResultMask(): Uint8Array {
+  const m = new Uint8Array(DOC_W * DOC_H);
+  for (const [x, y] of [[2, 2], [3, 2], [2, 3], [3, 3]]) {
+    m[y! * DOC_W + x!] = 255;
+  }
+  return m;
+}
+
+describe('wand strategy', () => {
+  beforeEach(() => {
+    floodFill.mockReset();
+    floodFillGraduated.mockReset();
+    readLayerPixelsForFill.mockReset();
+    editorState.setSelection.mockClear();
+    editorState.clearSelection.mockClear();
+    uiState.setTransform.mockClear();
+    engine = { __engine: 'mock' };
+    editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+    ts.settings.wand = { tolerance: 40, contiguous: true, graduated: false };
+    readLayerPixelsForFill.mockReturnValue(new Uint8Array(DOC_W * DOC_H * 4));
+    floodFill.mockReturnValue(wandResultMask());
+    floodFillGraduated.mockReturnValue(wandResultMask());
+  });
+
+  it('returns undefined without an engine and leaves the selection untouched', () => {
+    engine = null;
+    const result = wandStrategy.onDown(makeCtx(), 'wand');
+    expect(result).toBeUndefined();
+    expect(floodFill).not.toHaveBeenCalled();
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('flood-fills at the rounded click point with the configured tolerance', () => {
+    wandStrategy.onDown(makeCtx({ canvasPos: { x: 2.4, y: 2.6 } }), 'wand');
+    expect(floodFill).toHaveBeenCalledTimes(1);
+    const args = floodFill.mock.calls[0]!;
+    // (pixels, docW, docH, cx, cy, r, g, b, a, tolerance, contiguous)
+    expect(args[1]).toBe(DOC_W);
+    expect(args[2]).toBe(DOC_H);
+    expect(args[3]).toBe(2);
+    expect(args[4]).toBe(3);
+    expect(args[9]).toBe(40);
+    expect(args[10]).toBe(true);
+  });
+
+  it('commits the wand mask as the selection with correct bounds', () => {
+    wandStrategy.onDown(makeCtx(), 'wand');
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(bounds).toEqual({ x: 2, y: 2, width: 2, height: 2 });
+    expect(mask[2 * DOC_W + 2]).toBe(255);
+    expect(mask[0]).toBe(0);
+    expect(uiState.setTransform).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the graduated flood fill when the setting is enabled', () => {
+    ts.settings.wand.graduated = true;
+    wandStrategy.onDown(makeCtx(), 'wand');
+    expect(floodFillGraduated).toHaveBeenCalledTimes(1);
+    expect(floodFill).not.toHaveBeenCalled();
+  });
+
+  it('shift-click adds the wand result to the existing selection', () => {
+    const existing = new Uint8ClampedArray(DOC_W * DOC_H);
+    existing[0] = 255; // pixel (0,0) already selected
+    editorState.selection = {
+      active: true,
+      mask: existing,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    wandStrategy.onDown(makeCtx({ shiftKey: true }), 'wand');
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(mask[0]).toBe(255); // old selection kept
+    expect(mask[2 * DOC_W + 2]).toBe(255); // new region added
+    expect(bounds).toEqual({ x: 0, y: 0, width: 4, height: 4 });
+  });
+
+  it('alt-click subtracts the wand result from the existing selection', () => {
+    const existing = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
+    editorState.selection = {
+      active: true,
+      mask: existing,
+      bounds: { x: 0, y: 0, width: DOC_W, height: DOC_H },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    wandStrategy.onDown(makeCtx({ altKey: true }), 'wand');
+    const [, mask] = editorState.setSelection.mock.calls[0]! as [
+      unknown,
+      Uint8ClampedArray,
+    ];
+    expect(mask[2 * DOC_W + 2]).toBe(0); // subtracted
+    expect(mask[0]).toBe(255); // rest preserved
+  });
+
+  it('replaces the existing selection when no modifier is held', () => {
+    const existing = new Uint8ClampedArray(DOC_W * DOC_H);
+    existing[0] = 255;
+    editorState.selection = {
+      active: true,
+      mask: existing,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      maskWidth: DOC_W,
+      maskHeight: DOC_H,
+    };
+    wandStrategy.onDown(makeCtx(), 'wand');
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(mask[0]).toBe(0); // old selection replaced, not merged
+    expect(bounds).toEqual({ x: 2, y: 2, width: 2, height: 2 });
+  });
+
+  it('ignores an existing mask whose dimensions do not match the document', () => {
+    editorState.selection = {
+      active: true,
+      mask: new Uint8ClampedArray(4 * 4).fill(255),
+      bounds: { x: 0, y: 0, width: 4, height: 4 },
+      maskWidth: 4,
+      maskHeight: 4,
+    };
+    wandStrategy.onDown(makeCtx({ shiftKey: true }), 'wand');
+    const [bounds] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+    ];
+    // No combine happened — just the wand result.
+    expect(bounds).toEqual({ x: 2, y: 2, width: 2, height: 2 });
+  });
+
+  it('clears the selection when the wand finds nothing', () => {
+    floodFill.mockReturnValue(new Uint8Array(DOC_W * DOC_H));
+    wandStrategy.onDown(makeCtx(), 'wand');
+    expect(editorState.clearSelection).toHaveBeenCalledTimes(1);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds unit-test coverage for all 17 previously untested tool interaction handlers in `src/tools/`. Tests follow the established mocking pattern from `gradient-interaction.test.ts` / `healing-interaction.test.ts`: the real handler runs against mocked `wasm-bridge` / `engine-state` / store boundaries, and assertions check concrete behavior — coordinates passed to the GPU, emitted operations, mask contents, state transitions, modifier handling, and cancel/edge paths. No production code changes.

## Coverage added (tests per file)

| File | Tests | What is covered |
| --- | --- | --- |
| `src/tools/crop/crop-interaction.test.ts` | 14 | drag anchor, normalization, doc clamping, aspect lock, zero-size drag, degenerate rect discard, perspective-mode routing |
| `src/tools/crop/perspective-crop-interaction.test.ts` | 15 | quad seeding, corner grabbing with zoom-scaled hit radius, corner drag (incl. negative coords), commit warp output pixels, layer-local quad translation, unreadable-layer skip |
| `src/tools/dodge/dodge-interaction.test.ts` | 11 | stroke begin/dab/end lifecycle, dodge vs burn mode, shift-click line connect, quarter-size dab spacing, no-engine guards |
| `src/tools/eyedropper/eyedropper-interaction.test.ts` | 7 | sample coordinates, alpha normalization, layer-offset translation on move, short-result and no-engine guards |
| `src/tools/fill/fill-interaction.test.ts` | 9 | flood-fill args (rounded coords, tolerance, color), layer-offset translation, selection intersection/veto, quick-mask and layer-mask routing |
| `src/tools/lasso/lasso-strategy.test.ts` | 5 | trace build, polygon mask commit (real mask contents), <3 points and degenerate polygon rejection |
| `src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts` | 11 | edge-snapped start, contrast threshold conversion, frequency auto-anchor, loop close + mask commit, engine failure guards |
| `src/tools/marquee/marquee-strategy.test.ts` | 17 | rect/ellipse mask contents, reversed-drag normalization, square constrain, aspect lock, grid snap, move-existing-selection translation/clipping, GPU float drop, click-clears-selection |
| `src/tools/path/path-interaction.test.ts` | 23 | anchor placement, close-path radius, handle pull thresholds, anchor/handle/segment hit-testing with zoom scaling, double-click + meta-click spline conversion, drag handle vs anchor, up-state cleanup |
| `src/tools/quick-select/quick-select-interaction.test.ts` | 9 | region seeding from real pixel fixture, add/subtract modes, stroke session growth, finished-session guard |
| `src/tools/smudge/smudge-interaction.test.ts` | 9 | no-op first dab, shift-click line pull, continuous prev-point chaining, strength fraction, no-engine guards |
| `src/tools/sponge/sponge-interaction.test.ts` | 13 | saturate/desaturate modes, squared strength curve, shift-click interpolation, stroke end + pending registry clear |
| `src/tools/spray/spray-interaction.test.ts` | 11 | density dabs per tick, radius scatter bound, held-pointer interval (fake timers), stroke-start color capture, up stops timer |
| `src/tools/stamp/stamp-interaction.test.ts` | 11 | alt/meta source pick, offset locking on first paint, locked-offset reuse, shift-click line clone, move interpolation |
| `src/tools/wand/wand-strategy.test.ts` | 9 | rounded click coords + tolerance, bounds from result mask, graduated mode, shift-add/alt-subtract/replace, mismatched-mask guard, empty-result clear |
| `src/tools/text/text-interaction.test.ts` | 26 | drag-to-create vs click-to-edit dispatch, hit-test ordering/visibility/lock, typography sync into tool settings, click-anchor recovery via engine layout offsets, 4px area-text threshold (incl. exact-threshold edge), reversed-drag normalization, sequential naming, full `commitTextEditing` matrix (engine render + upload position, empty-pixel fallback, no-engine fallback, path-bound text, empty-text cancel for new vs existing layer, missing layer, re-entry guard) |
| `src/tools/shape/shape-interaction.test.ts` | 29 | preview snapshot + history on down, center-out render geometry and color normalization, meta circle constrain, aspect lock, corner-radius cap, sub-pixel drag rejection, click-vs-drag (4px) routing to size modal, document-overflow expanded re-render, engine bounds sync into store (incl. no-op path), path output anchors for ellipse/polygon in document space, degenerate constrained path rejection, `confirmShapeSize` |

**Total: 229 tests across 17 files.**

## Notes

- The 15 inherited handler test files needed minor fixes to pass `tsc`: two `.at(-1)` uses (project lib target predates ES2022) and three typed `vi.fn` mocks that rejected spread forwarding. No assertions were weakened.
- `scripts/check-pixel-debt.mjs`: added the 7 new test files that allocate `Uint8ClampedArray`/`Float32Array`/`ImageData` fixtures to the allowlist's test-fixture section, as the policy in that script directs. No production entries were touched and no budgets were raised.
- Nothing was skipped — all 17 handlers listed for coverage have tests.

## Verification

- `npm run test` — 120 files, **1254 passed**, 0 failed
- `npm run typecheck` — exit 0, no errors
- `npm run lint` — exit 0 (0 errors; pre-existing `no-non-null-assertion` warnings only), pixel-debt check OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)