### PR TITLE
docs(features): update Saturation/Vibrance node cap to +200

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -321,7 +321,7 @@ Available node types (Add menu):
 - **Exposure** — stops (multiplier = 2^value)
 - **Contrast** — -100 to +100
 - **Highlights / Shadows** — Highlights -100 to +100, Shadows -100 to +100, Whites -100 to +100, Blacks -100 to +100
-- **Saturation** — Saturation -100 to +100, Vibrance -100 to +100
+- **Saturation** — Saturation -100 to +200, Vibrance -100 to +200 (the +200 ceiling pushes ~3× past gray and clips only at the gamut edge; the -100 floor is full desaturation)
 - **Vignette** — 0 to 100 (now correctly piped through the per-group adjustment pipeline)
 - **Curves** — per-channel tone curves (RGB master + R / G / B), evaluated as
   monotone cubic Hermite splines. Master applies to every channel first,


### PR DESCRIPTION
## Summary

Scheduled FEATURES.md audit (2026-06-15). Reviewed recent `origin/main` commits and re-verified tool/filter/feature documentation against the current code.

One genuine documentation inaccuracy was found and fixed:

- **Saturation adjustment node cap**: [#585](https://github.com/theseamusjames/lopsy.art/pull/585) raised the Adjustments-panel Saturation node's **Saturation** and **Vibrance** sliders from a +100 to a **+200** ceiling (`src/panels/AdjustmentsPanel/controls/SaturationControls.tsx`), but `FEATURES.md` still documented the old +100 cap. Updated the range and added a one-line note on the behavior.

## Audit notes (no change needed)

- The audit was rebased onto `origin/main`, **not** the stale long-lived `theseamusjames/docs-features-*` branch (which had drifted behind and still contained claims that [#605](https://github.com/theseamusjames/lopsy.art/pull/605) had already corrected on main).
- Verified [#605](https://github.com/theseamusjames/lopsy.art/pull/605)'s corrections still hold in code:
  - Radial-symmetry segment control is an `<input type="number">` (min 2, max 32), **not** a slider — `SymmetryControls.tsx`.
  - The ⌘R "Show Rulers" accelerator is listed in the View menu but **not** wired to a global key handler (`edit-shortcuts.ts` wires grid `'` and guides `;` only) — docs correctly say so.
- The separate **Hue/Saturation** node is unaffected by #585 (still −100/+100) — left as-is.
- Other recent `feat` commits (RAF import #562, Emboss #540) are already documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)