### PR TITLE
fix(crop): clear marquee after crop and fix undo restoring wrong content

### DIFF
--- a/src/app/MenuBar/menus/edit-menu.ts
+++ b/src/app/MenuBar/menus/edit-menu.ts
@@ -28,9 +28,10 @@ export function fillSelection(): void {
 }
 
 export function cropToSelection(): void {
-  const { selection } = useEditorStore.getState();
-  if (!selection.active || !selection.bounds) return;
-  useEditorStore.getState().cropCanvas(selection.bounds);
+  const state = useEditorStore.getState();
+  if (!state.selection.active || !state.selection.bounds) return;
+  state.cropCanvas(state.selection.bounds);
+  state.clearSelection();
 }
 
 export function createEditMenu(showFilterDialog: (id: FilterDialogId) => void): MenuDef {

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -661,13 +661,19 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
 
   cropCanvas: (rect) => {
     const s = get();
+    const doc = s.document;
+    const x1 = Math.max(0, Math.round(rect.x));
+    const y1 = Math.max(0, Math.round(rect.y));
+    const x2 = Math.min(doc.width, Math.round(rect.x + rect.width));
+    const y2 = Math.min(doc.height, Math.round(rect.y + rect.height));
+    if (x2 - x1 <= 0 || y2 - y1 <= 0) return;
+    s.pushHistory('Crop Canvas');
     const result = computeCropCanvas(
-      s.document,
-      resolveAllPixelData(s.document.layerOrder, s.document.layers),
+      doc,
+      resolveAllPixelData(doc.layerOrder, doc.layers),
       s.renderVersion, rect,
     );
     if (!result) return;
-    s.pushHistory('Crop Canvas');
     applyActionResult(set, result);
     if (result.layerPixelData && result.document) {
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);


### PR DESCRIPTION
## Summary
- **Marquee stays after crop**: `cropToSelection()` now calls `clearSelection()` after cropping so the marching ants don't linger at the old position.
- **Undo restores wrong content**: `cropCanvas()` was calling `computeCropCanvas()` (which mutates GPU textures in-place via `cropLayerTexture`) *before* `pushHistory()`, so the undo snapshot captured the already-cropped pixels. Moved `pushHistory()` before the compute step and added a pre-validation guard to avoid pushing history for zero-area rects.

## Test plan
- [x] Existing unit tests pass (crop-canvas, document-slice)
- [ ] Open a 4K+ document, make a small marquee selection, Edit > Crop — marching ants should disappear
- [ ] Undo — canvas and content should both restore to original size
- [ ] Redo — crop should re-apply correctly
- [ ] Crop with a zero-area rect should be a no-op (no history entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)