### PR TITLE
docs(features): correct Saturation/Vibrance node cap to +200

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -321,7 +321,7 @@ Available node types (Add menu):
 - **Exposure** — stops (multiplier = 2^value)
 - **Contrast** — -100 to +100
 - **Highlights / Shadows** — Highlights -100 to +100, Shadows -100 to +100, Whites -100 to +100, Blacks -100 to +100
-- **Saturation** — Saturation -100 to +100, Vibrance -100 to +100
+- **Saturation** — Saturation -100 to +200, Vibrance -100 to +200 (the -100 floor is full desaturation; the cap extrapolates past 1× saturation distance from gray and only clips at the gamut edge)
 - **Vignette** — 0 to 100 (now correctly piped through the per-group adjustment pipeline)
 - **Curves** — per-channel tone curves (RGB master + R / G / B), evaluated as
   monotone cubic Hermite splines. Master applies to every channel first,


### PR DESCRIPTION
## What

The Saturation adjustment node's **Saturation** and **Vibrance** sliders were raised from a +100 cap to a +200 cap in [#585](https://github.com/theseamusjames/lopsy.art/pull/585), but FEATURES.md still listed the old `-100 to +100` range under Image Adjustments → Saturation.

Corrected the range to `-100 to +200` and noted that the `-100` floor is full desaturation while the higher cap extrapolates past 1× saturation distance from gray (clipping only at the gamut edge).

## Why

This was caught by a scheduled audit reviewing FEATURES.md for accuracy and exhaustiveness against the current code. `SaturationControls.tsx` now uses `max={200}` for both sliders; the catalog was stale. Subsequent docs commits (#594, #605) didn't catch it.

Note: this is unrelated to open PR [#612](https://github.com/theseamusjames/lopsy.art/pull/612) (paths/guides round-trip), so it ships as its own one-line change off `main`.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)