### PR TITLE
docs(features): note paths/guides round-trip in .lopsy save

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -715,7 +715,7 @@ A compact heads-up readout that mirrors what Photoshop's Info panel surfaces.
 - **Export PSD** (File menu): serialises the current document via the PSD writer at 16-bit precision (pass-through groups are written as `normal` since PSD has no pass-through discriminant)
 
 ### Native Project Format (.lopsy)
-- **Save Project** (`⌘S`): writes the full editor state to a `.lopsy` file and triggers a browser download. Round-trips every layer (raster pixels, text, shape, group), masks, blend modes, opacity, position, clip-to-below, layer effects, color tags, group adjustment node stacks, the active layer, and the document's name / size / background.
+- **Save Project** (`⌘S`): writes the full editor state to a `.lopsy` file and triggers a browser download. Round-trips every layer (raster pixels, text, shape, group), masks, blend modes, opacity, position, clip-to-below, layer effects, color tags, group adjustment node stacks, the active layer, the document's name / size / background, and the workspace's stored vector paths (Paths panel) and canvas guides. (Files saved before paths/guides were serialized simply omit those fields and load with an empty path/guide set.)
 - **Open Project…**: file picker filtered to `.lopsy`. Restores all of the above; pixel data is gzip-compressed inside the file.
 - **Format**: binary container — `LOPSY\0` magic + uint16 version + uint32 manifest-length + UTF-8 JSON manifest + per-layer gzipped RGBA blobs + per-mask raw byte blobs (referenced from the manifest by index). Entirely client-side; no server round-trip.
 


### PR DESCRIPTION
## Summary
Recurring FEATURES.md audit. The `.lopsy` project serializer round-trips stored vector paths (Paths panel) and canvas guides — `project-save.ts` writes them into the manifest (`paths`, `guides`) and `project-load.ts` restores them — but the **Save Project** bullet in FEATURES.md omitted both from its round-trip list.

This adds paths and guides to the documented list and notes that older files lacking the fields load with empty path/guide sets (matching the `?? []` fallbacks in the loader).

## Audit scope
Reviewed recent `origin/main` commits (#595–#605) and swept every tool's modifier/gesture handling against FEATURES.md. Findings:
- Most commits since the last doc update (#605, #594) are internal refactors/perf/test — no doc impact.
- The ICC-correct export (#600) is already documented (lines 733–734).
- The only genuine, unaddressed gap was the `.lopsy` paths/guides round-trip — fixed here.
- The quick-mask "move marquee also moves painted mask" nuance is already in flight via PR #545; not duplicated.
- The Saturation/Vibrance +200 cap correction is in flight via PR #609; not duplicated.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)