### PR TITLE
refactor(text): extract settings into per-tool slice (#453)

### DIFF
--- a/e2e/bug-text-shrink-rotate.spec.ts
+++ b/e2e/bug-text-shrink-rotate.spec.ts
@@ -70,9 +70,9 @@ test('text does not shrink after: add → change size while editing → commit �
   // Use the store directly to set font size — avoids stealing keyboard focus
   await page.evaluate(() => {
     const s = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { setTextFontSize: (n: number) => void };
+      getState: () => { setTextSetting: (key: 'fontSize', value: number) => void };
     };
-    s.getState().setTextFontSize(24);
+    s.getState().setTextSetting('fontSize', 24);
   });
 
   await page.keyboard.press('t');
@@ -101,9 +101,9 @@ test('text does not shrink after: add → change size while editing → commit �
   // ─── Step 3: Change font size to LARGE via store (no focus change) ────────
   await page.evaluate(() => {
     const s = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { setTextFontSize: (n: number) => void };
+      getState: () => { setTextSetting: (key: 'fontSize', value: number) => void };
     };
-    s.getState().setTextFontSize(80);
+    s.getState().setTextSetting('fontSize', 80);
   });
   // Wait for the live preview to upload the new texture
   await page.waitForTimeout(400);

--- a/e2e/composition-export-roundtrip.spec.ts
+++ b/e2e/composition-export-roundtrip.spec.ts
@@ -245,15 +245,15 @@ async function setActiveTool(page: Page, tool: string) {
   await page.waitForTimeout(100);
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
+async function setTextToolSetting(page: Page, key: string, value: unknown) {
   await page.evaluate(
-    ({ setter, value }) => {
+    ({ key, value }) => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
+        getState: () => { setTextSetting: (key: string, value: unknown) => void };
       };
-      store.getState()[setter]!(value);
+      store.getState().setTextSetting(key, value);
     },
-    { setter, value },
+    { key, value },
   );
 }
 
@@ -327,11 +327,11 @@ async function createTextLayer(
   } = {},
 ): Promise<string> {
   // Configure tool settings before entering text mode
-  if (opts.fontFamily) await setToolSetting(page, 'setTextFontFamily', opts.fontFamily);
-  if (opts.fontSize) await setToolSetting(page, 'setTextFontSize', opts.fontSize);
-  if (opts.fontWeight) await setToolSetting(page, 'setTextFontWeight', opts.fontWeight);
-  if (opts.fontStyle) await setToolSetting(page, 'setTextFontStyle', opts.fontStyle);
-  if (opts.textAlign) await setToolSetting(page, 'setTextAlign', opts.textAlign);
+  if (opts.fontFamily) await setTextToolSetting(page, 'fontFamily', opts.fontFamily);
+  if (opts.fontSize) await setTextToolSetting(page, 'fontSize', opts.fontSize);
+  if (opts.fontWeight) await setTextToolSetting(page, 'fontWeight', opts.fontWeight);
+  if (opts.fontStyle) await setTextToolSetting(page, 'fontStyle', opts.fontStyle);
+  if (opts.textAlign) await setTextToolSetting(page, 'align', opts.textAlign);
   if (opts.color) await setForegroundColor(page, opts.color);
 
   await setActiveTool(page, 'text');

--- a/e2e/cut-paste-position.spec.ts
+++ b/e2e/cut-paste-position.spec.ts
@@ -334,13 +334,12 @@ test.describe('Cut text then paste preserves correct clipboard', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setTextFontSize: (s: number) => void;
-          setTextFontFamily: (f: string) => void;
+          setTextSetting: (key: 'fontSize' | 'fontFamily', value: number | string) => void;
         };
       };
       const s = ts.getState();
-      s.setTextFontSize(80);
-      s.setTextFontFamily('Inter');
+      s.setTextSetting('fontSize', 80);
+      s.setTextSetting('fontFamily', 'Inter');
     });
     await setForegroundColor(page, 0, 0, 0);
 

--- a/e2e/rasterize-text-selection.spec.ts
+++ b/e2e/rasterize-text-selection.spec.ts
@@ -99,9 +99,9 @@ test.describe('rasterize text + cmd+click selection alignment', () => {
     // Set font size to 200px via tool settings store
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setFontSize: (v: number) => void };
+        getState: () => { setTextSetting: (key: 'fontSize', value: number) => void };
       };
-      store.getState().setTextFontSize(200);
+      store.getState().setTextSetting('fontSize', 200);
     });
     await page.waitForTimeout(100);
 

--- a/e2e/text-brush-merge.spec.ts
+++ b/e2e/text-brush-merge.spec.ts
@@ -104,10 +104,10 @@ test.describe('Text + brush + merge down', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setTextFontSize: (s: number) => void;
+          setTextSetting: (key: 'fontSize', value: number) => void;
         };
       };
-      ts.getState().setTextFontSize(40);
+      ts.getState().setTextSetting('fontSize', 40);
     });
     await setForegroundColor(page, 255, 0, 0);
 

--- a/e2e/text-selection-merge.spec.ts
+++ b/e2e/text-selection-merge.spec.ts
@@ -116,13 +116,12 @@ test.describe('Text selection + merge', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setTextFontSize: (s: number) => void;
-          setTextFontFamily: (f: string) => void;
+          setTextSetting: (key: 'fontSize' | 'fontFamily', value: number | string) => void;
         };
       };
       const s = ts.getState();
-      s.setTextFontSize(150);
-      s.setTextFontFamily('Inter');
+      s.setTextSetting('fontSize', 150);
+      s.setTextSetting('fontFamily', 'Inter');
     });
     await setForegroundColor(page, 0, 0, 0);
     const textPos = await docToScreen(page, 150, 100);

--- a/src/app/OptionsBar/tool-options/TextOptions.tsx
+++ b/src/app/OptionsBar/tool-options/TextOptions.tsx
@@ -26,20 +26,14 @@ const WEIGHT_LABELS: Record<number, string> = {
 };
 
 export function TextOptions() {
-  const textFontSize = useToolSettingsStore((s) => s.textFontSize);
-  const textFontFamily = useToolSettingsStore((s) => s.textFontFamily);
-  const textFontWeight = useToolSettingsStore((s) => s.textFontWeight);
-  const textFontStyle = useToolSettingsStore((s) => s.textFontStyle);
-  const textAlign = useToolSettingsStore((s) => s.textAlign);
-  const textUnderline = useToolSettingsStore((s) => s.textUnderline);
-  const textStrikethrough = useToolSettingsStore((s) => s.textStrikethrough);
-  const setTextFontSize = useToolSettingsStore((s) => s.setTextFontSize);
-  const setTextFontFamily = useToolSettingsStore((s) => s.setTextFontFamily);
-  const setTextFontWeight = useToolSettingsStore((s) => s.setTextFontWeight);
-  const setTextFontStyle = useToolSettingsStore((s) => s.setTextFontStyle);
-  const setTextAlign = useToolSettingsStore((s) => s.setTextAlign);
-  const setTextUnderline = useToolSettingsStore((s) => s.setTextUnderline);
-  const setTextStrikethrough = useToolSettingsStore((s) => s.setTextStrikethrough);
+  const textFontSize = useToolSettingsStore((s) => s.settings.text.fontSize);
+  const textFontFamily = useToolSettingsStore((s) => s.settings.text.fontFamily);
+  const textFontWeight = useToolSettingsStore((s) => s.settings.text.fontWeight);
+  const textFontStyle = useToolSettingsStore((s) => s.settings.text.fontStyle);
+  const textAlign = useToolSettingsStore((s) => s.settings.text.align);
+  const textUnderline = useToolSettingsStore((s) => s.settings.text.underline);
+  const textStrikethrough = useToolSettingsStore((s) => s.settings.text.strikethrough);
+  const setTextSetting = useToolSettingsStore((s) => s.setTextSetting);
 
   const fontEntry = useMemo(() => {
     const family = extractFamilyName(textFontFamily);
@@ -95,7 +89,7 @@ export function TextOptions() {
 
   const handleFontChange = useCallback(
     (value: string) => {
-      setTextFontFamily(value);
+      setTextSetting('fontFamily', value);
       const family = extractFamilyName(value);
       const entry = fontsByFamily.get(family);
       if (entry) {
@@ -103,7 +97,7 @@ export function TextOptions() {
           const nearest = entry.weights.reduce((prev, curr) =>
             Math.abs(curr - textFontWeight) < Math.abs(prev - textFontWeight) ? curr : prev,
           );
-          setTextFontWeight(nearest);
+          setTextSetting('fontWeight', nearest);
         }
         if (entry.source === 'google') {
           loadGoogleFont(family, entry.weights);
@@ -118,12 +112,12 @@ export function TextOptions() {
         }
       }
     },
-    [textFontWeight, setTextFontFamily, setTextFontWeight],
+    [textFontWeight, setTextSetting],
   );
 
   return (
     <>
-      <Slider label="Size" value={textFontSize} min={1} max={500} onChange={setTextFontSize} />
+      <Slider label="Size" value={textFontSize} min={1} max={500} onChange={(v) => setTextSetting('fontSize', v)} />
       <label className={styles.label} id="text-font-label">Font</label>
       <FontPicker value={textFontFamily} onChange={handleFontChange} />
       <select
@@ -131,7 +125,7 @@ export function TextOptions() {
         value={textFontWeight}
         onChange={(e) => {
           const w = Number(e.target.value);
-          setTextFontWeight(w);
+          setTextSetting('fontWeight', w);
           if (fontEntry?.source === 'google') {
             const family = extractFamilyName(textFontFamily);
             loadFontBinaryToEngine(family, w);
@@ -146,7 +140,7 @@ export function TextOptions() {
       <select
         className={styles.select}
         value={textFontStyle}
-        onChange={(e) => setTextFontStyle(e.target.value as FontStyle)}
+        onChange={(e) => setTextSetting('fontStyle', e.target.value as FontStyle)}
         aria-label="Font style"
       >
         <option value="normal">Normal</option>
@@ -156,7 +150,7 @@ export function TextOptions() {
       <select
         className={styles.select}
         value={textAlign}
-        onChange={(e) => setTextAlign(e.target.value as TextAlign)}
+        onChange={(e) => setTextSetting('align', e.target.value as TextAlign)}
         aria-labelledby="text-align-label"
       >
         <option value="left">Left</option>
@@ -167,7 +161,7 @@ export function TextOptions() {
       <div className={decorationStyles.decorationGroup}>
         <button
           className={`${decorationStyles.decorationBtn} ${textUnderline ? decorationStyles.decorationBtnActive : ''}`}
-          onClick={() => setTextUnderline(!textUnderline)}
+          onClick={() => setTextSetting('underline', !textUnderline)}
           aria-label="Toggle underline"
           aria-pressed={textUnderline}
           title="Underline"
@@ -176,7 +170,7 @@ export function TextOptions() {
         </button>
         <button
           className={`${decorationStyles.decorationBtn} ${textStrikethrough ? decorationStyles.decorationBtnActive : ''}`}
-          onClick={() => setTextStrikethrough(!textStrikethrough)}
+          onClick={() => setTextSetting('strikethrough', !textStrikethrough)}
           aria-label="Toggle strikethrough"
           aria-pressed={textStrikethrough}
           title="Strikethrough"

--- a/src/app/rendering/render-overlay-frame.ts
+++ b/src/app/rendering/render-overlay-frame.ts
@@ -134,17 +134,17 @@ export function renderOverlayFrame(overlayCanvas: HTMLCanvasElement, antPhase: n
     }
   }
   if (textEditing && !editingLayerIsPathText) {
-    const ts = toolState;
+    const text = toolState.settings.text;
     const glyphPositions = Array.from(getGlyphPositions(engine, textEditing.layerId)) as number[];
     renderTextEditOverlay(overlayCtx, textEditing, {
-      fontSize: ts.textFontSize,
-      fontFamily: ts.textFontFamily,
-      fontWeight: ts.textFontWeight,
-      fontStyle: ts.textFontStyle,
+      fontSize: text.fontSize,
+      fontFamily: text.fontFamily,
+      fontWeight: text.fontWeight,
+      fontStyle: text.fontStyle,
       color: toolState.foregroundColor,
       lineHeight: 1.4,
       letterSpacing: 0,
-      textAlign: ts.textAlign,
+      textAlign: text.align,
     }, viewport.zoom, antPhase, glyphPositions);
   }
 

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -18,6 +18,8 @@ import type { StampSettings } from '../tools/stamp/stamp-settings';
 import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import { DEFAULT_MAGNETIC_LASSO_SETTINGS } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { TextSettings } from '../tools/text/text-settings';
+import { DEFAULT_TEXT_SETTINGS } from '../tools/text/text-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -39,6 +41,7 @@ export interface ToolSettingsSlices {
   path: PathSettings;
   stamp: StampSettings;
   magneticLasso: MagneticLassoSettings;
+  text: TextSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -52,4 +55,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   path: DEFAULT_PATH_SETTINGS,
   stamp: DEFAULT_STAMP_SETTINGS,
   magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
+  text: DEFAULT_TEXT_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -593,3 +593,107 @@ describe('per-tool slice: eraser (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: text (#453)', () => {
+  it('exposes text settings under settings.text with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setTextSetting.
+    useToolSettingsStore.getState().setTextSetting('content', 'Text');
+    useToolSettingsStore.getState().setTextSetting('fontSize', 24);
+    useToolSettingsStore.getState().setTextSetting('fontFamily', 'Inter, sans-serif');
+    useToolSettingsStore.getState().setTextSetting('fontWeight', 400);
+    useToolSettingsStore.getState().setTextSetting('fontStyle', 'normal');
+    useToolSettingsStore.getState().setTextSetting('align', 'left');
+    useToolSettingsStore.getState().setTextSetting('underline', false);
+    useToolSettingsStore.getState().setTextSetting('strikethrough', false);
+    const { text } = useToolSettingsStore.getState().settings;
+    expect(text).toEqual({
+      content: 'Text',
+      fontSize: 24,
+      fontFamily: 'Inter, sans-serif',
+      fontWeight: 400,
+      fontStyle: 'normal',
+      align: 'left',
+      underline: false,
+      strikethrough: false,
+    });
+  });
+
+  it('setTextSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.text;
+    useToolSettingsStore.getState().setTextSetting('fontSize', 72);
+    const after = useToolSettingsStore.getState().settings.text;
+    expect(after.fontSize).toBe(72);
+    expect(after.fontFamily).toBe(before.fontFamily);
+    expect(after.fontWeight).toBe(before.fontWeight);
+    expect(after.fontStyle).toBe(before.fontStyle);
+    expect(after.align).toBe(before.align);
+    expect(after.underline).toBe(before.underline);
+    expect(after.strikethrough).toBe(before.strikethrough);
+  });
+
+  it('setTextSetting clamps fontSize into [1, 500]', () => {
+    useToolSettingsStore.getState().setTextSetting('fontSize', 0);
+    expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(1);
+    useToolSettingsStore.getState().setTextSetting('fontSize', 99999);
+    expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(500);
+    useToolSettingsStore.getState().setTextSetting('fontSize', 36);
+    expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(36);
+  });
+
+  it('setTextSetting accepts both normal and italic font styles', () => {
+    useToolSettingsStore.getState().setTextSetting('fontStyle', 'italic');
+    expect(useToolSettingsStore.getState().settings.text.fontStyle).toBe('italic');
+    useToolSettingsStore.getState().setTextSetting('fontStyle', 'normal');
+    expect(useToolSettingsStore.getState().settings.text.fontStyle).toBe('normal');
+  });
+
+  it('setTextSetting accepts all four alignment values', () => {
+    for (const align of ['left', 'center', 'right', 'justify'] as const) {
+      useToolSettingsStore.getState().setTextSetting('align', align);
+      expect(useToolSettingsStore.getState().settings.text.align).toBe(align);
+    }
+  });
+
+  it('setTextSetting toggles decoration booleans independently', () => {
+    useToolSettingsStore.getState().setTextSetting('underline', true);
+    useToolSettingsStore.getState().setTextSetting('strikethrough', true);
+    expect(useToolSettingsStore.getState().settings.text.underline).toBe(true);
+    expect(useToolSettingsStore.getState().settings.text.strikethrough).toBe(true);
+    useToolSettingsStore.getState().setTextSetting('underline', false);
+    expect(useToolSettingsStore.getState().settings.text.underline).toBe(false);
+    // strikethrough unchanged
+    expect(useToolSettingsStore.getState().settings.text.strikethrough).toBe(true);
+  });
+
+  it('setTextSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setTextSetting('fontSize', 48);
+    expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(48);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when text changes. This is the
+    // invariant that justifies slicing instead of fattening the flat
+    // bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -14,6 +14,7 @@ import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
 import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import { clampTextSetting } from '../tools/text/text-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -67,14 +68,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   quickSelectTolerance: 32,
   quickSelectEdgeStrength: 50,
   quickSelectMode: 'add' as const,
-  textContent: 'Text',
-  textFontSize: 24,
-  textFontFamily: 'Inter, sans-serif',
-  textFontWeight: 400,
-  textFontStyle: 'normal' as const,
-  textAlign: 'left' as const,
-  textUnderline: false,
-  textStrikethrough: false,
   brushSpacing: 0,
   brushScatter: 0,
   brushAngle: 0,
@@ -296,14 +289,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       magneticLasso: { ...s.settings.magneticLasso, [key]: clampMagneticLassoSetting(key, value) },
     },
   })),
-  setTextContent: (content) => set({ textContent: content }),
-  setTextFontSize: (size) => set({ textFontSize: Math.max(1, Math.min(500, size)) }),
-  setTextFontFamily: (family) => set({ textFontFamily: family }),
-  setTextFontWeight: (weight) => set({ textFontWeight: weight }),
-  setTextFontStyle: (style) => set({ textFontStyle: style }),
-  setTextAlign: (align) => set({ textAlign: align }),
-  setTextUnderline: (underline) => set({ textUnderline: underline }),
-  setTextStrikethrough: (strikethrough) => set({ textStrikethrough: strikethrough }),
+  setTextSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      text: { ...s.settings.text, [key]: clampTextSetting(key, value) },
+    },
+  })),
 
   setForegroundColor: (color) => set({ foregroundColor: color }),
   setBackgroundColor: (color) => set({ backgroundColor: color }),

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,4 +1,4 @@
-import type { Color, FontStyle, TextAlign } from '../types';
+import type { Color } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
@@ -13,6 +13,7 @@ import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { TextSettings } from '../tools/text/text-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -51,14 +52,6 @@ export interface ToolSettings {
   quickSelectTolerance: number;
   quickSelectEdgeStrength: number;
   quickSelectMode: 'add' | 'subtract';
-  textContent: string;
-  textFontSize: number;
-  textFontFamily: string;
-  textFontWeight: number;
-  textFontStyle: FontStyle;
-  textAlign: TextAlign;
-  textUnderline: boolean;
-  textStrikethrough: boolean;
   brushSpacing: number;
   brushScatter: number;
   brushAngle: number;
@@ -128,14 +121,7 @@ export interface ToolSettings {
   setQuickSelectEdgeStrength: (strength: number) => void;
   setQuickSelectMode: (mode: 'add' | 'subtract') => void;
   setMagneticLassoSetting: <K extends keyof MagneticLassoSettings>(key: K, value: MagneticLassoSettings[K]) => void;
-  setTextContent: (content: string) => void;
-  setTextFontSize: (size: number) => void;
-  setTextFontFamily: (family: string) => void;
-  setTextFontWeight: (weight: number) => void;
-  setTextFontStyle: (style: FontStyle) => void;
-  setTextAlign: (align: TextAlign) => void;
-  setTextUnderline: (underline: boolean) => void;
-  setTextStrikethrough: (strikethrough: boolean) => void;
+  setTextSetting: <K extends keyof TextSettings>(key: K, value: TextSettings[K]) => void;
   setBrushOpacity: (opacity: number) => void;
   setBrushHardness: (hardness: number) => void;
   setPencilSetting: <K extends keyof PencilSettings>(key: K, value: PencilSettings[K]) => void;

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -168,14 +168,14 @@ function renderFrameGpu(
     syncTextLayers(
       engine,
       textEditing,
-      toolState.textFontSize,
-      toolState.textFontFamily,
-      toolState.textFontWeight,
-      toolState.textFontStyle,
-      toolState.textAlign,
+      toolState.settings.text.fontSize,
+      toolState.settings.text.fontFamily,
+      toolState.settings.text.fontWeight,
+      toolState.settings.text.fontStyle,
+      toolState.settings.text.align,
       toolState.foregroundColor,
-      toolState.textUnderline,
-      toolState.textStrikethrough,
+      toolState.settings.text.underline,
+      toolState.settings.text.strikethrough,
       (layerId, x, y) => {
         const layer = layers.find((l) => l.id === layerId);
         if (layer && (layer.x !== x || layer.y !== y)) {

--- a/src/tools/text/text-interaction.test.ts
+++ b/src/tools/text/text-interaction.test.ts
@@ -51,22 +51,21 @@ vi.mock('../../app/editor-store', () => ({
 
 const ts = {
   foregroundColor: { r: 255, g: 128, b: 0, a: 1 },
-  textFontFamily: 'Inter',
-  textFontSize: 24,
-  textFontWeight: 400,
-  textFontStyle: 'normal' as 'normal' | 'italic',
-  textAlign: 'left' as 'left' | 'center' | 'right' | 'justify',
-  textUnderline: false,
-  textStrikethrough: false,
+  settings: {
+    text: {
+      content: 'Text',
+      fontFamily: 'Inter',
+      fontSize: 24,
+      fontWeight: 400,
+      fontStyle: 'normal' as 'normal' | 'italic',
+      align: 'left' as 'left' | 'center' | 'right' | 'justify',
+      underline: false,
+      strikethrough: false,
+    },
+  },
   addRecentColor: vi.fn(),
-  setTextFontSize: vi.fn(),
-  setTextFontFamily: vi.fn(),
-  setTextFontWeight: vi.fn(),
-  setTextFontStyle: vi.fn(),
-  setTextAlign: vi.fn(),
+  setTextSetting: vi.fn(),
   setForegroundColor: vi.fn(),
-  setTextUnderline: vi.fn(),
-  setTextStrikethrough: vi.fn(),
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },
@@ -181,15 +180,19 @@ beforeEach(() => {
   editorState.setActiveLayer.mockClear();
   editorState.addTextLayer.mockClear();
   ts.addRecentColor.mockClear();
-  ts.setTextFontSize.mockClear();
-  ts.setTextFontFamily.mockClear();
-  ts.setTextFontWeight.mockClear();
-  ts.setTextFontStyle.mockClear();
-  ts.setTextAlign.mockClear();
+  ts.setTextSetting.mockClear();
   ts.setForegroundColor.mockClear();
-  ts.setTextUnderline.mockClear();
-  ts.setTextStrikethrough.mockClear();
   ts.foregroundColor = { r: 255, g: 128, b: 0, a: 1 };
+  ts.settings.text = {
+    content: 'Text',
+    fontFamily: 'Inter',
+    fontSize: 24,
+    fontWeight: 400,
+    fontStyle: 'normal',
+    align: 'left',
+    underline: false,
+    strikethrough: false,
+  };
 });
 
 describe('text down — new text drag', () => {
@@ -237,14 +240,14 @@ describe('text down — clicking an existing text layer', () => {
     // Hit region: x 100..100+5*36*0.6, y 50..50+36*1.4
     const result = handleTextDown(makeCtx({ canvasPos: { x: 110, y: 60 } }));
     expect(result).toBeUndefined();
-    expect(ts.setTextFontSize).toHaveBeenCalledWith(36);
-    expect(ts.setTextFontFamily).toHaveBeenCalledWith('Georgia');
-    expect(ts.setTextFontWeight).toHaveBeenCalledWith(700);
-    expect(ts.setTextFontStyle).toHaveBeenCalledWith('italic');
-    expect(ts.setTextAlign).toHaveBeenCalledWith('center');
+    expect(ts.setTextSetting).toHaveBeenCalledWith('fontSize', 36);
+    expect(ts.setTextSetting).toHaveBeenCalledWith('fontFamily', 'Georgia');
+    expect(ts.setTextSetting).toHaveBeenCalledWith('fontWeight', 700);
+    expect(ts.setTextSetting).toHaveBeenCalledWith('fontStyle', 'italic');
+    expect(ts.setTextSetting).toHaveBeenCalledWith('align', 'center');
     expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 10, g: 20, b: 30, a: 1 });
-    expect(ts.setTextUnderline).toHaveBeenCalledWith(true);
-    expect(ts.setTextStrikethrough).toHaveBeenCalledWith(true);
+    expect(ts.setTextSetting).toHaveBeenCalledWith('underline', true);
+    expect(ts.setTextSetting).toHaveBeenCalledWith('strikethrough', true);
     expect(editorState.setActiveLayer).toHaveBeenCalledWith('text-1');
     expect(clearJsPixelData).toHaveBeenCalledWith('text-1');
     expect(uiState.startTextEditing).toHaveBeenCalledWith(

--- a/src/tools/text/text-interaction.ts
+++ b/src/tools/text/text-interaction.ts
@@ -68,19 +68,20 @@ export function commitTextEditing(): void {
     // whether the rAF-driven syncTextLayers loop had time to fire.
     const engine = getEngine();
     if (engine) {
+      const text = toolSettings.settings.text;
       const propsJson = JSON.stringify({
         text: editing.text,
-        fontFamily: toolSettings.textFontFamily,
-        fontSize: toolSettings.textFontSize,
-        fontWeight: toolSettings.textFontWeight,
-        fontStyle: toolSettings.textFontStyle,
+        fontFamily: text.fontFamily,
+        fontSize: text.fontSize,
+        fontWeight: text.fontWeight,
+        fontStyle: text.fontStyle,
         color: [textColor.r / 255, textColor.g / 255, textColor.b / 255, textColor.a],
         lineHeight: 1.4,
         letterSpacing: 0,
-        textAlign: toolSettings.textAlign,
+        textAlign: text.align,
         areaWidth: areaWidth ?? null,
-        underline: toolSettings.textUnderline,
-        strikethrough: toolSettings.textStrikethrough,
+        underline: text.underline,
+        strikethrough: text.strikethrough,
       });
       setTextLayerContent(engine, editing.layerId, propsJson);
       const boundsResult = renderTextLayer(engine, editing.layerId);
@@ -106,20 +107,21 @@ export function commitTextEditing(): void {
   editorState.pushHistory('Text');
   toolSettings.addRecentColor(textColor);
 
+  const textForLayer = toolSettings.settings.text;
   editorState.updateTextLayerProperties(editing.layerId, {
     text: editing.text,
-    fontFamily: toolSettings.textFontFamily,
-    fontSize: toolSettings.textFontSize,
-    fontWeight: toolSettings.textFontWeight,
-    fontStyle: toolSettings.textFontStyle,
+    fontFamily: textForLayer.fontFamily,
+    fontSize: textForLayer.fontSize,
+    fontWeight: textForLayer.fontWeight,
+    fontStyle: textForLayer.fontStyle,
     color: textColor,
-    textAlign: toolSettings.textAlign,
+    textAlign: textForLayer.align,
     width: areaWidth,
     x: finalX,
     y: finalY,
     visible: true,
-    underline: toolSettings.textUnderline,
-    strikethrough: toolSettings.textStrikethrough,
+    underline: textForLayer.underline,
+    strikethrough: textForLayer.strikethrough,
   });
 
   editorState.notifyRender();
@@ -140,14 +142,14 @@ export function handleTextDown(ctx: InteractionContext): InteractionState | unde
   const hitLayer = hitTestTextLayer(editorState.document.layers, canvasPos);
   if (hitLayer) {
     const toolSettings = useToolSettingsStore.getState();
-    toolSettings.setTextFontSize(hitLayer.fontSize);
-    toolSettings.setTextFontFamily(hitLayer.fontFamily);
-    toolSettings.setTextFontWeight(hitLayer.fontWeight);
-    toolSettings.setTextFontStyle(hitLayer.fontStyle);
-    toolSettings.setTextAlign(hitLayer.textAlign);
+    toolSettings.setTextSetting('fontSize', hitLayer.fontSize);
+    toolSettings.setTextSetting('fontFamily', hitLayer.fontFamily);
+    toolSettings.setTextSetting('fontWeight', hitLayer.fontWeight);
+    toolSettings.setTextSetting('fontStyle', hitLayer.fontStyle);
+    toolSettings.setTextSetting('align', hitLayer.textAlign);
     toolSettings.setForegroundColor(hitLayer.color);
-    toolSettings.setTextUnderline(hitLayer.underline);
-    toolSettings.setTextStrikethrough(hitLayer.strikethrough);
+    toolSettings.setTextSetting('underline', hitLayer.underline);
+    toolSettings.setTextSetting('strikethrough', hitLayer.strikethrough);
 
     editorState.setActiveLayer(hitLayer.id);
 
@@ -257,11 +259,12 @@ export function handleTextUp(state: InteractionState, canvasPos: Point): void {
   const boundsW = isAreaText ? Math.abs(dx) : null;
   const boundsH = isAreaText ? Math.abs(dy) : null;
 
+  const text = toolSettings.settings.text;
   const newLayer = createTextLayer({
     name: `Text ${editorState.document.layers.length + 1}`,
     text: '',
-    fontFamily: toolSettings.textFontFamily,
-    fontSize: toolSettings.textFontSize,
+    fontFamily: text.fontFamily,
+    fontSize: text.fontSize,
     color: textColor,
   });
 
@@ -270,9 +273,9 @@ export function handleTextUp(state: InteractionState, canvasPos: Point): void {
     x: boundsX,
     y: boundsY,
     width: boundsW,
-    fontWeight: toolSettings.textFontWeight,
-    fontStyle: toolSettings.textFontStyle,
-    textAlign: toolSettings.textAlign,
+    fontWeight: text.fontWeight,
+    fontStyle: text.fontStyle,
+    textAlign: text.align,
     visible: true, // GPU renders text preview in real-time
   });
 

--- a/src/tools/text/text-settings.test.ts
+++ b/src/tools/text/text-settings.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TEXT_SETTINGS,
+  clampTextSetting,
+  type TextSettings,
+} from './text-settings';
+
+describe('text-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_TEXT_SETTINGS).toEqual({
+      content: 'Text',
+      fontSize: 24,
+      fontFamily: 'Inter, sans-serif',
+      fontWeight: 400,
+      fontStyle: 'normal',
+      align: 'left',
+      underline: false,
+      strikethrough: false,
+    } satisfies TextSettings);
+  });
+
+  it('clamps fontSize into [1, 500]', () => {
+    expect(clampTextSetting('fontSize', 0)).toBe(1);
+    expect(clampTextSetting('fontSize', -5)).toBe(1);
+    expect(clampTextSetting('fontSize', 99999)).toBe(500);
+    expect(clampTextSetting('fontSize', 24)).toBe(24);
+    expect(clampTextSetting('fontSize', 500)).toBe(500);
+    expect(clampTextSetting('fontSize', 1)).toBe(1);
+  });
+
+  it('does not round fontSize — preserves fractional sizes', () => {
+    // Sub-pixel font sizes are meaningful for animations and HDPI rendering,
+    // so the clamp range guards the bounds without forcing integer values.
+    expect(clampTextSetting('fontSize', 24.5)).toBe(24.5);
+    expect(clampTextSetting('fontSize', 36.25)).toBe(36.25);
+  });
+
+  it('passes string fields through untouched', () => {
+    expect(clampTextSetting('fontFamily', 'Comic Sans MS')).toBe('Comic Sans MS');
+    expect(clampTextSetting('content', 'Hello, world')).toBe('Hello, world');
+    // Empty strings pass through — the engine handles empty content,
+    // and an empty fontFamily falls back to the browser default.
+    expect(clampTextSetting('fontFamily', '')).toBe('');
+    expect(clampTextSetting('content', '')).toBe('');
+  });
+
+  it('passes enum fields through untouched', () => {
+    expect(clampTextSetting('fontStyle', 'italic')).toBe('italic');
+    expect(clampTextSetting('fontStyle', 'normal')).toBe('normal');
+    expect(clampTextSetting('align', 'center')).toBe('center');
+    expect(clampTextSetting('align', 'justify')).toBe('justify');
+  });
+
+  it('passes booleans through untouched', () => {
+    expect(clampTextSetting('underline', true)).toBe(true);
+    expect(clampTextSetting('underline', false)).toBe(false);
+    expect(clampTextSetting('strikethrough', true)).toBe(true);
+    expect(clampTextSetting('strikethrough', false)).toBe(false);
+  });
+});

--- a/src/tools/text/text-settings.ts
+++ b/src/tools/text/text-settings.ts
@@ -1,0 +1,54 @@
+import type { FontStyle, TextAlign } from '../../types';
+
+/**
+ * Per-tool settings slice for the Text tool.
+ *
+ * Authoritative settings type for text. The slice lives under
+ * `settings.text` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Eight fields covering typography
+ * (size, family, weight, style), layout (align), decoration
+ * (underline, strikethrough), and the staged content string.
+ *
+ * Only `fontSize` carries a clamp range — the rest are either
+ * trusted string identifiers (`fontFamily` from the font catalog),
+ * tagged-union enums (`fontStyle`, `align`), or booleans whose set
+ * of valid values is the type itself.
+ */
+export interface TextSettings {
+  content: string;
+  fontSize: number;
+  fontFamily: string;
+  fontWeight: number;
+  fontStyle: FontStyle;
+  align: TextAlign;
+  underline: boolean;
+  strikethrough: boolean;
+}
+
+export const DEFAULT_TEXT_SETTINGS: TextSettings = {
+  content: 'Text',
+  fontSize: 24,
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 400,
+  fontStyle: 'normal',
+  align: 'left',
+  underline: false,
+  strikethrough: false,
+};
+
+export function clampTextSetting<K extends keyof TextSettings>(
+  key: K,
+  value: TextSettings[K],
+): TextSettings[K] {
+  if (key === 'fontSize') {
+    const n = value as number;
+    return Math.max(1, Math.min(500, n)) as TextSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Fourteenth per-tool slice in the [#453](https://github.com/theseamusjames/lopsy.art/issues/453) rollout. Text settings move from the eight flat fields (`textContent`, `textFontSize`, `textFontFamily`, `textFontWeight`, `textFontStyle`, `textAlign`, `textUnderline`, `textStrikethrough`) and their eight setters to a single `settings.text.*` slice with one typed `setTextSetting<K>(key, value)` setter, following the established slice template (`<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + `clamp<Tool>Setting`, registered in `tool-settings-slices.ts`).

Largest slice landed so far by field count, the first slice to carry mixed-arity fields (one string `content`, three typography identifiers, two booleans, two enums). The legacy `textAlign` field folds into `settings.text.align` — shorter inside the slice's `text.` prefix, no semantic change.

## What changed

- New `src/tools/text/text-settings.ts` — `TextSettings` interface + defaults + `clampTextSetting` (only `fontSize` carries a clamp range `[1, 500]`; the rest are trusted string identifiers, tagged-union enums, or booleans).
- Register `text` in `ToolSettingsSlices`.
- Replace the eight setters on `tool-settings-store.ts` with one typed `setTextSetting` (~5 lines).
- Retarget read sites in `TextOptions.tsx`, `text-interaction.ts` (commit, hit-test-fill-from, area-text creation), `useCanvasRendering.ts` (syncTextLayers), and `render-overlay-frame.ts`.
- Retarget six e2e helpers to the new typed setter. `composition-export-roundtrip.spec.ts`'s `setToolSetting` helper was only used by text setters, so it collapses into a single typed `setTextToolSetting` wrapper.

## Tests

- New `src/tools/text/text-settings.test.ts` — 6 tests covering defaults, fontSize clamp at boundaries, fractional sizes preserved, string passthrough, enum acceptance, boolean passthrough.
- New `per-tool slice: text (#453)` describe block in `tool-settings-store.test.ts` — 7 tests covering defaults round-trip, single-field isolation across all eight fields, fontSize clamp, both font-style enums, all four alignment values, decoration toggle independence, and sibling-slice referential identity across all eleven `main`-side slices.
- `text-interaction.test.ts` mock store updated to use the slice shape.
- Full suite: 1309 unit tests pass, lint clean (0 errors), typecheck clean.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (1309 / 1309)
- [ ] Pick the text tool in the toolbox → typography options bar opens; setting size/weight/style/align/underline/strikethrough updates the live preview
- [ ] Click an existing text layer with the text tool active → its typography pulls into the options bar
- [ ] Confirm the e2e suite still passes (`text-on-path`, `text-brush-merge`, `text-selection-merge`, `rasterize-text-selection`, `cut-paste-position`, `bug-text-shrink-rotate`, `composition-export-roundtrip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSSSkWbVfLGVGo7wVxHGNC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSSSkWbVfLGVGo7wVxHGNC)_