### PR TITLE
refactor(healing): extract settings into per-tool slice (#453)

### DIFF
--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -57,7 +57,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'stamp') {
     ts.setStampSetting('size', ts.settings.stamp.size + delta);
   } else if (tool === 'healing') {
-    ts.setHealingSize(ts.healingSize + delta);
+    ts.setHealingSetting('size', ts.settings.healing.size + delta);
   } else if (tool === 'path') {
     ts.setPathSetting('strokeWidth', ts.settings.path.strokeWidth + delta);
   } else if (tool === 'shape') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -22,6 +22,8 @@ import type { TextSettings } from '../tools/text/text-settings';
 import { DEFAULT_TEXT_SETTINGS } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
+import type { HealingSettings } from '../tools/healing/healing-settings';
+import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -45,6 +47,7 @@ export interface ToolSettingsSlices {
   magneticLasso: MagneticLassoSettings;
   text: TextSettings;
   spray: SpraySettings;
+  healing: HealingSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -60,4 +63,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
+  healing: DEFAULT_HEALING_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -101,6 +101,23 @@ describe('opacity setters — issue #250 (percent vs normalised footgun)', () =>
     expect(messages.some((m: string) => m.includes('setEraserSetting(opacity)'))).toBe(true);
     expect(messages.some((m: string) => m.includes('setSpraySetting(opacity)'))).toBe(true);
   });
+
+  it('also warns from setHealingSetting(opacity) and clamps the value to 1', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setHealingSetting('opacity', 0.5);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const messages = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? ''));
+    expect(messages.some((m: string) => m.includes('setHealingSetting(opacity)'))).toBe(true);
+    // The clamp range starts at 1, so a normalised 0.5 ends up as 1, not 0,
+    // which would have been a silent no-op stroke.
+    expect(store.getState().settings.healing.opacity).toBe(1);
+  });
+
+  it('does not warn when setHealingSetting touches size with a fractional value', async () => {
+    const { useToolSettingsStore: store } = await import('./tool-settings-store');
+    store.getState().setHealingSetting('size', 0.5);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('per-tool slice: wand (#453)', () => {
@@ -775,6 +792,74 @@ describe('per-tool slice: spray (#453)', () => {
     expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: healing (#453)', () => {
+  it('exposes healing settings under settings.healing with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setHealingSetting.
+    useToolSettingsStore.getState().setHealingSetting('size', 20);
+    useToolSettingsStore.getState().setHealingSetting('opacity', 100);
+    const { healing } = useToolSettingsStore.getState().settings;
+    expect(healing).toEqual({ size: 20, opacity: 100 });
+  });
+
+  it('setHealingSetting updates one field without disturbing the other', () => {
+    const before = useToolSettingsStore.getState().settings.healing;
+    useToolSettingsStore.getState().setHealingSetting('size', 75);
+    const after = useToolSettingsStore.getState().settings.healing;
+    expect(after.size).toBe(75);
+    expect(after.opacity).toBe(before.opacity);
+  });
+
+  it('setHealingSetting clamps size into [1, 5000]', () => {
+    useToolSettingsStore.getState().setHealingSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(1);
+    useToolSettingsStore.getState().setHealingSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(5000);
+  });
+
+  it('setHealingSetting clamps opacity into [1, 100]', () => {
+    // The legacy setHealingOpacity clamped to [1, 100], not [0, 100] —
+    // a 0 here would silently produce a no-op healing stroke, the same
+    // percent-vs-normalised footgun guarded by the warn-once dedupe.
+    // Preserve that range under the slice.
+    useToolSettingsStore.getState().setHealingSetting('opacity', -10);
+    expect(useToolSettingsStore.getState().settings.healing.opacity).toBe(1);
+    useToolSettingsStore.getState().setHealingSetting('opacity', 200);
+    expect(useToolSettingsStore.getState().settings.healing.opacity).toBe(100);
+  });
+
+  it('setHealingSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setHealingSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.healing.size).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -16,6 +16,7 @@ import { clampStampSetting } from '../tools/stamp/stamp-settings';
 import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
+import { clampHealingSetting } from '../tools/healing/healing-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -61,8 +62,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
   ],
   gradientReverse: false,
-  healingSize: 20,
-  healingOpacity: 100,
   dodgeExposure: 50,
   dodgeMode: 'dodge',
   quickSelectSize: 20,
@@ -241,10 +240,14 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       stamp: { ...s.settings.stamp, [key]: clampStampSetting(key, value) },
     },
   })),
-  setHealingSize: (size) => set({ healingSize: Math.max(1, Math.min(5000, size)) }),
-  setHealingOpacity: (opacity) => {
-    warnIfNormalisedOpacity('setHealingOpacity', opacity);
-    set({ healingOpacity: Math.max(1, Math.min(100, opacity)) });
+  setHealingSetting: (key, value) => {
+    if (key === 'opacity') warnIfNormalisedOpacity('setHealingSetting(opacity)', value as number);
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        healing: { ...s.settings.healing, [key]: clampHealingSetting(key, value) },
+      },
+    }));
   },
   setPathSetting: (key, value) => set((s) => ({
     settings: {

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -15,6 +15,7 @@ import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
+import type { HealingSettings } from '../tools/healing/healing-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -45,8 +46,6 @@ export interface ToolSettings {
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
-  healingSize: number;
-  healingOpacity: number;
   dodgeExposure: number;
   dodgeMode: DodgeMode;
   quickSelectSize: number;
@@ -102,8 +101,7 @@ export interface ToolSettings {
   setBrushAngle: (angle: number) => void;
   setActiveBrushTip: (tip: BrushTipData | null) => void;
   setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
-  setHealingSize: (size: number) => void;
-  setHealingOpacity: (opacity: number) => void;
+  setHealingSetting: <K extends keyof HealingSettings>(key: K, value: HealingSettings[K]) => void;
   setDodgeExposure: (exposure: number) => void;
   setDodgeMode: (mode: DodgeMode) => void;
   setSpongeSetting: <K extends keyof SpongeSettings>(key: K, value: SpongeSettings[K]) => void;

--- a/src/tools/healing/HealingOptions.tsx
+++ b/src/tools/healing/HealingOptions.tsx
@@ -5,18 +5,17 @@ import { docScaledMax } from '../../utils/slider-ranges';
 import styles from '../../app/OptionsBar/OptionsBar.module.css';
 
 export function HealingOptions() {
-  const healingSize = useToolSettingsStore((s) => s.healingSize);
-  const setHealingSize = useToolSettingsStore((s) => s.setHealingSize);
-  const healingOpacity = useToolSettingsStore((s) => s.healingOpacity);
-  const setHealingOpacity = useToolSettingsStore((s) => s.setHealingOpacity);
+  const healingSize = useToolSettingsStore((s) => s.settings.healing.size);
+  const healingOpacity = useToolSettingsStore((s) => s.settings.healing.opacity);
+  const setHealingSetting = useToolSettingsStore((s) => s.setHealingSetting);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 200);
 
   return (
     <>
-      <Slider label="Size" value={healingSize} min={1} max={sizeMax} onChange={setHealingSize} />
-      <Slider label="Opacity" value={healingOpacity} min={1} max={100} onChange={setHealingOpacity} />
+      <Slider label="Size" value={healingSize} min={1} max={sizeMax} onChange={(v) => setHealingSetting('size', v)} />
+      <Slider label="Opacity" value={healingOpacity} min={1} max={100} onChange={(v) => setHealingSetting('opacity', v)} />
       <span className={styles.hint}>Alt/Cmd+click to set source</span>
     </>
   );

--- a/src/tools/healing/healing-interaction.test.ts
+++ b/src/tools/healing/healing-interaction.test.ts
@@ -22,8 +22,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  healingSize: 20,
-  healingOpacity: 100,
+  settings: {
+    healing: { size: 20, opacity: 100 },
+  },
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },

--- a/src/tools/healing/healing-interaction.ts
+++ b/src/tools/healing/healing-interaction.ts
@@ -48,8 +48,7 @@ export function handleHealingDown(ctx: InteractionContext): InteractionState | u
     };
   }
 
-  const toolSettings = useToolSettingsStore.getState();
-  const { healingSize, healingOpacity } = toolSettings;
+  const { size: healingSize, opacity: healingOpacity } = useToolSettingsStore.getState().settings.healing;
 
   if (shiftKey && ctx.lastPaintPointRef.current && ctx.lastPaintPointRef.current.layerId === activeLayerId) {
     const spacing = Math.max(1, healingSize * 0.25);
@@ -78,8 +77,7 @@ export function handleHealingMove(
 ): void {
   if (!state.lastPoint || !stampOffsetRef.current || !state.layerId) return;
 
-  const toolSettings = useToolSettingsStore.getState();
-  const { healingSize, healingOpacity } = toolSettings;
+  const { size: healingSize, opacity: healingOpacity } = useToolSettingsStore.getState().settings.healing;
   const spacing = Math.max(1, healingSize * 0.25);
 
   const pts = interpolateFlat(state.lastPoint, layerLocalPos, spacing);

--- a/src/tools/healing/healing-settings.test.ts
+++ b/src/tools/healing/healing-settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_HEALING_SETTINGS,
+  clampHealingSetting,
+  type HealingSettings,
+} from './healing-settings';
+
+describe('healing-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_HEALING_SETTINGS).toEqual({
+      size: 20,
+      opacity: 100,
+    } satisfies HealingSettings);
+  });
+
+  it('clamps size into [1, 5000]', () => {
+    expect(clampHealingSetting('size', 0)).toBe(1);
+    expect(clampHealingSetting('size', -5)).toBe(1);
+    expect(clampHealingSetting('size', 99999)).toBe(5000);
+    expect(clampHealingSetting('size', 20)).toBe(20);
+    expect(clampHealingSetting('size', 5000)).toBe(5000);
+    expect(clampHealingSetting('size', 1)).toBe(1);
+  });
+
+  it('clamps opacity into [1, 100]', () => {
+    // Range starts at 1, not 0 — a 0 here would silently produce a no-op
+    // stroke, the same percent-vs-normalised footgun guarded by the
+    // warn-once dedupe in the store.
+    expect(clampHealingSetting('opacity', -10)).toBe(1);
+    expect(clampHealingSetting('opacity', 0)).toBe(1);
+    expect(clampHealingSetting('opacity', 200)).toBe(100);
+    expect(clampHealingSetting('opacity', 50)).toBe(50);
+    expect(clampHealingSetting('opacity', 1)).toBe(1);
+    expect(clampHealingSetting('opacity', 100)).toBe(100);
+  });
+
+  it('does not round numeric fields — preserves fractional values inside the range', () => {
+    // Sub-pixel sizes are meaningful for HDPI rendering and animations,
+    // so the clamp range guards the bounds without forcing integers.
+    expect(clampHealingSetting('size', 20.5)).toBe(20.5);
+    expect(clampHealingSetting('opacity', 75.25)).toBe(75.25);
+  });
+});

--- a/src/tools/healing/healing-settings.ts
+++ b/src/tools/healing/healing-settings.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-tool settings slice for the Healing Brush tool.
+ *
+ * Authoritative settings type for healing. The slice lives under
+ * `settings.healing` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts`: `<Tool>Settings` interface
+ * + `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting` helper, then
+ * registered in `tool-settings-slices.ts`. Two numeric fields: `size`
+ * and `opacity`. Mirrors the eraser-slice shape — opacity clamps to
+ * `[1, 100]` (not `[0, 100]`) so callers can't silently get a no-op
+ * stroke, the same percent-vs-normalised footgun guarded by the
+ * warn-once dedupe in the store.
+ */
+export interface HealingSettings {
+  size: number;
+  opacity: number;
+}
+
+export const DEFAULT_HEALING_SETTINGS: HealingSettings = {
+  size: 20,
+  opacity: 100,
+};
+
+export function clampHealingSetting<K extends keyof HealingSettings>(
+  key: K,
+  value: HealingSettings[K],
+): HealingSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as HealingSettings[K];
+  }
+  if (key === 'opacity') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as HealingSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Fifteenth per-tool slice for #453 — migrates the **Healing Brush** from the flat-bag `healingSize` / `healingOpacity` fields to `settings.healing.{size,opacity}`, following the eraser template.

Healing mirrors the eraser shape exactly (two numeric fields, opacity carries the percent-vs-normalised warn-once guard), so the slice infrastructure carries a second tool through that pattern with no surprises. Small surface, low risk: 2 fields, 5 read sites across 4 files (`HealingOptions.tsx`, `healing-interaction.ts` ×2, `tool-shortcuts.ts`); no e2e tests reference the legacy field or setter names.

## Changes

- New `src/tools/healing/healing-settings.ts` with `HealingSettings` interface, `DEFAULT_HEALING_SETTINGS`, and `clampHealingSetting` helper. Same shape as `eraser-settings.ts`.
- `settings.healing` registered in `ToolSettingsSlices` (`src/app/tool-settings-slices.ts`).
- New typed `setHealingSetting(key, value)` on the store; the `opacity` branch keeps the warn-once `percent-vs-normalised` guard.
- Legacy `healingSize`, `healingOpacity`, `setHealingSize`, `setHealingOpacity` removed from `tool-settings-types.ts` and `tool-settings-store.ts`.
- Read sites migrated:
  - `src/tools/healing/HealingOptions.tsx` → `settings.healing.size` / `settings.healing.opacity` + `setHealingSetting`.
  - `src/tools/healing/healing-interaction.ts` (both `handleHealingDown` and `handleHealingMove`).
  - `src/app/shortcuts/tool-shortcuts.ts` — `[`/`]` size shortcut.
- `src/tools/healing/healing-interaction.test.ts` mock retargeted to the new `settings.healing` shape — all three pre-existing assertions still pass.

## Tests

- New `src/tools/healing/healing-settings.test.ts` covers defaults, size clamp `[1, 5000]`, opacity clamp `[1, 100]`, and that fractional values inside the range pass through unrounded.
- New `per-tool slice: healing (#453)` describe block in `src/app/tool-settings-store.test.ts` covering defaults round-trip, independent-field updates, both clamps, and sibling-slice referential identity across all twelve `main`-side slices (wand, fill, marquee, smudge, pencil, sponge, path, stamp, eraser, magneticLasso, text, spray).
- Two new warn-once tests confirm `setHealingSetting('opacity', 0.5)` warns and clamps to `1`, and `setHealingSetting('size', 0.5)` does **not** warn (no percent footgun on size).
- Full suite: `npx vitest run` — 1332 tests pass. `npm run typecheck` — clean. `npm run lint` — 0 errors. `npx vite build` — clean.

## Acceptance criteria progress

The two criteria addressed:

> Per-tool `*Settings` types are used by the store, not decorative.
> Adding a new tool's settings is a one-file change in the tool's directory.

…now hold for **healing** in addition to wand, fill, marquee, smudge, pencil, sponge, path, stamp, eraser, magneticLasso, text, spray on `main`. Remaining: brush (largest), shape, gradient, dodge, quick-select (the latter two have stale earlier PRs but are otherwise still flat on `main`), plus the cross-tool root fields (aspectRatio, gradient*, symmetry*, color).

## Test plan

- [x] `npx vitest run` — 1332 tests pass.
- [x] `npm run typecheck` — passes.
- [x] `npm run lint` — 0 errors.
- [x] `npx vite build` — production bundle builds clean.
- [ ] Manual smoke: Healing tool — size slider, opacity slider, `[`/`]` shortcuts, alt/cmd-click source + drag stroke.

---
_Generated by [Claude Code](https://claude.ai/code/session_018rFPQ7bWTvHfxzssUoG5vm)_