### PR TITLE
fix(resize): scale sub-document layers by their own dimensions

### DIFF
--- a/src/app/store/actions/resize-image.test.ts
+++ b/src/app/store/actions/resize-image.test.ts
@@ -46,6 +46,27 @@ describe('computeResizeImage', () => {
     expect(layer.y).toBe(8); // 4 * 2
   });
 
+  it('scales a sub-document-sized layer by its own dimensions, not the doc size', () => {
+    // An added layer cropped to its content: a 30x20 region at (10, 6) inside
+    // a 60x60 document. Resizing the doc to 1/3 must shrink the layer too.
+    const layer = { ...createRasterLayer({ name: 'Fill', width: 30, height: 20 }), x: 10, y: 6 };
+    const doc: DocumentState = {
+      id: 'doc-1', name: 'Test', width: 60, height: 60,
+      layers: [layer],
+      layerOrder: [layer.id],
+      activeLayerId: layer.id,
+      selectedLayerIds: [],
+      backgroundColor: { r: 255, g: 255, b: 255, a: 1 },
+    };
+    const result = computeResizeImage(doc, new Map(), 0, 20, 20);
+    const updated = result.document!.layers[0]! as RasterLayer;
+    // scaleX = scaleY = 1/3
+    expect(updated.width).toBe(10); // round(30 / 3)
+    expect(updated.height).toBe(7); // round(20 / 3)
+    expect(updated.x).toBe(3); // round(10 / 3)
+    expect(updated.y).toBe(2); // round(6 / 3)
+  });
+
   it('scales text layer position without converting to raster', () => {
     const textLayer = { ...createTextLayer({ name: 'Text', text: 'Hello' }), x: 4, y: 6 };
     const raster = createRasterLayer({ name: 'Background', width: 10, height: 10 });

--- a/src/app/store/actions/resize-image.ts
+++ b/src/app/store/actions/resize-image.ts
@@ -1,4 +1,5 @@
 import type { DocumentState, Layer } from '../../../types';
+import type { RasterLayer } from '../../../types/layers';
 import type { ActionResult } from '../types';
 import { scaleLayerTexture } from '../../../engine-wasm/wasm-bridge';
 import { mapLayersForTransform } from './_helpers/layer-transform';
@@ -20,15 +21,23 @@ export function computeResizeImage(
       y: Math.round(layer.y * scaleY),
     }) as Layer,
     onRaster: (layer, engine) => {
+      // Raster layers are stored cropped to their content bounds, so their
+      // texture is layer.width x layer.height positioned at (x, y) — not
+      // necessarily the full document. Scale the layer's own dimensions and
+      // position by the document scale factor; substituting the document size
+      // here would stretch a small layer to fill the whole canvas.
+      const raster = layer as RasterLayer;
+      const scaledWidth = Math.max(1, Math.round(raster.width * scaleX));
+      const scaledHeight = Math.max(1, Math.round(raster.height * scaleY));
       if (engine) {
-        scaleLayerTexture(engine, layer.id, newWidth, newHeight);
+        scaleLayerTexture(engine, layer.id, scaledWidth, scaledHeight);
       }
       return {
         ...layer,
         x: Math.round(layer.x * scaleX),
         y: Math.round(layer.y * scaleY),
-        width: newWidth,
-        height: newHeight,
+        width: scaledWidth,
+        height: scaledHeight,
       } as Layer;
     },
   });


### PR DESCRIPTION
## Problem

Resizing the whole image (Image Size) scaled the opened background image correctly, but **added layers did not resize or keep their position**. Repro:

1. Open an image, add a layer
2. Make a rectangle marquee, fill with blue
3. Set blend mode to multiply
4. Resize the image to ⅓ — the background scales, the blue content does not.

## Root cause

`computeResizeImage` assumed *every* raster layer was full-document-size at origin `(0,0)`:

```ts
scaleLayerTexture(engine, layer.id, newWidth, newHeight);   // ← document size
return { ...layer, x: …, y: …, width: newWidth, height: newHeight };
```

That holds for the opened background image, but added layers are stored **cropped to their content bounds** — a filled rectangle becomes a small texture `W×H` at `(x, y)`, not a full-canvas layer. The buggy code then stretched that small content texture to fill the *entire* new canvas and forced `layer.width/height` to the document size. The background worked only because it genuinely *is* doc-sized.

## Fix

Scale each raster layer by its **own** `width/height` and position using the document scale factor — mirroring what `resize-canvas.ts` already does. This keeps the engine texture size consistent with `layer.width × layer.height`, the invariant the rest of the pipeline relies on.

## Test

Adds a regression test for a sub-document-sized layer (30×20 at `(10,6)` in a 60×60 doc, resized to ⅓ → `10×7` at `(3,2)`). Existing tests missed this because their test layer was coincidentally doc-sized (10×10 in a 10×10 doc), where scaling-by-factor and substituting-the-doc-size produce the same number.

## Out of scope

Two adjacent latent issues remain untouched: shape/group layers still pass through `mapLayersForTransform` unscaled, and layer masks aren't resampled on resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)