### PR TITLE
refactor(magnetic-lasso): extract settings into per-tool slice (#453)

### DIFF
--- a/e2e/composition-photoediting.spec.ts
+++ b/e2e/composition-photoediting.spec.ts
@@ -722,9 +722,17 @@ test.describe('Composition 3: Photo Editing Workflow', () => {
     await setActiveTool(page, 'lasso-magnetic');
     expect(await getActiveTool(page)).toBe('lasso-magnetic');
 
-    await setToolSetting(page, 'setMagneticLassoWidth', 20);
-    await setToolSetting(page, 'setMagneticLassoContrast', 30);
-    await setToolSetting(page, 'setMagneticLassoFrequency', 30);
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => {
+          setMagneticLassoSetting: (key: 'width' | 'contrast' | 'frequency', value: number) => void;
+        };
+      };
+      const state = store.getState();
+      state.setMagneticLassoSetting('width', 20);
+      state.setMagneticLassoSetting('contrast', 30);
+      state.setMagneticLassoSetting('frequency', 30);
+    });
 
     // Trace around the white circle (center at 250,200, radius 80)
     const startPt = await docToScreen(page, 170, 200);

--- a/e2e/magnetic-lasso.spec.ts
+++ b/e2e/magnetic-lasso.spec.ts
@@ -63,15 +63,13 @@ async function setMagneticLassoSettings(
   await page.evaluate((s) => {
     const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
       getState: () => {
-        setMagneticLassoWidth: (n: number) => void;
-        setMagneticLassoContrast: (n: number) => void;
-        setMagneticLassoFrequency: (n: number) => void;
+        setMagneticLassoSetting: (key: 'width' | 'contrast' | 'frequency', value: number) => void;
       };
     };
     const state = ts.getState();
-    if (s.width !== undefined) state.setMagneticLassoWidth(s.width);
-    if (s.contrast !== undefined) state.setMagneticLassoContrast(s.contrast);
-    if (s.frequency !== undefined) state.setMagneticLassoFrequency(s.frequency);
+    if (s.width !== undefined) state.setMagneticLassoSetting('width', s.width);
+    if (s.contrast !== undefined) state.setMagneticLassoSetting('contrast', s.contrast);
+    if (s.frequency !== undefined) state.setMagneticLassoSetting('frequency', s.frequency);
   }, settings);
 }
 

--- a/src/app/OptionsBar/tool-options/MagneticLassoOptions.tsx
+++ b/src/app/OptionsBar/tool-options/MagneticLassoOptions.tsx
@@ -2,18 +2,16 @@ import { useToolSettingsStore } from '../../tool-settings-store';
 import { Slider } from '../../../components/Slider/Slider';
 
 export function MagneticLassoOptions() {
-  const width = useToolSettingsStore((s) => s.magneticLassoWidth);
-  const contrast = useToolSettingsStore((s) => s.magneticLassoContrast);
-  const frequency = useToolSettingsStore((s) => s.magneticLassoFrequency);
-  const setWidth = useToolSettingsStore((s) => s.setMagneticLassoWidth);
-  const setContrast = useToolSettingsStore((s) => s.setMagneticLassoContrast);
-  const setFrequency = useToolSettingsStore((s) => s.setMagneticLassoFrequency);
+  const width = useToolSettingsStore((s) => s.settings.magneticLasso.width);
+  const contrast = useToolSettingsStore((s) => s.settings.magneticLasso.contrast);
+  const frequency = useToolSettingsStore((s) => s.settings.magneticLasso.frequency);
+  const setSetting = useToolSettingsStore((s) => s.setMagneticLassoSetting);
 
   return (
     <>
-      <Slider label="Width" value={width} min={1} max={40} onChange={setWidth} />
-      <Slider label="Contrast" value={contrast} min={1} max={100} onChange={setContrast} />
-      <Slider label="Frequency" value={frequency} min={0} max={200} onChange={setFrequency} />
+      <Slider label="Width" value={width} min={1} max={40} onChange={(v) => setSetting('width', v)} />
+      <Slider label="Contrast" value={contrast} min={1} max={100} onChange={(v) => setSetting('contrast', v)} />
+      <Slider label="Frequency" value={frequency} min={0} max={200} onChange={(v) => setSetting('frequency', v)} />
     </>
   );
 }

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -16,6 +16,8 @@ import type { PathSettings } from '../tools/path/path-settings';
 import { DEFAULT_PATH_SETTINGS } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
+import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import { DEFAULT_MAGNETIC_LASSO_SETTINGS } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -36,6 +38,7 @@ export interface ToolSettingsSlices {
   eraser: EraserSettings;
   path: PathSettings;
   stamp: StampSettings;
+  magneticLasso: MagneticLassoSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -48,4 +51,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   eraser: DEFAULT_ERASER_SETTINGS,
   path: DEFAULT_PATH_SETTINGS,
   stamp: DEFAULT_STAMP_SETTINGS,
+  magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -452,6 +452,88 @@ describe('per-tool slice: stamp (#453)', () => {
   });
 });
 
+describe('per-tool slice: magneticLasso (#453)', () => {
+  it('exposes magneticLasso settings under settings.magneticLasso with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setMagneticLassoSetting.
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 10);
+    useToolSettingsStore.getState().setMagneticLassoSetting('contrast', 40);
+    useToolSettingsStore.getState().setMagneticLassoSetting('frequency', 40);
+    const { magneticLasso } = useToolSettingsStore.getState().settings;
+    expect(magneticLasso).toEqual({ width: 10, contrast: 40, frequency: 40 });
+  });
+
+  it('setMagneticLassoSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.magneticLasso;
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 25);
+    const after = useToolSettingsStore.getState().settings.magneticLasso;
+    expect(after.width).toBe(25);
+    expect(after.contrast).toBe(before.contrast);
+    expect(after.frequency).toBe(before.frequency);
+  });
+
+  it('setMagneticLassoSetting clamps width into [1, 40] and rounds', () => {
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 0);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(1);
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 999);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(40);
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 10.4);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(10);
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 10.6);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(11);
+  });
+
+  it('setMagneticLassoSetting clamps contrast into [1, 100] and rounds', () => {
+    useToolSettingsStore.getState().setMagneticLassoSetting('contrast', 0);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.contrast).toBe(1);
+    useToolSettingsStore.getState().setMagneticLassoSetting('contrast', 999);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.contrast).toBe(100);
+    useToolSettingsStore.getState().setMagneticLassoSetting('contrast', 42.7);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.contrast).toBe(43);
+  });
+
+  it('setMagneticLassoSetting clamps frequency into [0, 200] and rounds', () => {
+    // The frequency range starts at 0 (not 1) — a 0 frequency means
+    // "never auto-anchor", which is a meaningful value for the magnetic
+    // lasso, not a no-op like brush size 0.
+    useToolSettingsStore.getState().setMagneticLassoSetting('frequency', -10);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.frequency).toBe(0);
+    useToolSettingsStore.getState().setMagneticLassoSetting('frequency', 999);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.frequency).toBe(200);
+    useToolSettingsStore.getState().setMagneticLassoSetting('frequency', 50.6);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.frequency).toBe(51);
+  });
+
+  it('setMagneticLassoSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setMagneticLassoSetting('width', 25);
+    expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(25);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when magneticLasso changes. This
+    // is the invariant that justifies slicing instead of fattening the
+    // flat bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
 describe('per-tool slice: eraser (#453)', () => {
   it('exposes eraser settings under settings.eraser with the legacy defaults', () => {
     // Reset to the legacy defaults — prior tests in this file may have

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -13,6 +13,7 @@ import { clampSpongeSetting } from '../tools/sponge/sponge-settings';
 import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
+import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -66,9 +67,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   quickSelectTolerance: 32,
   quickSelectEdgeStrength: 50,
   quickSelectMode: 'add' as const,
-  magneticLassoWidth: 10,
-  magneticLassoContrast: 40,
-  magneticLassoFrequency: 40,
   textContent: 'Text',
   textFontSize: 24,
   textFontFamily: 'Inter, sans-serif',
@@ -292,9 +290,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setQuickSelectTolerance: (tolerance) => set({ quickSelectTolerance: Math.max(0, Math.min(255, Math.round(tolerance))) }),
   setQuickSelectEdgeStrength: (strength) => set({ quickSelectEdgeStrength: Math.max(0, Math.min(100, Math.round(strength))) }),
   setQuickSelectMode: (mode) => set({ quickSelectMode: mode }),
-  setMagneticLassoWidth: (width) => set({ magneticLassoWidth: Math.max(1, Math.min(40, Math.round(width))) }),
-  setMagneticLassoContrast: (contrast) => set({ magneticLassoContrast: Math.max(1, Math.min(100, Math.round(contrast))) }),
-  setMagneticLassoFrequency: (frequency) => set({ magneticLassoFrequency: Math.max(0, Math.min(200, Math.round(frequency))) }),
+  setMagneticLassoSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      magneticLasso: { ...s.settings.magneticLasso, [key]: clampMagneticLassoSetting(key, value) },
+    },
+  })),
   setTextContent: (content) => set({ textContent: content }),
   setTextFontSize: (size) => set({ textFontSize: Math.max(1, Math.min(500, size)) }),
   setTextFontFamily: (family) => set({ textFontFamily: family }),

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -12,6 +12,7 @@ import type { SpongeSettings } from '../tools/sponge/sponge-settings';
 import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
+import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -50,9 +51,6 @@ export interface ToolSettings {
   quickSelectTolerance: number;
   quickSelectEdgeStrength: number;
   quickSelectMode: 'add' | 'subtract';
-  magneticLassoWidth: number;
-  magneticLassoContrast: number;
-  magneticLassoFrequency: number;
   textContent: string;
   textFontSize: number;
   textFontFamily: string;
@@ -129,9 +127,7 @@ export interface ToolSettings {
   setQuickSelectTolerance: (tolerance: number) => void;
   setQuickSelectEdgeStrength: (strength: number) => void;
   setQuickSelectMode: (mode: 'add' | 'subtract') => void;
-  setMagneticLassoWidth: (width: number) => void;
-  setMagneticLassoContrast: (contrast: number) => void;
-  setMagneticLassoFrequency: (frequency: number) => void;
+  setMagneticLassoSetting: <K extends keyof MagneticLassoSettings>(key: K, value: MagneticLassoSettings[K]) => void;
   setTextContent: (content: string) => void;
   setTextFontSize: (size: number) => void;
   setTextFontFamily: (family: string) => void;

--- a/src/tools/magnetic-lasso/magnetic-lasso-settings.ts
+++ b/src/tools/magnetic-lasso/magnetic-lasso-settings.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-tool settings slice for the Magnetic Lasso tool.
+ *
+ * Authoritative settings type for magnetic-lasso. The slice lives under
+ * `settings.magneticLasso` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts`: `<Tool>Settings` interface +
+ * `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting` helper, then
+ * registered in `tool-settings-slices.ts`. Three numeric fields, all
+ * rounded integers with different clamp ranges — the first slice with
+ * a pure round-and-clamp shape across every field.
+ */
+export interface MagneticLassoSettings {
+  width: number;
+  contrast: number;
+  frequency: number;
+}
+
+export const DEFAULT_MAGNETIC_LASSO_SETTINGS: MagneticLassoSettings = {
+  width: 10,
+  contrast: 40,
+  frequency: 40,
+};
+
+export function clampMagneticLassoSetting<K extends keyof MagneticLassoSettings>(
+  key: K,
+  value: MagneticLassoSettings[K],
+): MagneticLassoSettings[K] {
+  if (key === 'width') {
+    const n = value as number;
+    return Math.max(1, Math.min(40, Math.round(n))) as MagneticLassoSettings[K];
+  }
+  if (key === 'contrast') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, Math.round(n))) as MagneticLassoSettings[K];
+  }
+  if (key === 'frequency') {
+    const n = value as number;
+    return Math.max(0, Math.min(200, Math.round(n))) as MagneticLassoSettings[K];
+  }
+  return value;
+}

--- a/src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts
+++ b/src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts
@@ -62,10 +62,10 @@ vi.mock('../../app/ui-store', () => ({
 }));
 
 const ts = {
-  settings: { marquee: { feather: 0 } },
-  magneticLassoWidth: 10,
-  magneticLassoContrast: 10,
-  magneticLassoFrequency: 100,
+  settings: {
+    marquee: { feather: 0 },
+    magneticLasso: { width: 10, contrast: 10, frequency: 100 },
+  },
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },
@@ -134,7 +134,7 @@ beforeEach(() => {
   uiState.clearLassoPoints.mockClear();
   editorState.setSelection.mockClear();
   editorState.clearSelection.mockClear();
-  ts.magneticLassoFrequency = 100;
+  ts.settings.magneticLasso = { width: 10, contrast: 10, frequency: 100 };
   magneticLassoSnap.mockImplementation(straightSnap);
   magneticLassoSnapPoint.mockImplementation((...args: unknown[]) => {
     const [, x, y] = args as [unknown, number, number];
@@ -171,7 +171,7 @@ describe('magnetic lasso onDown', () => {
   });
 
   it('converts the contrast setting into a 1..255 threshold for the snapper', () => {
-    ts.magneticLassoContrast = 10;
+    ts.settings.magneticLasso = { ...ts.settings.magneticLasso, contrast: 10 };
     magneticLassoStrategy.onDown(makeCtx(), 'lasso-magnetic');
     // round(10 * 2.55) = 26
     expect(magneticLassoSnapPoint.mock.calls[0]![4]).toBe(26);
@@ -196,7 +196,7 @@ describe('magnetic lasso onMove', () => {
   });
 
   it('auto-anchors when the live segment grows past the frequency length', () => {
-    ts.magneticLassoFrequency = 5;
+    ts.settings.magneticLasso = { ...ts.settings.magneticLasso, frequency: 5 };
     magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
     magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 0 }, false);
     // The 8px segment exceeds frequency 5, so an anchor is committed at the
@@ -221,7 +221,7 @@ describe('magnetic lasso onMove', () => {
 
 describe('magnetic lasso onUp', () => {
   it('closes the loop and commits a polygon selection', () => {
-    ts.magneticLassoFrequency = 5;
+    ts.settings.magneticLasso = { ...ts.settings.magneticLasso, frequency: 5 };
     magneticLassoStrategy.onDown(makeCtx({ canvasPos: { x: 0, y: 0 } }), 'lasso-magnetic');
     magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 0 }, false);
     magneticLassoStrategy.onMove!(makeState(), { x: 8, y: 8 }, false);

--- a/src/tools/magnetic-lasso/magnetic-lasso-strategy.ts
+++ b/src/tools/magnetic-lasso/magnetic-lasso-strategy.ts
@@ -29,9 +29,9 @@ let magneticLassoTrace: MagneticLassoState | null = null;
 
 function makeMagneticSnapFn(): SnapFn {
   const engine = getEngine();
-  const settings = useToolSettingsStore.getState();
-  const radius = settings.magneticLassoWidth;
-  const threshold = Math.max(1, Math.min(255, Math.round(settings.magneticLassoContrast * 2.55)));
+  const { magneticLasso } = useToolSettingsStore.getState().settings;
+  const radius = magneticLasso.width;
+  const threshold = Math.max(1, Math.min(255, Math.round(magneticLasso.contrast * 2.55)));
   return (from, to) => {
     if (!engine) return [from, to];
     const flat = wasmMagneticLassoSnap(engine, from.x, from.y, to.x, to.y, radius, threshold);
@@ -42,9 +42,9 @@ function makeMagneticSnapFn(): SnapFn {
 function snapCursorToEdge(p: Point): Point {
   const engine = getEngine();
   if (!engine) return p;
-  const settings = useToolSettingsStore.getState();
-  const radius = settings.magneticLassoWidth;
-  const threshold = Math.max(1, Math.min(255, Math.round(settings.magneticLassoContrast * 2.55)));
+  const { magneticLasso } = useToolSettingsStore.getState().settings;
+  const radius = magneticLasso.width;
+  const threshold = Math.max(1, Math.min(255, Math.round(magneticLasso.contrast * 2.55)));
   const snapped = wasmMagneticLassoSnapPoint(engine, p.x, p.y, radius, threshold);
   return snapped.length >= 2 ? { x: snapped[0]!, y: snapped[1]! } : p;
 }
@@ -64,9 +64,9 @@ export const magneticLassoStrategy: SelectionToolStrategy = {
     } catch {
       return undefined;
     }
-    const settings = useToolSettingsStore.getState();
-    const radius = settings.magneticLassoWidth;
-    const threshold = Math.max(1, Math.min(255, Math.round(settings.magneticLassoContrast * 2.55)));
+    const { magneticLasso } = useToolSettingsStore.getState().settings;
+    const radius = magneticLasso.width;
+    const threshold = Math.max(1, Math.min(255, Math.round(magneticLasso.contrast * 2.55)));
     const snapped = wasmMagneticLassoSnapPoint(engine, ctx.canvasPos.x, ctx.canvasPos.y, radius, threshold);
     const startPoint = snapped.length >= 2
       ? { x: snapped[0]!, y: snapped[1]! }
@@ -89,7 +89,7 @@ export const magneticLassoStrategy: SelectionToolStrategy = {
     if (!magneticLassoTrace) return;
     const snap = makeMagneticSnapFn();
     let trace = magneticUpdateCursor(magneticLassoTrace, canvasPos, snap);
-    const frequency = useToolSettingsStore.getState().magneticLassoFrequency;
+    const frequency = useToolSettingsStore.getState().settings.magneticLasso.frequency;
     if (shouldAutoAnchor(trace, frequency)) {
       trace = magneticAddAnchor(trace, snapCursorToEdge(canvasPos), snap);
     }


### PR DESCRIPTION
## Summary

Twelfth per-tool slice in the #453 rollout. Magnetic-lasso settings move from the flat `magneticLassoWidth` / `magneticLassoContrast` / `magneticLassoFrequency` fields and their three setters to a single `settings.magneticLasso.*` slice with one typed `setMagneticLassoSetting<K>(key, value)` setter, following the established slice template.

**Why magnetic-lasso next:**
- **First slice on a magnetic-lasso (assistant-selection) tool class.** Wand and marquee are click-based selection tools; magnetic-lasso is a continuous-trace assistant. The slice infrastructure now covers selection-click, selection-trace, paint, vector, and clone-stamp tool classes.
- **First slice with a pure round-and-clamp shape across every field.** All three fields use `Math.round` with different clamp ranges (`width` `[1, 40]`, `contrast` `[1, 100]`, `frequency` `[0, 200]`). The frequency range starts at 0 (not 1) because a 0 frequency means "never auto-anchor" — a meaningful value for the magnetic lasso, not a no-op like brush size 0.
- **Small surface, low risk.** 3 fields, 7 read sites across 4 source files: `MagneticLassoOptions.tsx` (×3 sliders), `magnetic-lasso-strategy.ts` (×3 — `makeMagneticSnapFn`, `snapCursorToEdge`, `onDown`, plus `onMove` for frequency). Plus the e2e helpers in `magnetic-lasso.spec.ts` and one call site in `composition-photoediting.spec.ts`.

The store tests now assert sibling-slice referential identity across all ten `main`-side slices (wand → fill → marquee → smudge → pencil → sponge → path → stamp → eraser → magneticLasso), so the invariant stays locked in for the rest of the rollout.

## Test plan

- [x] Unit tests pass — added 6 new tests under `per-tool slice: magneticLasso (#453)` covering defaults, per-field clamping with rounding, the frequency-starts-at-0 invariant, and sibling-slice referential identity.
- [x] `magnetic-lasso-strategy.test.ts` updated for the new slice shape; all 11 strategy tests still pass.
- [x] `npm run typecheck` clean.
- [x] `npm run test` clean (1296 passed).
- [x] `npm run lint` clean (0 errors).

labels: autofix

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMtV79bVFN4JN1V9UHUfSr)_