### PR TITLE
perf(marquee): make drawing/moving selections fast on large canvases

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -23,6 +23,22 @@ When diagnosing perf issues, write a benchmark e2e test that reproduces the exac
 
 ## All pixel manipulation must happen in Rust/WASM engine, never JS Canvas 2D
 
+## Live tool drags must not rebuild/upload a full-res mask per pointer move
+
+`setSelectionMask` (selection_gpu.rs) allocates `vec![0u8; w*h*4]` (a full
+RGBA texture — 48MB on a 12MP canvas) and uploads it every call. Calling
+`setSelection` on each pointer move (as the marquee tool used to) floods the
+WASM bridge and drops to <1fps on large canvases, with seconds of catch-up
+after a fast drag. Fix: drive the live drag from a tiny analytic preview kept
+*outside* the Zustand stores (`src/tools/marquee/marquee-preview.ts`) so
+mutating it doesn't trip the render dirty flag (no GPU recomposite), draw the
+marching ants from geometry on the 2D overlay (`renderMarqueeDraftAnts`), and
+materialize + commit the real mask once on pointer up. The rAF loop animates
+the preview via the overlay-only path (gated on `getMarqueePreview()`).
+`getSelectionEdges`/`traceSelectionContours` also take an optional `scanBounds`
+so they scan only the selection bbox, not the whole canvas — used by lasso/wand
+which still trace per frame.
+
 ## Undo snapshots use normalized u16, not raw FP16 bits
 
 Undo snapshots read GPU RGBA16F textures as normalized u16 (value * 65535) and restore by dividing back (u16 / 65535). This linear encoding can't preserve FP16's extra precision at small magnitudes. Values above ~0.03 round-trip losslessly; darker values can shift by a few FP16 ULPs (worst case ~8 ULPs near 0.001).

--- a/src/app/rendering/render-overlay-frame.ts
+++ b/src/app/rendering/render-overlay-frame.ts
@@ -4,7 +4,9 @@ import { useToolSettingsStore } from '../tool-settings-store';
 import { getBrushCursorInfo } from '../useCanvasCursor';
 import { getEngine } from '../../engine-wasm/engine-state';
 import { renderGrid, renderPixelGrid, renderRulers } from './render-grid';
-import { renderSelectionAnts, renderTransformHandles } from './render-selection';
+import { renderSelectionAnts, renderTransformHandles, renderMarqueeDraftAnts } from './render-selection';
+import { getMarqueePreview } from '../../tools/marquee/marquee-preview';
+import { createTransformState, type TransformState } from '../../tools/transform/transform';
 import { renderMeshWarpOverlay } from './render-mesh-warp';
 import { renderPathOverlay, renderLassoPreview, renderCropPreview, renderGradientPreview, renderBrushCursor, renderSymmetryCenter, renderPerspectiveCropOverlay } from './render-overlays';
 import { renderTextDragOverlay, renderTextEditOverlay, renderTextHoverBounds } from './render-text-overlay';
@@ -76,8 +78,27 @@ export function renderOverlayFrame(overlayCanvas: HTMLCanvasElement, antPhase: n
     renderGrid(overlayCtx, doc.width, doc.height, gridSize, viewport.zoom);
   }
 
-  renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhase, transform);
-  renderTransformHandles(overlayCtx, selection, transform, viewport.zoom);
+  // A live marquee drag renders from its analytic preview (rect/ellipse, or a
+  // translated copy of the committed selection) so it never builds or uploads
+  // a mask mid-drag. The real selection is committed on pointer up.
+  const marqueePreview = getMarqueePreview();
+  if (marqueePreview) {
+    if (marqueePreview.kind === 'move') {
+      if (selection.active) {
+        const moveTransform: TransformState = {
+          ...createTransformState(selection.bounds),
+          translateX: marqueePreview.dx,
+          translateY: marqueePreview.dy,
+        };
+        renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhase, moveTransform);
+      }
+    } else {
+      renderMarqueeDraftAnts(overlayCtx, marqueePreview.rect, marqueePreview.kind, viewport.zoom, antPhase);
+    }
+  } else {
+    renderSelectionAnts(overlayCtx, selection, viewport.zoom, antPhase, transform);
+    renderTransformHandles(overlayCtx, selection, transform, viewport.zoom);
+  }
 
   const meshWarp = uiState.meshWarp;
   if (meshWarp) {

--- a/src/app/rendering/render-selection.ts
+++ b/src/app/rendering/render-selection.ts
@@ -1,12 +1,14 @@
 import { traceSelectionContours } from '../../selection/selection';
 import { getHandlePositions } from '../../tools/transform/transform';
 import type { TransformHandle, TransformState } from '../../tools/transform/transform';
+import type { Rect } from '../../types';
 
 export interface SelectionData {
   active: boolean;
   mask: Uint8ClampedArray | null;
   maskWidth: number;
   maskHeight: number;
+  bounds?: Rect | null;
 }
 
 let cachedMaskRef: Uint8ClampedArray | null = null;
@@ -22,7 +24,7 @@ export function renderSelectionAnts(
   if (!selection.active || !selection.mask) return;
 
   if (selection.mask !== cachedMaskRef) {
-    cachedContours = traceSelectionContours(selection.mask, selection.maskWidth, selection.maskHeight);
+    cachedContours = traceSelectionContours(selection.mask, selection.maskWidth, selection.maskHeight, selection.bounds);
     cachedMaskRef = selection.mask;
   }
 
@@ -66,6 +68,56 @@ export function renderSelectionAnts(
   ctx.lineDashOffset = -offset;
   ctx.strokeStyle = '#ffffff';
   drawContours();
+
+  ctx.restore();
+}
+
+/**
+ * Draw marching ants for an in-progress marquee drag directly from its
+ * rectangle/ellipse geometry — no mask, no contour tracing. Used by the live
+ * preview so a drag never touches a full-resolution buffer or the GPU bridge.
+ */
+export function renderMarqueeDraftAnts(
+  ctx: CanvasRenderingContext2D,
+  rect: Rect,
+  shape: 'rect' | 'ellipse',
+  zoom: number,
+  antPhase: number,
+): void {
+  if (rect.width <= 0 || rect.height <= 0) return;
+
+  ctx.save();
+  ctx.imageSmoothingEnabled = false;
+
+  ctx.lineWidth = 1.5 / zoom;
+  const dashLen = 8 / zoom;
+  const offset = (antPhase % 120) / 120 * dashLen * 2;
+
+  const trace = () => {
+    ctx.beginPath();
+    if (shape === 'ellipse') {
+      ctx.ellipse(
+        rect.x + rect.width / 2,
+        rect.y + rect.height / 2,
+        rect.width / 2,
+        rect.height / 2,
+        0, 0, Math.PI * 2,
+      );
+    } else {
+      ctx.rect(rect.x, rect.y, rect.width, rect.height);
+    }
+  };
+
+  ctx.setLineDash([]);
+  ctx.strokeStyle = '#000000';
+  trace();
+  ctx.stroke();
+
+  ctx.setLineDash([dashLen, dashLen]);
+  ctx.lineDashOffset = -offset;
+  ctx.strokeStyle = '#ffffff';
+  trace();
+  ctx.stroke();
 
   ctx.restore();
 }

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -25,6 +25,7 @@ import {
   markAllLayersDirty,
 } from '../engine-wasm/engine-sync';
 import { renderOverlayFrame } from './rendering/render-overlay-frame';
+import { getMarqueePreview } from '../tools/marquee/marquee-preview';
 import { clearFrameCache } from '../engine-wasm/gpu-pixel-access';
 
 import { expandLayerToDocSize, cropLayerToContent, hasFloat } from '../engine-wasm/wasm-bridge';
@@ -330,7 +331,10 @@ export function useCanvasRendering(
       } else if (!sel.active && selectionActive) {
         selectionActive = false;
       }
-      if (selectionActive || hasTextEditing) {
+      // A live marquee drag animates on the overlay only — it must not force a
+      // GPU recomposite (and it carries no committed selection yet).
+      const hasMarqueePreview = getMarqueePreview() !== null;
+      if (selectionActive || hasTextEditing || hasMarqueePreview) {
         antPhaseRef.current++;
         overlayOnly = true;
       }

--- a/src/selection/selection.test.ts
+++ b/src/selection/selection.test.ts
@@ -181,4 +181,29 @@ describe('getSelectionEdges', () => {
     expect(edges.h.length).toBe(0);
     expect(edges.v.length).toBe(0);
   });
+
+  it('produces identical edges when scan is limited to the content bounds', () => {
+    const W = 64;
+    const H = 64;
+    const cases = [
+      createRectSelection({ x: 10, y: 12, width: 20, height: 15 }, W, H),
+      createEllipseSelection({ x: 8, y: 8, width: 40, height: 30 }, W, H),
+      // Content flush against the canvas edges (top-left corner).
+      createRectSelection({ x: 0, y: 0, width: 12, height: 9 }, W, H),
+      // Content flush against the canvas edges (bottom-right corner).
+      createRectSelection({ x: W - 12, y: H - 9, width: 12, height: 9 }, W, H),
+    ];
+    const bounds = [
+      { x: 10, y: 12, width: 20, height: 15 },
+      { x: 8, y: 8, width: 40, height: 30 },
+      { x: 0, y: 0, width: 12, height: 9 },
+      { x: W - 12, y: H - 9, width: 12, height: 9 },
+    ];
+    for (let i = 0; i < cases.length; i++) {
+      const full = getSelectionEdges(cases[i]!, W, H);
+      const limited = getSelectionEdges(cases[i]!, W, H, bounds[i]);
+      expect(Array.from(limited.h)).toEqual(Array.from(full.h));
+      expect(Array.from(limited.v)).toEqual(Array.from(full.v));
+    }
+  });
 });

--- a/src/selection/selection.ts
+++ b/src/selection/selection.ts
@@ -299,17 +299,29 @@ export function getSelectionEdges(
   mask: Uint8ClampedArray,
   maskWidth: number,
   maskHeight: number,
+  scanBounds?: Rect | null,
 ): { h: Float64Array; v: Float64Array } {
   const threshold = 128;
   const hSegments: number[] = [];
   const vSegments: number[] = [];
 
+  // Limit the edge scan to the selection's bounding box (expanded one pixel
+  // so border pixels still see their unselected neighbour). The mask is zero
+  // outside its content bounds, so scanning a superset region yields
+  // identical edges at a fraction of the cost — without this, a live marquee
+  // drag re-scans the entire canvas every frame and collapses to <1fps on
+  // large documents.
+  const sx0 = scanBounds ? Math.max(0, Math.floor(scanBounds.x) - 1) : 0;
+  const sy0 = scanBounds ? Math.max(0, Math.floor(scanBounds.y) - 1) : 0;
+  const sx1 = scanBounds ? Math.min(maskWidth, Math.ceil(scanBounds.x + scanBounds.width) + 1) : maskWidth;
+  const sy1 = scanBounds ? Math.min(maskHeight, Math.ceil(scanBounds.y + scanBounds.height) + 1) : maskHeight;
+
   // Horizontal edges: scan row by row, merge adjacent segments on the same Y
-  for (let y = 0; y < maskHeight; y++) {
+  for (let y = sy0; y < sy1; y++) {
     let topStart = -1;
     let botStart = -1;
-    for (let x = 0; x <= maskWidth; x++) {
-      const selected = x < maskWidth && (mask[y * maskWidth + x] ?? 0) >= threshold;
+    for (let x = sx0; x <= sx1; x++) {
+      const selected = x < sx1 && (mask[y * maskWidth + x] ?? 0) >= threshold;
       const isTopEdge = selected && (y === 0 || (mask[(y - 1) * maskWidth + x] ?? 0) < threshold);
       const isBotEdge = selected && (y === maskHeight - 1 || (mask[(y + 1) * maskWidth + x] ?? 0) < threshold);
 
@@ -333,11 +345,11 @@ export function getSelectionEdges(
   }
 
   // Vertical edges: scan column by column, merge adjacent segments on the same X
-  for (let x = 0; x < maskWidth; x++) {
+  for (let x = sx0; x < sx1; x++) {
     let leftStart = -1;
     let rightStart = -1;
-    for (let y = 0; y <= maskHeight; y++) {
-      const selected = y < maskHeight && (mask[y * maskWidth + x] ?? 0) >= threshold;
+    for (let y = sy0; y <= sy1; y++) {
+      const selected = y < sy1 && (mask[y * maskWidth + x] ?? 0) >= threshold;
       const isLeftEdge = selected && (x === 0 || (mask[y * maskWidth + x - 1] ?? 0) < threshold);
       const isRightEdge = selected && (x === maskWidth - 1 || (mask[y * maskWidth + x + 1] ?? 0) < threshold);
 
@@ -373,8 +385,9 @@ export function traceSelectionContours(
   mask: Uint8ClampedArray,
   maskWidth: number,
   maskHeight: number,
+  scanBounds?: Rect | null,
 ): number[][] {
-  const edges = getSelectionEdges(mask, maskWidth, maskHeight);
+  const edges = getSelectionEdges(mask, maskWidth, maskHeight, scanBounds);
 
   // Collect all segments
   const segs: Array<[number, number, number, number]> = [];

--- a/src/tools/marquee/marquee-preview.ts
+++ b/src/tools/marquee/marquee-preview.ts
@@ -1,0 +1,27 @@
+import type { Rect } from '../../types';
+
+/**
+ * Live marquee drag preview. While a marquee is being drawn or moved we do
+ * NOT build a full-resolution selection mask or upload it to the GPU on every
+ * pointer move — on a large canvas that floods the WASM bridge (a multi-MB
+ * RGBA texture per event) and collapses to <1fps. Instead the strategy stores
+ * a tiny analytic description here and the overlay renderer draws the marching
+ * ants from geometry. The real mask is materialised once, on pointer up.
+ *
+ * Kept outside the Zustand stores on purpose: mutating it must not trip the
+ * render loop's dirty flag (which would force a full GPU recomposite). The
+ * overlay-only animation path in the rAF loop picks it up each frame.
+ */
+export type MarqueePreview =
+  | { readonly kind: 'rect' | 'ellipse'; readonly rect: Rect }
+  | { readonly kind: 'move'; readonly dx: number; readonly dy: number };
+
+let preview: MarqueePreview | null = null;
+
+export function setMarqueePreview(next: MarqueePreview | null): void {
+  preview = next;
+}
+
+export function getMarqueePreview(): MarqueePreview | null {
+  return preview;
+}

--- a/src/tools/marquee/marquee-strategy.test.ts
+++ b/src/tools/marquee/marquee-strategy.test.ts
@@ -75,6 +75,7 @@ vi.mock('../../app/tool-settings-store', () => ({
 }));
 
 import { marqueeStrategy } from './marquee-strategy';
+import { getMarqueePreview, setMarqueePreview } from './marquee-preview';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 import type { SelectionUpContext } from '../../app/interactions/selection-strategy';
@@ -140,7 +141,15 @@ beforeEach(() => {
   uiState.snapToGrid = false;
   ts.aspectRatioLocked = false;
   ts.settings.marquee.feather = 0;
+  setMarqueePreview(null);
 });
+
+/** Narrow the live preview to its rect/ellipse shape for assertions. */
+function rectPreview(): { x: number; y: number; width: number; height: number } {
+  const p = getMarqueePreview();
+  if (!p || p.kind === 'move') throw new Error('expected a rect/ellipse preview');
+  return p.rect;
+}
 
 describe('marquee onDown', () => {
   it('starts a fresh selection drag outside any existing selection', () => {
@@ -218,41 +227,30 @@ describe('marquee onDown', () => {
 });
 
 describe('marquee onMove — creating a selection', () => {
-  it('builds a rect mask from start to cursor', () => {
+  it('previews a rect from start to cursor without touching the bridge', () => {
     marqueeStrategy.onMove!(makeState(), { x: 30, y: 25 }, false);
-    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
-    const [rect, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-      Uint8ClampedArray,
-      number,
-      number,
-    ];
-    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 15 });
-    expect(w).toBe(DOC_W);
-    expect(h).toBe(DOC_H);
-    expect(mask[12 * DOC_W + 12]).toBe(255); // inside
-    expect(mask[5 * DOC_W + 5]).toBe(0); // outside
-    expect(uiState.setTransform).toHaveBeenCalledTimes(1);
+    // No mask is built and nothing is committed mid-drag.
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    expect(getMarqueePreview()).toEqual({
+      kind: 'rect',
+      rect: { x: 10, y: 10, width: 20, height: 15 },
+    });
   });
 
   it('normalizes a drag up-left of the start point', () => {
     marqueeStrategy.onMove!(makeState({ startPoint: { x: 50, y: 50 } }), { x: 30, y: 40 }, false);
-    const [rect] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-    ];
-    expect(rect).toEqual({ x: 30, y: 40, width: 20, height: 10 });
+    expect(rectPreview()).toEqual({ x: 30, y: 40, width: 20, height: 10 });
   });
 
-  it('does nothing for a zero-size drag', () => {
+  it('clears the preview for a zero-size drag', () => {
     marqueeStrategy.onMove!(makeState(), { x: 10, y: 10 }, false);
+    expect(getMarqueePreview()).toBeNull();
     expect(editorState.setSelection).not.toHaveBeenCalled();
   });
 
   it('meta key constrains the selection to a square', () => {
     marqueeStrategy.onMove!(makeState(), { x: 50, y: 20 }, true);
-    const [rect] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-    ];
+    const rect = rectPreview();
     expect(rect.width).toBe(rect.height);
     expect(rect).toEqual({ x: 10, y: 10, width: 10, height: 10 });
   });
@@ -262,21 +260,16 @@ describe('marquee onMove — creating a selection', () => {
     ts.aspectRatioW = 2;
     ts.aspectRatioH = 1;
     marqueeStrategy.onMove!(makeState(), { x: 50, y: 40 }, false);
-    const [rect] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-    ];
+    const rect = rectPreview();
     expect(rect.width / rect.height).toBeCloseTo(2);
   });
 
-  it('builds an ellipse mask for the ellipse tool', () => {
+  it('previews an ellipse for the ellipse tool', () => {
     marqueeStrategy.onMove!(makeState({ tool: 'marquee-ellipse' }), { x: 30, y: 30 }, false);
-    const [rect, mask] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-      Uint8ClampedArray,
-    ];
-    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 20 });
-    expect(mask[20 * DOC_W + 20]).toBe(255); // center of ellipse
-    expect(mask[10 * DOC_W + 10]).toBe(0); // bounding-box corner is outside
+    expect(getMarqueePreview()).toEqual({
+      kind: 'ellipse',
+      rect: { x: 10, y: 10, width: 20, height: 20 },
+    });
   });
 
   it('snaps start and end to the grid when grid snapping is on', () => {
@@ -284,53 +277,20 @@ describe('marquee onMove — creating a selection', () => {
     uiState.snapToGrid = true;
     uiState.gridSize = 10;
     marqueeStrategy.onMove!(makeState({ startPoint: { x: 12, y: 12 } }), { x: 33, y: 28 }, false);
-    const [rect] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-    ];
-    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+    expect(rectPreview()).toEqual({ x: 10, y: 10, width: 20, height: 20 });
   });
 });
 
 describe('marquee onMove — moving an existing selection', () => {
-  it('translates the mask and bounds by the drag delta', () => {
-    editorState.document = { width: 10, height: 10, layers: [] };
-    const src = new Uint8ClampedArray(10 * 10);
-    // 2x2 block at (2,2)
-    src[2 * 10 + 2] = 255;
-    src[2 * 10 + 3] = 255;
-    src[3 * 10 + 2] = 255;
-    src[3 * 10 + 3] = 255;
+  it('previews the move delta without rebuilding or committing a mask', () => {
     const state = makeState({
       startPoint: { x: 0, y: 0 },
-      moveOriginalMask: src,
+      moveOriginalMask: new Uint8ClampedArray(100),
       moveOriginalBounds: { x: 2, y: 2, width: 2, height: 2 },
     });
     marqueeStrategy.onMove!(state, { x: 3, y: 2 }, false);
-    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-      Uint8ClampedArray,
-    ];
-    expect(bounds).toEqual({ x: 5, y: 4, width: 2, height: 2 });
-    expect(mask[4 * 10 + 5]).toBe(255); // (2,2) moved to (5,4)
-    expect(mask[2 * 10 + 2]).toBe(0); // old location cleared
-  });
-
-  it('clips mask content dragged outside the document', () => {
-    editorState.document = { width: 10, height: 10, layers: [] };
-    const src = new Uint8ClampedArray(10 * 10);
-    src[0] = 255; // pixel at (0,0)
-    const state = makeState({
-      startPoint: { x: 0, y: 0 },
-      moveOriginalMask: src,
-      moveOriginalBounds: { x: 0, y: 0, width: 1, height: 1 },
-    });
-    marqueeStrategy.onMove!(state, { x: -3, y: -3 }, false);
-    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
-      { x: number; y: number; width: number; height: number },
-      Uint8ClampedArray,
-    ];
-    expect(bounds).toEqual({ x: -3, y: -3, width: 1, height: 1 });
-    expect(mask.every((v) => v === 0)).toBe(true);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+    expect(getMarqueePreview()).toEqual({ kind: 'move', dx: 3, dy: 2 });
   });
 });
 
@@ -341,25 +301,70 @@ describe('marquee onUp', () => {
     expect(uiState.setTransform).toHaveBeenCalledWith(null);
   });
 
-  it('commits the selection after a real drag', () => {
-    const mask = new Uint8ClampedArray(DOC_W * DOC_H);
-    mask[12 * DOC_W + 12] = 255;
-    editorState.selection = {
-      active: true,
-      mask,
-      bounds: { x: 12, y: 12, width: 1, height: 1 },
-      maskWidth: DOC_W,
-      maskHeight: DOC_H,
-    };
+  it('builds and commits the previewed rect after a real drag', () => {
+    setMarqueePreview({ kind: 'rect', rect: { x: 10, y: 10, width: 20, height: 20 } });
     marqueeStrategy.onUp!(makeState({ startPoint: { x: 10, y: 10 } }), { x: 40, y: 40 }, makeUpCtx(40, 40));
     expect(editorState.clearSelection).not.toHaveBeenCalled();
-    // feather = 0 commits the mask straight through
-    expect(editorState.setSelection).toHaveBeenCalledWith(
-      { x: 12, y: 12, width: 1, height: 1 }, mask, DOC_W, DOC_H,
-    );
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [rect, mask, w, h] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+      number,
+      number,
+    ];
+    expect(rect).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+    expect(w).toBe(DOC_W);
+    expect(h).toBe(DOC_H);
+    expect(mask[12 * DOC_W + 12]).toBe(255); // inside
+    expect(mask[5 * DOC_W + 5]).toBe(0); // outside
+    expect(getMarqueePreview()).toBeNull(); // preview cleared on commit
   });
 
-  it('does nothing when finishing a selection move', () => {
+  it('commits a moved selection by translating the original mask on release', () => {
+    editorState.document = { width: 10, height: 10, layers: [] };
+    const src = new Uint8ClampedArray(10 * 10);
+    // 2x2 block at (2,2)
+    src[2 * 10 + 2] = 255;
+    src[2 * 10 + 3] = 255;
+    src[3 * 10 + 2] = 255;
+    src[3 * 10 + 3] = 255;
+    setMarqueePreview({ kind: 'move', dx: 3, dy: 2 });
+    const state = makeState({
+      startPoint: { x: 0, y: 0 },
+      moveOriginalMask: src,
+      moveOriginalBounds: { x: 2, y: 2, width: 2, height: 2 },
+    });
+    marqueeStrategy.onUp!(state, { x: 3, y: 2 }, makeUpCtx(3, 2));
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(bounds).toEqual({ x: 5, y: 4, width: 2, height: 2 });
+    expect(mask[4 * 10 + 5]).toBe(255); // (2,2) moved to (5,4)
+    expect(mask[2 * 10 + 2]).toBe(0); // old location cleared
+  });
+
+  it('clips moved mask content dragged outside the document', () => {
+    editorState.document = { width: 10, height: 10, layers: [] };
+    const src = new Uint8ClampedArray(10 * 10);
+    src[0] = 255; // pixel at (0,0)
+    setMarqueePreview({ kind: 'move', dx: -3, dy: -3 });
+    const state = makeState({
+      startPoint: { x: 0, y: 0 },
+      moveOriginalMask: src,
+      moveOriginalBounds: { x: 0, y: 0, width: 1, height: 1 },
+    });
+    marqueeStrategy.onUp!(state, { x: -3, y: -3 }, makeUpCtx(-3, -3));
+    const [bounds, mask] = editorState.setSelection.mock.calls[0]! as [
+      { x: number; y: number; width: number; height: number },
+      Uint8ClampedArray,
+    ];
+    expect(bounds).toEqual({ x: -3, y: -3, width: 1, height: 1 });
+    expect(mask.every((v) => v === 0)).toBe(true);
+  });
+
+  it('leaves the selection untouched when a move ends with no delta', () => {
+    setMarqueePreview({ kind: 'move', dx: 0, dy: 0 });
     const state = makeState({
       moveOriginalMask: new Uint8ClampedArray(4),
       moveOriginalBounds: { x: 0, y: 0, width: 2, height: 2 },

--- a/src/tools/marquee/marquee-strategy.ts
+++ b/src/tools/marquee/marquee-strategy.ts
@@ -16,6 +16,7 @@ import {
   createEllipseSelection,
   commitFeatheredSelection,
 } from '../../app/interactions/selection-handlers';
+import { getMarqueePreview, setMarqueePreview } from './marquee-preview';
 
 export const marqueeStrategy: SelectionToolStrategy = {
   onDown(ctx: InteractionContext, tool: SelectionToolId): InteractionState | undefined {
@@ -24,6 +25,7 @@ export const marqueeStrategy: SelectionToolStrategy = {
     const sel = editorState.selection;
     const cx = Math.round(canvasPos.x);
     const cy = Math.round(canvasPos.y);
+    setMarqueePreview(null);
     if (sel.active && sel.mask && getSelectionMaskValue(sel, cx, cy) > 0) {
       const engine = getEngine();
       if (engine && hasFloat(engine)) {
@@ -59,29 +61,17 @@ export const marqueeStrategy: SelectionToolStrategy = {
     };
   },
 
+  // While dragging, only a tiny analytic preview is updated — no mask is built
+  // and nothing crosses the WASM bridge. The full mask is materialised once on
+  // pointer up. This keeps the marquee fast on large canvases, where building
+  // and uploading a multi-MB mask per pointer event collapsed to <1fps.
   onMove(state: InteractionState, canvasPos: Point, metaKey: boolean): void {
     if (!state.startPoint) return;
 
     if (state.moveOriginalMask && state.moveOriginalBounds) {
       const dx = Math.round(canvasPos.x - state.startPoint.x);
       const dy = Math.round(canvasPos.y - state.startPoint.y);
-      const orig = state.moveOriginalBounds;
-      const editorState = useEditorStore.getState();
-      const { width: docW, height: docH } = editorState.document;
-      const srcMask = state.moveOriginalMask;
-      const newMask = new Uint8ClampedArray(srcMask.length);
-      for (let y = 0; y < docH; y++) {
-        for (let x = 0; x < docW; x++) {
-          const sx = x - dx;
-          const sy = y - dy;
-          if (sx >= 0 && sx < docW && sy >= 0 && sy < docH) {
-            newMask[y * docW + x] = srcMask[sy * docW + sx]!;
-          }
-        }
-      }
-      const newBounds = { x: orig.x + dx, y: orig.y + dy, width: orig.width, height: orig.height };
-      editorState.setSelection(newBounds, newMask, docW, docH);
-      useUIStore.getState().setTransform(createTransformState(newBounds));
+      setMarqueePreview({ kind: 'move', dx, dy });
       return;
     }
 
@@ -109,36 +99,75 @@ export const marqueeStrategy: SelectionToolStrategy = {
     const y = mEnd.y >= mStart.y ? mStart.y : mStart.y - h;
 
     if (w > 0 && h > 0) {
-      const selRect = { x, y, width: w, height: h };
-      const mask = state.tool === 'marquee-rect'
-        ? createRectSelection(selRect, editorState.document.width, editorState.document.height)
-        : createEllipseSelection(selRect, editorState.document.width, editorState.document.height);
-      editorState.setSelection(selRect, mask, editorState.document.width, editorState.document.height);
-      useUIStore.getState().setTransform(createTransformState(selRect));
+      setMarqueePreview({
+        kind: state.tool === 'marquee-rect' ? 'rect' : 'ellipse',
+        rect: { x, y, width: w, height: h },
+      });
+    } else {
+      setMarqueePreview(null);
     }
   },
 
   onUp(state: InteractionState, _canvasPos: Point, upCtx: SelectionUpContext): void {
-    if (state.moveOriginalMask) return;
-    if (state.startPoint) {
-      const rect = upCtx.containerRef.current?.getBoundingClientRect();
-      if (rect) {
-        const screenX = upCtx.event.clientX - rect.left;
-        const screenY = upCtx.event.clientY - rect.top;
-        const upPos = upCtx.screenToCanvas(screenX, screenY);
-        const dx = Math.abs(upPos.x - state.startPoint.x);
-        const dy = Math.abs(upPos.y - state.startPoint.y);
-        if (dx < 2 && dy < 2) {
-          useEditorStore.getState().clearSelection();
-          useUIStore.getState().setTransform(null);
-        } else {
-          const sel = useEditorStore.getState().selection;
-          if (sel.active && sel.mask) {
-            const { width: docW, height: docH } = useEditorStore.getState().document;
-            commitFeatheredSelection(sel.bounds!, sel.mask, docW, docH);
-          }
+    const preview = getMarqueePreview();
+    setMarqueePreview(null);
+    const editorState = useEditorStore.getState();
+    const { width: docW, height: docH } = editorState.document;
+
+    // Commit a moved selection: translate the original mask by the final
+    // delta. Only the original bounding box holds content, so the copy walks
+    // that region rather than the whole document.
+    if (state.moveOriginalMask && state.moveOriginalBounds) {
+      if (!preview || preview.kind !== 'move' || (preview.dx === 0 && preview.dy === 0)) {
+        return;
+      }
+      const { dx, dy } = preview;
+      const orig = state.moveOriginalBounds;
+      const srcMask = state.moveOriginalMask;
+      const newMask = new Uint8ClampedArray(srcMask.length);
+      const rx0 = Math.max(0, Math.floor(orig.x));
+      const ry0 = Math.max(0, Math.floor(orig.y));
+      const rx1 = Math.min(docW, Math.ceil(orig.x + orig.width));
+      const ry1 = Math.min(docH, Math.ceil(orig.y + orig.height));
+      for (let sy = ry0; sy < ry1; sy++) {
+        const ty = sy + dy;
+        if (ty < 0 || ty >= docH) continue;
+        const srcRow = sy * docW;
+        const dstRow = ty * docW;
+        for (let sx = rx0; sx < rx1; sx++) {
+          const v = srcMask[srcRow + sx]!;
+          if (v === 0) continue;
+          const tx = sx + dx;
+          if (tx < 0 || tx >= docW) continue;
+          newMask[dstRow + tx] = v;
         }
       }
+      const newBounds = { x: orig.x + dx, y: orig.y + dy, width: orig.width, height: orig.height };
+      editorState.setSelection(newBounds, newMask, docW, docH);
+      useUIStore.getState().setTransform(createTransformState(newBounds));
+      return;
     }
+
+    // Commit a freshly drawn marquee.
+    if (!state.startPoint) return;
+    const rect = upCtx.containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const screenX = upCtx.event.clientX - rect.left;
+    const screenY = upCtx.event.clientY - rect.top;
+    const upPos = upCtx.screenToCanvas(screenX, screenY);
+    const dx = Math.abs(upPos.x - state.startPoint.x);
+    const dy = Math.abs(upPos.y - state.startPoint.y);
+
+    if ((dx < 2 && dy < 2) || !preview || preview.kind === 'move') {
+      editorState.clearSelection();
+      useUIStore.getState().setTransform(null);
+      return;
+    }
+
+    const selRect = preview.rect;
+    const mask = preview.kind === 'ellipse'
+      ? createEllipseSelection(selRect, docW, docH)
+      : createRectSelection(selRect, docW, docH);
+    commitFeatheredSelection(selRect, mask, docW, docH);
   },
 };


### PR DESCRIPTION
## Problem

Drawing or moving a marquee selection was unusable on large images — **<1fps**, with ~2 seconds of catch-up after a fast drag.

Every pointer move rebuilt a full-resolution `Uint8` mask and called `setSelection`. That ran through `syncSelection → setSelectionMask`, which in Rust allocates a full RGBA texture (`vec![0u8; w*h*4]` — **48MB on a 12MP canvas**) and uploads it to the GPU. Fast drags emit many coalesced events per frame, so the bridge was flooded with tens of megabytes per move.

On top of that, marching-ants contour tracing (`getSelectionEdges`) scanned the **entire** mask (≈2×W×H branchy iterations) every frame regardless of selection size, and the "move existing selection" path did a full-document pixel copy.

## Fix

- **Defer mask construction to pointer-up.** During the drag, the marquee stores a tiny analytic preview (`{kind:'rect'|'ellipse', rect}` or `{kind:'move', dx, dy}`) in a module-level holder (`marquee-preview.ts`) kept **outside the Zustand stores** — so updating it costs nothing on the bridge and doesn't trip the render dirty flag (no GPU recomposite). The real mask is materialized and committed **once**, on release.
- **Render ants from geometry.** `renderMarqueeDraftAnts` strokes the rect/ellipse directly on the 2D overlay; a moved selection reuses its cached contour translated by the drag delta. The rAF loop animates the preview via the existing overlay-only path.
- **Bounds-limit the contour scan.** `getSelectionEdges`/`traceSelectionContours` take an optional `scanBounds` and scan only the selection's bounding box (~10× on a 4032×3024 doc). Still used per-frame by lasso/wand, which trace arbitrary masks.

Per-move work during a marquee drag goes from "allocate + 48MB upload + full-canvas trace" to "set a few numbers + one Canvas2D stroke."

## Testing

- `npm run typecheck` clean; `npm run lint` 0 errors.
- Full unit suite: **1290 passing**. `marquee-strategy.test.ts` rewritten to assert the preview-during-drag / commit-on-up behavior; new `selection.test.ts` case proves the bounds-limited scan yields byte-identical edges to the full scan (rect, ellipse, edge-flush cases).
- Confirmed smooth in-app on `samples/sample.dng` (4032×3024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)