### PR TITLE
refactor(tool-settings): migrate dodge to per-tool slice (#453)

### DIFF
--- a/e2e/composition-painting.spec.ts
+++ b/e2e/composition-painting.spec.ts
@@ -443,7 +443,12 @@ test.describe('Composition 1: Painted Landscape', () => {
     // Dodge (lighten) the left side of mountains
     await setToolOption(page, 'Size', 50);
     await setToolOption(page, 'Exposure', 60);
-    await setToolSetting(page, 'setDodgeMode', 'dodge');
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setDodgeSetting: (key: 'mode' | 'exposure', value: 'dodge' | 'burn' | number) => void };
+      };
+      store.getState().setDodgeSetting('mode', 'dodge');
+    });
 
     const beforeDodge = await snapshot(page);
     await drawStroke(page, { x: 160, y: 180 }, { x: 200, y: 240 }, 8);
@@ -452,7 +457,12 @@ test.describe('Composition 1: Painted Landscape', () => {
     expect(pixelDiff(beforeDodge, afterDodge)).toBeGreaterThan(20);
 
     // Burn (darken) the right side
-    await setToolSetting(page, 'setDodgeMode', 'burn');
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setDodgeSetting: (key: 'mode' | 'exposure', value: 'dodge' | 'burn' | number) => void };
+      };
+      store.getState().setDodgeSetting('mode', 'burn');
+    });
     const beforeBurn = await snapshot(page);
     await drawStroke(page, { x: 370, y: 160 }, { x: 420, y: 220 }, 8);
     const afterBurn = await snapshot(page);

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -6,11 +6,10 @@ import type { DodgeMode } from '../../../tools/dodge/dodge';
 import styles from '../OptionsBar.module.css';
 
 export function DodgeOptions() {
-  const dodgeExposure = useToolSettingsStore((s) => s.dodgeExposure);
-  const dodgeMode = useToolSettingsStore((s) => s.dodgeMode);
+  const dodgeExposure = useToolSettingsStore((s) => s.settings.dodge.exposure);
+  const dodgeMode = useToolSettingsStore((s) => s.settings.dodge.mode);
   const brushSize = useToolSettingsStore((s) => s.brushSize);
-  const setDodgeExposure = useToolSettingsStore((s) => s.setDodgeExposure);
-  const setDodgeMode = useToolSettingsStore((s) => s.setDodgeMode);
+  const setDodgeSetting = useToolSettingsStore((s) => s.setDodgeSetting);
   const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
@@ -22,13 +21,13 @@ export function DodgeOptions() {
       <select
         className={styles.select}
         value={dodgeMode}
-        onChange={(e) => setDodgeMode(e.target.value as DodgeMode)}
+        onChange={(e) => setDodgeSetting('mode', e.target.value as DodgeMode)}
         aria-labelledby="dodge-mode-label"
       >
         <option value="dodge">Dodge</option>
         <option value="burn">Burn</option>
       </select>
-      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={setDodgeExposure} />
+      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={(v) => setDodgeSetting('exposure', v)} />
       <Slider label="Size" value={brushSize} min={1} max={sizeMax} sliderMax={300} onChange={setBrushSize} />
     </>
   );

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -18,6 +18,8 @@ import type { StampSettings } from '../tools/stamp/stamp-settings';
 import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import { DEFAULT_MAGNETIC_LASSO_SETTINGS } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
+import { DEFAULT_DODGE_SETTINGS } from '../tools/dodge/dodge-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -39,6 +41,7 @@ export interface ToolSettingsSlices {
   path: PathSettings;
   stamp: StampSettings;
   magneticLasso: MagneticLassoSettings;
+  dodge: DodgeSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -52,4 +55,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   path: DEFAULT_PATH_SETTINGS,
   stamp: DEFAULT_STAMP_SETTINGS,
   magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
+  dodge: DEFAULT_DODGE_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -534,6 +534,70 @@ describe('per-tool slice: magneticLasso (#453)', () => {
   });
 });
 
+describe('per-tool slice: dodge (#453)', () => {
+  it('exposes dodge settings under settings.dodge with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setDodgeSetting.
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 50);
+    const { dodge } = useToolSettingsStore.getState().settings;
+    expect(dodge).toEqual({ mode: 'dodge', exposure: 50 });
+  });
+
+  it('setDodgeSetting updates one field without disturbing the other', () => {
+    const before = useToolSettingsStore.getState().settings.dodge;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 75);
+    const after = useToolSettingsStore.getState().settings.dodge;
+    expect(after.exposure).toBe(75);
+    expect(after.mode).toBe(before.mode);
+  });
+
+  it('setDodgeSetting clamps exposure into [1, 100]', () => {
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 0);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(1);
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 999);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(100);
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 42);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(42);
+  });
+
+  it('setDodgeSetting accepts both dodge and burn modes', () => {
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'burn');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('burn');
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('dodge');
+  });
+
+  it('setDodgeSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 30);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(30);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when dodge changes.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
 describe('per-tool slice: eraser (#453)', () => {
   it('exposes eraser settings under settings.eraser with the legacy defaults', () => {
     // Reset to the legacy defaults — prior tests in this file may have

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -14,6 +14,7 @@ import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
 import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import { clampDodgeSetting } from '../tools/dodge/dodge-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -61,8 +62,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   gradientReverse: false,
   healingSize: 20,
   healingOpacity: 100,
-  dodgeExposure: 50,
-  dodgeMode: 'dodge',
   quickSelectSize: 20,
   quickSelectTolerance: 32,
   quickSelectEdgeStrength: 50,
@@ -260,8 +259,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       path: { ...s.settings.path, [key]: clampPathSetting(key, value) },
     },
   })),
-  setDodgeExposure: (exposure) => set({ dodgeExposure: Math.max(1, Math.min(100, exposure)) }),
-  setDodgeMode: (mode) => set({ dodgeMode: mode }),
+  setDodgeSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      dodge: { ...s.settings.dodge, [key]: clampDodgeSetting(key, value) },
+    },
+  })),
   setSpongeSetting: (key, value) => set((s) => ({
     settings: {
       ...s.settings,

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,7 +1,6 @@
 import type { Color, FontStyle, TextAlign } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
-import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
@@ -13,6 +12,7 @@ import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -45,8 +45,6 @@ export interface ToolSettings {
   gradientReverse: boolean;
   healingSize: number;
   healingOpacity: number;
-  dodgeExposure: number;
-  dodgeMode: DodgeMode;
   quickSelectSize: number;
   quickSelectTolerance: number;
   quickSelectEdgeStrength: number;
@@ -117,8 +115,7 @@ export interface ToolSettings {
   setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
   setHealingSize: (size: number) => void;
   setHealingOpacity: (opacity: number) => void;
-  setDodgeExposure: (exposure: number) => void;
-  setDodgeMode: (mode: DodgeMode) => void;
+  setDodgeSetting: <K extends keyof DodgeSettings>(key: K, value: DodgeSettings[K]) => void;
   setSpongeSetting: <K extends keyof SpongeSettings>(key: K, value: SpongeSettings[K]) => void;
   setSmudgeSetting: <K extends keyof SmudgeSettings>(key: K, value: SmudgeSettings[K]) => void;
   setMarqueeSetting: <K extends keyof MarqueeSettings>(key: K, value: MarqueeSettings[K]) => void;

--- a/src/tools/dodge/dodge-interaction.test.ts
+++ b/src/tools/dodge/dodge-interaction.test.ts
@@ -31,8 +31,12 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  dodgeMode: 'dodge' as 'dodge' | 'burn',
-  dodgeExposure: 50,
+  settings: {
+    dodge: {
+      mode: 'dodge' as 'dodge' | 'burn',
+      exposure: 50,
+    },
+  },
   brushSize: 20,
 };
 vi.mock('../../app/tool-settings-store', () => ({
@@ -88,8 +92,8 @@ beforeEach(() => {
   clearPendingDodgeStroke.mockClear();
   editorState.pushHistory.mockClear();
   editorState.notifyRender.mockClear();
-  ts.dodgeMode = 'dodge';
-  ts.dodgeExposure = 50;
+  ts.settings.dodge.mode = 'dodge';
+  ts.settings.dodge.exposure = 50;
   ts.brushSize = 20;
 });
 
@@ -109,7 +113,7 @@ describe('dodge down', () => {
   });
 
   it('burn mode uses mode 1 and the Burn history label', () => {
-    ts.dodgeMode = 'burn';
+    ts.settings.dodge.mode = 'burn';
     handleDodgeDown(makeCtx());
     expect(editorState.pushHistory).toHaveBeenCalledWith('Burn');
     expect(beginDodgeBurnStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 1);
@@ -157,7 +161,7 @@ describe('dodge move', () => {
   });
 
   it('passes the current exposure setting on every move', () => {
-    ts.dodgeExposure = 80;
+    ts.settings.dodge.exposure = 80;
     handleDodgeMove(makeState({ lastPoint: { x: 0, y: 0 } }), { x: 10, y: 0 });
     expect(applyDodgeBurnDabBatch.mock.calls[0]![5]).toBeCloseTo(0.8);
   });

--- a/src/tools/dodge/dodge-interaction.ts
+++ b/src/tools/dodge/dodge-interaction.ts
@@ -26,9 +26,9 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
   const editorState = useEditorStore.getState();
   const toolSettings = useToolSettingsStore.getState();
-  const dodgeMode = toolSettings.dodgeMode;
+  const dodgeMode = toolSettings.settings.dodge.mode;
   editorState.pushHistory(dodgeMode === 'dodge' ? 'Dodge' : 'Burn');
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeShiftLine = shiftKey
     && ctx.lastPaintPointRef.current
@@ -64,7 +64,7 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
 export function handleDodgeMove(state: InteractionState, layerLocalPos: Point): void {
   if (!state.lastPoint) return;
   const toolSettings = useToolSettingsStore.getState();
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeSpacing = Math.max(1, dodgeSize * 0.25);
 

--- a/src/tools/dodge/dodge-settings.ts
+++ b/src/tools/dodge/dodge-settings.ts
@@ -1,0 +1,36 @@
+import type { DodgeMode } from './dodge';
+
+/**
+ * Per-tool settings slice for the Dodge/Burn tool.
+ *
+ * Authoritative settings type for dodge. The slice lives under
+ * `settings.dodge` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Two fields — exposure (a 1–100 percent
+ * applied as ÷100 to the dab) and mode (dodge | burn).
+ */
+export interface DodgeSettings {
+  mode: DodgeMode;
+  exposure: number;
+}
+
+export const DEFAULT_DODGE_SETTINGS: DodgeSettings = {
+  mode: 'dodge',
+  exposure: 50,
+};
+
+export function clampDodgeSetting<K extends keyof DodgeSettings>(
+  key: K,
+  value: DodgeSettings[K],
+): DodgeSettings[K] {
+  if (key === 'exposure') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as DodgeSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Thirteenth per-tool slice in the #453 rollout. Dodge settings move from the flat `dodgeMode` / `dodgeExposure` fields and their two setters to a single `settings.dodge.*` slice with one typed `setDodgeSetting<K>(key, value)` setter, following the established slice template.

The slice carries a **two-field number-plus-enum shape**:
- `mode` (`'dodge' | 'burn'`) — the dodge/burn toggle (no clamp).
- `exposure` — clamped to `[1, 100]`, applied as ÷100 to the GPU dab.

Read sites in `DodgeOptions.tsx` and `dodge-interaction.ts` now access `settings.dodge.{mode,exposure}`. The e2e helper in `composition-painting.spec.ts` was retargeted to the new slice setter.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 1301 unit tests pass (added 5 new tests under `per-tool slice: dodge (#453)`)
- [x] Dodge/burn read sites updated in `dodge-interaction.ts` and `DodgeOptions.tsx`
- [x] e2e `composition-painting.spec.ts` updated to call `setDodgeSetting('mode', …)` instead of `setDodgeMode(…)`
- [ ] Manual smoke: switch to dodge tool, set exposure 60, draw stroke, switch to burn, draw stroke — both should affect canvas

Closes part of #453.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KFu8gJnH2YbHwySRkuFTxU)_