### PR TITLE
refactor(spray): extract settings into per-tool slice (#453)

### DIFF
--- a/src/app/OptionsBar/tool-options/SprayOptions.tsx
+++ b/src/app/OptionsBar/tool-options/SprayOptions.tsx
@@ -4,24 +4,18 @@ import { Slider } from '../../../components/Slider/Slider';
 import { docScaledMax } from '../../../utils/slider-ranges';
 
 export function SprayOptions() {
-  const spraySize = useToolSettingsStore((s) => s.spraySize);
-  const sprayDensity = useToolSettingsStore((s) => s.sprayDensity);
-  const sprayOpacity = useToolSettingsStore((s) => s.sprayOpacity);
-  const sprayHardness = useToolSettingsStore((s) => s.sprayHardness);
-  const setSpraySize = useToolSettingsStore((s) => s.setSpraySize);
-  const setSprayDensity = useToolSettingsStore((s) => s.setSprayDensity);
-  const setSprayOpacity = useToolSettingsStore((s) => s.setSprayOpacity);
-  const setSprayHardness = useToolSettingsStore((s) => s.setSprayHardness);
+  const spray = useToolSettingsStore((s) => s.settings.spray);
+  const setSpraySetting = useToolSettingsStore((s) => s.setSpraySetting);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 500);
 
   return (
     <>
-      <Slider label="Size" value={spraySize} min={1} max={sizeMax} sliderMax={500} onChange={setSpraySize} />
-      <Slider label="Density" value={sprayDensity} min={1} max={100} onChange={setSprayDensity} />
-      <Slider label="Opacity" value={sprayOpacity} min={1} max={100} onChange={setSprayOpacity} />
-      <Slider label="Softness" value={sprayHardness} min={0} max={100} onChange={setSprayHardness} />
+      <Slider label="Size" value={spray.size} min={1} max={sizeMax} sliderMax={500} onChange={(v) => setSpraySetting('size', v)} />
+      <Slider label="Density" value={spray.density} min={1} max={100} onChange={(v) => setSpraySetting('density', v)} />
+      <Slider label="Opacity" value={spray.opacity} min={1} max={100} onChange={(v) => setSpraySetting('opacity', v)} />
+      <Slider label="Softness" value={spray.hardness} min={0} max={100} onChange={(v) => setSpraySetting('hardness', v)} />
     </>
   );
 }

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -20,6 +20,8 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import { DEFAULT_MAGNETIC_LASSO_SETTINGS } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import type { TextSettings } from '../tools/text/text-settings';
 import { DEFAULT_TEXT_SETTINGS } from '../tools/text/text-settings';
+import type { SpraySettings } from '../tools/spray/spray-settings';
+import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -42,6 +44,7 @@ export interface ToolSettingsSlices {
   stamp: StampSettings;
   magneticLasso: MagneticLassoSettings;
   text: TextSettings;
+  spray: SpraySettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -56,4 +59,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   stamp: DEFAULT_STAMP_SETTINGS,
   magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
   text: DEFAULT_TEXT_SETTINGS,
+  spray: DEFAULT_SPRAY_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -92,14 +92,14 @@ describe('opacity setters — issue #250 (percent vs normalised footgun)', () =>
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('also warns from setEraserSetting(opacity) and setSprayOpacity (same footgun)', async () => {
+  it('also warns from setEraserSetting(opacity) and setSpraySetting(opacity) (same footgun)', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
     store.getState().setEraserSetting('opacity', 0.5);
-    store.getState().setSprayOpacity(0.3);
+    store.getState().setSpraySetting('opacity', 0.3);
     expect(warnSpy).toHaveBeenCalledTimes(2);
     const messages = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ''));
     expect(messages.some((m: string) => m.includes('setEraserSetting(opacity)'))).toBe(true);
-    expect(messages.some((m: string) => m.includes('setSprayOpacity'))).toBe(true);
+    expect(messages.some((m: string) => m.includes('setSpraySetting(opacity)'))).toBe(true);
   });
 });
 
@@ -680,10 +680,91 @@ describe('per-tool slice: text (#453)', () => {
     const beforeBrushSize = useToolSettingsStore.getState().brushSize;
     useToolSettingsStore.getState().setTextSetting('fontSize', 48);
     expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(48);
-    // Sibling slice references preserved — selectors subscribed to the
-    // other slices should not re-render when text changes. This is the
-    // invariant that justifies slicing instead of fattening the flat
-    // bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: spray (#453)', () => {
+  it('exposes spray settings under settings.spray with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setSpraySetting.
+    useToolSettingsStore.getState().setSpraySetting('size', 40);
+    useToolSettingsStore.getState().setSpraySetting('density', 20);
+    useToolSettingsStore.getState().setSpraySetting('opacity', 60);
+    useToolSettingsStore.getState().setSpraySetting('hardness', 30);
+    const { spray } = useToolSettingsStore.getState().settings;
+    expect(spray).toEqual({ size: 40, density: 20, opacity: 60, hardness: 30 });
+  });
+
+  it('setSpraySetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.spray;
+    useToolSettingsStore.getState().setSpraySetting('density', 75);
+    const after = useToolSettingsStore.getState().settings.spray;
+    expect(after.density).toBe(75);
+    expect(after.size).toBe(before.size);
+    expect(after.opacity).toBe(before.opacity);
+    expect(after.hardness).toBe(before.hardness);
+  });
+
+  it('setSpraySetting clamps size into [1, 5000]', () => {
+    useToolSettingsStore.getState().setSpraySetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.spray.size).toBe(1);
+    useToolSettingsStore.getState().setSpraySetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.spray.size).toBe(5000);
+  });
+
+  it('setSpraySetting clamps density into [1, 100]', () => {
+    useToolSettingsStore.getState().setSpraySetting('density', 0);
+    expect(useToolSettingsStore.getState().settings.spray.density).toBe(1);
+    useToolSettingsStore.getState().setSpraySetting('density', 9999);
+    expect(useToolSettingsStore.getState().settings.spray.density).toBe(100);
+  });
+
+  it('setSpraySetting clamps opacity into [1, 100]', () => {
+    // The legacy setSprayOpacity clamped to [1, 100], not [0, 100] —
+    // a 0 here would silently produce a no-op spray stroke, the same
+    // percent-vs-normalised footgun guarded by the warn-once dedupe.
+    // Preserve that range under the slice.
+    useToolSettingsStore.getState().setSpraySetting('opacity', -10);
+    expect(useToolSettingsStore.getState().settings.spray.opacity).toBe(1);
+    useToolSettingsStore.getState().setSpraySetting('opacity', 200);
+    expect(useToolSettingsStore.getState().settings.spray.opacity).toBe(100);
+  });
+
+  it('setSpraySetting clamps hardness into [0, 100]', () => {
+    // Hardness is exposed in the UI as a "Softness" slider with min 0,
+    // so the slice mirrors that range — distinct from opacity's
+    // [1, 100], where 0 would be a no-op.
+    useToolSettingsStore.getState().setSpraySetting('hardness', -10);
+    expect(useToolSettingsStore.getState().settings.spray.hardness).toBe(0);
+    useToolSettingsStore.getState().setSpraySetting('hardness', 200);
+    expect(useToolSettingsStore.getState().settings.spray.hardness).toBe(100);
+  });
+
+  it('setSpraySetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setSpraySetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.spray.size).toBe(42);
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
     expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
     expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -15,6 +15,7 @@ import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
 import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import { clampTextSetting } from '../tools/text/text-settings';
+import { clampSpraySetting } from '../tools/spray/spray-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -110,10 +111,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { r: 255, g: 130, b: 0,   a: 1 },
     { r: 0,   g: 200, b: 200, a: 1 },
   ],
-  spraySize: 40,
-  sprayDensity: 20,
-  sprayOpacity: 60,
-  sprayHardness: 30,
   brushSizeJitter: 0,
   brushAngleJitter: 0,
   brushOpacityJitter: 0,
@@ -144,13 +141,15 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     brushTextures: s.brushTextures.filter((t) => t.id !== id),
     brushTextureData: s.brushTextureData?.id === id ? null : s.brushTextureData,
   })),
-  setSpraySize: (size) => set({ spraySize: Math.max(1, Math.min(5000, size)) }),
-  setSprayDensity: (density) => set({ sprayDensity: Math.max(1, Math.min(100, density)) }),
-  setSprayOpacity: (opacity) => {
-    warnIfNormalisedOpacity('setSprayOpacity', opacity);
-    set({ sprayOpacity: Math.max(1, Math.min(100, opacity)) });
+  setSpraySetting: (key, value) => {
+    if (key === 'opacity') warnIfNormalisedOpacity('setSpraySetting(opacity)', value as number);
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        spray: { ...s.settings.spray, [key]: clampSpraySetting(key, value) },
+      },
+    }));
   },
-  setSprayHardness: (hardness) => set({ sprayHardness: Math.max(0, Math.min(100, hardness)) }),
   setBrushSize: (size) => set({ brushSize: Math.max(1, Math.min(5000, size)) }),
   setBrushFade: (fade) => set({ brushFade: Math.max(0, Math.min(5000, fade)) }),
   setBrushTaper: (taper) => set({ brushTaper: Math.max(0, Math.min(5000, taper)) }),

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -14,6 +14,7 @@ import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import type { TextSettings } from '../tools/text/text-settings';
+import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -65,10 +66,6 @@ export interface ToolSettings {
   foregroundColor: Color;
   backgroundColor: Color;
   recentColors: readonly Color[];
-  spraySize: number;
-  sprayDensity: number;
-  sprayOpacity: number;
-  sprayHardness: number;
   brushSizeJitter: number;
   brushAngleJitter: number;
   brushOpacityJitter: number;
@@ -96,10 +93,7 @@ export interface ToolSettings {
   setBrushTextureScale: (scale: number) => void;
   addBrushTexture: (texture: BrushTextureData) => void;
   removeBrushTexture: (id: string) => void;
-  setSpraySize: (size: number) => void;
-  setSprayDensity: (density: number) => void;
-  setSprayOpacity: (opacity: number) => void;
-  setSprayHardness: (hardness: number) => void;
+  setSpraySetting: <K extends keyof SpraySettings>(key: K, value: SpraySettings[K]) => void;
   setBrushSize: (size: number) => void;
   setBrushFade: (fade: number) => void;
   setBrushTaper: (taper: number) => void;

--- a/src/tools/spray/spray-interaction.test.ts
+++ b/src/tools/spray/spray-interaction.test.ts
@@ -20,10 +20,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  spraySize: 40,
-  sprayDensity: 12,
-  sprayOpacity: 60,
-  sprayHardness: 30,
+  settings: {
+    spray: { size: 40, density: 12, opacity: 60, hardness: 30 },
+  },
   foregroundColor: { r: 255, g: 0, b: 0, a: 1 },
   addRecentColor: vi.fn(),
 };
@@ -64,8 +63,7 @@ beforeEach(() => {
   editorState.notifyRender.mockClear();
   ts.addRecentColor.mockClear();
   ts.foregroundColor = { r: 255, g: 0, b: 0, a: 1 };
-  ts.sprayDensity = 12;
-  ts.spraySize = 40;
+  ts.settings = { spray: { size: 40, density: 12, opacity: 60, hardness: 30 } };
 });
 
 afterEach(() => {
@@ -87,7 +85,7 @@ describe('spray down', () => {
 
   it('scatters dabs within the brush radius around the cursor', () => {
     handleSprayDown(makeCtx({ layerPos: { x: 100, y: 100 } }));
-    const brushRadius = ts.spraySize / 2;
+    const brushRadius = ts.settings.spray.size / 2;
     for (const call of applyBrushDab.mock.calls) {
       const x = call[2] as number;
       const y = call[3] as number;

--- a/src/tools/spray/spray-interaction.ts
+++ b/src/tools/spray/spray-interaction.ts
@@ -44,10 +44,9 @@ function sprayAtCurrentPosition(state: InteractionState): void {
   if (!engine) return;
 
   const toolSettings = useToolSettingsStore.getState();
-  const size = toolSettings.spraySize;
-  const density = toolSettings.sprayDensity;
-  const opacity = toolSettings.sprayOpacity / 100;
-  const hardness = toolSettings.sprayHardness / 100;
+  const { size, density, opacity: opacityPct, hardness: hardnessPct } = toolSettings.settings.spray;
+  const opacity = opacityPct / 100;
+  const hardness = hardnessPct / 100;
   const color = state.strokeColor ?? toolSettings.foregroundColor;
   const r = color.r / 255;
   const g = color.g / 255;
@@ -82,10 +81,9 @@ export function handleSprayDown(
   const engine = getEngine();
   if (!engine) return state;
 
-  const size = toolSettings.spraySize;
-  const density = toolSettings.sprayDensity;
-  const opacity = toolSettings.sprayOpacity / 100;
-  const hardness = toolSettings.sprayHardness / 100;
+  const { size, density, opacity: opacityPct, hardness: hardnessPct } = toolSettings.settings.spray;
+  const opacity = opacityPct / 100;
+  const hardness = hardnessPct / 100;
   const color = strokeColor;
   toolSettings.addRecentColor(color);
   const r = color.r / 255;
@@ -112,10 +110,9 @@ export function handleSprayMove(
   if (!engine) return;
 
   const layerLocalPos = ctx.layerPos;
-  const size = toolSettings.spraySize;
-  const density = toolSettings.sprayDensity;
-  const opacity = toolSettings.sprayOpacity / 100;
-  const hardness = toolSettings.sprayHardness / 100;
+  const { size, density, opacity: opacityPct, hardness: hardnessPct } = toolSettings.settings.spray;
+  const opacity = opacityPct / 100;
+  const hardness = hardnessPct / 100;
   const color = state.strokeColor ?? toolSettings.foregroundColor;
   const r = color.r / 255;
   const g = color.g / 255;

--- a/src/tools/spray/spray-settings.test.ts
+++ b/src/tools/spray/spray-settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { clampSpraySetting, DEFAULT_SPRAY_SETTINGS } from './spray-settings';
+
+describe('spray-settings', () => {
+  it('defaults match the legacy flat-store spray defaults', () => {
+    expect(DEFAULT_SPRAY_SETTINGS).toEqual({
+      size: 40,
+      density: 20,
+      opacity: 60,
+      hardness: 30,
+    });
+  });
+
+  it('clamps size into [1, 5000]', () => {
+    expect(clampSpraySetting('size', 0)).toBe(1);
+    expect(clampSpraySetting('size', 1)).toBe(1);
+    expect(clampSpraySetting('size', 40)).toBe(40);
+    expect(clampSpraySetting('size', 5000)).toBe(5000);
+    expect(clampSpraySetting('size', 99999)).toBe(5000);
+  });
+
+  it('clamps density into [1, 100]', () => {
+    expect(clampSpraySetting('density', 0)).toBe(1);
+    expect(clampSpraySetting('density', 1)).toBe(1);
+    expect(clampSpraySetting('density', 50)).toBe(50);
+    expect(clampSpraySetting('density', 100)).toBe(100);
+    expect(clampSpraySetting('density', 9999)).toBe(100);
+  });
+
+  it('clamps opacity into [1, 100] — 0 would be a no-op stroke', () => {
+    // Legacy setSprayOpacity used [1, 100] not [0, 100]; preserve that.
+    // The percent-vs-normalised warn-once dedupe lives at the store
+    // edge (setSpraySetting) because it needs setter-name context, so
+    // the clamp helper itself is value-only.
+    expect(clampSpraySetting('opacity', -10)).toBe(1);
+    expect(clampSpraySetting('opacity', 0)).toBe(1);
+    expect(clampSpraySetting('opacity', 60)).toBe(60);
+    expect(clampSpraySetting('opacity', 100)).toBe(100);
+    expect(clampSpraySetting('opacity', 999)).toBe(100);
+  });
+
+  it('clamps hardness into [0, 100] — surfaced as "Softness" with min 0', () => {
+    expect(clampSpraySetting('hardness', -10)).toBe(0);
+    expect(clampSpraySetting('hardness', 0)).toBe(0);
+    expect(clampSpraySetting('hardness', 50)).toBe(50);
+    expect(clampSpraySetting('hardness', 100)).toBe(100);
+    expect(clampSpraySetting('hardness', 999)).toBe(100);
+  });
+});

--- a/src/tools/spray/spray-settings.ts
+++ b/src/tools/spray/spray-settings.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-tool settings slice for the Spray tool.
+ *
+ * Authoritative settings type for spray. The slice lives under
+ * `settings.spray` on the global ToolSettings store (see #453). Same
+ * pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts`: `<Tool>Settings`
+ * interface + `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting`
+ * helper, then registered in `tool-settings-slices.ts`. Four numeric
+ * fields with distinct clamp ranges — `opacity` carries the same
+ * percent-vs-normalised footgun as `setBrushOpacity` and
+ * `setEraserSetting('opacity')`, so the warn-once dedupe runs at the
+ * store edge (not here) when callers reach for it via
+ * `setSpraySetting('opacity', …)`.
+ */
+export interface SpraySettings {
+  size: number;
+  density: number;
+  opacity: number;
+  hardness: number;
+}
+
+export const DEFAULT_SPRAY_SETTINGS: SpraySettings = {
+  size: 40,
+  density: 20,
+  opacity: 60,
+  hardness: 30,
+};
+
+export function clampSpraySetting<K extends keyof SpraySettings>(
+  key: K,
+  value: SpraySettings[K],
+): SpraySettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as SpraySettings[K];
+  }
+  if (key === 'density') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as SpraySettings[K];
+  }
+  if (key === 'opacity') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as SpraySettings[K];
+  }
+  if (key === 'hardness') {
+    const n = value as number;
+    return Math.max(0, Math.min(100, n)) as SpraySettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Thirteenth per-tool slice in the #453 rollout. Spray's four flat fields (`spraySize`, `sprayDensity`, `sprayOpacity`, `sprayHardness`) and their four setters collapse to a single `settings.spray.*` slice with one typed `setSpraySetting<K>(key, value)` setter, following the established slice template.

First slice to mix four numeric fields with distinct clamp ranges:
- `size` — `[1, 5000]` (the standard paint-tool size range)
- `density` — `[1, 100]`
- `opacity` — `[1, 100]` (carries the percent-vs-normalised warn-once dedupe that `setEraserSetting('opacity')` and `setBrushOpacity` carry — the only opacity slice migrated so far that needed it)
- `hardness` — `[0, 100]` (the only field starting at 0; UI surfaces it as a "Softness" slider where 0 means "fully soft", not a no-op)

Read sites in `SprayOptions.tsx` and `spray-interaction.ts` now access `settings.spray.{size,density,opacity,hardness}`. The unit-test mock in `spray-interaction.test.ts` was retargeted to the new slice shape; the store-level percent-vs-normalised opacity test was updated to call `setSpraySetting('opacity', …)` instead of `setSprayOpacity`.

## Test plan

- [x] `npm run typecheck` — clean (only the pre-existing `baseUrl` deprecation warning, unrelated to this PR)
- [x] `npm run lint` — 0 errors, pixel-debt check OK
- [x] `npm test` — 1308 tests pass across 122 files, including:
  - new `spray-settings.test.ts` (clamp helper, 5 tests)
  - new `per-tool slice: spray (#453)` describe block in `tool-settings-store.test.ts` (7 tests: defaults, per-field isolation, each of the four clamp ranges, sibling-slice referential identity)
  - existing `spray-interaction.test.ts` (11 tests, retargeted to the new slice shape)
- [ ] Manual: pick the spray tool, drag the Size/Density/Opacity/Softness sliders in the options bar, paint a stroke — no visible behaviour change vs. prior

https://claude.ai/code/session_011CAfHV7o1pxyFF8Pv5SQ3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_011CAfHV7o1pxyFF8Pv5SQ3Q)_