### PR TITLE
fix(cursor): show default arrow cursor over rulers

### DIFF
--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -99,6 +99,7 @@ export function useCanvasCursor(
   const hoveredHandle = useUIStore((s) => s.activeTransformHandle);
   const transform = useUIStore((s) => s.transform);
   const isLiquifyOpen = useUIStore((s) => s.liquify !== null);
+  const rulerHover = useUIStore((s) => s.rulerHover);
   const selectionActive = useEditorStore((s) => s.selection.active);
   const selectedPathId = useEditorStore((s) => s.selectedPathId);
 
@@ -109,7 +110,9 @@ export function useCanvasCursor(
 
     let cursorClass: string;
 
-    if (showsGrabCursor(pointerMode)) {
+    if (rulerHover) {
+      cursorClass = styles.canvasDefault ?? '';
+    } else if (showsGrabCursor(pointerMode)) {
       cursorClass = styles.canvasGrab ?? '';
     } else if (isLiquifyOpen) {
       cursorClass = styles.canvasNone ?? '';
@@ -140,7 +143,7 @@ export function useCanvasCursor(
     if (cursorClass) {
       container.classList.add(cursorClass);
     }
-  }, [containerRef, pointerMode, activeTool, hoveredHandle, transform, isLiquifyOpen, selectionActive, selectedPathId]);
+  }, [containerRef, pointerMode, activeTool, hoveredHandle, transform, isLiquifyOpen, rulerHover, selectionActive, selectedPathId]);
 
   // Hit test transform handles on hover
   const updateHoveredHandle = useCallback(


### PR DESCRIPTION
## Summary
- When hovering over the ruler area (for dragging guides), the cursor now shows the default arrow instead of the active tool's cursor (crosshair, none, etc.)
- Adds a `rulerHover` check as the first condition in the cursor class computation in `useCanvasCursor.ts`

## Test plan
- [ ] Select the brush tool (cursor hidden on canvas) → hover over a ruler → cursor should be a default arrow
- [ ] Select the marquee tool (crosshair on canvas) → hover over a ruler → cursor should be a default arrow
- [ ] Move back from the ruler to the canvas → cursor should revert to the tool's cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)