### PR TITLE
refactor(shape): extract settings into per-tool slice (#453)

### DIFF
--- a/e2e/GUIDE.md
+++ b/e2e/GUIDE.md
@@ -460,10 +460,10 @@ instead. `sides=6` works for the polygon SDF and can be used for
 
 ### 11. Tool-settings store expects specific ranges
 
-`setShapePolygonSides` clamps to `[3, 64]`. `setShapeCornerRadius`
-clamps to `[0, 200]`. `setBrushSize` clamps to `[1, 2000]`. Check the
-setter before asserting on the stored value — the clamp may silently
-change what you wrote.
+`setShapeSetting('polygonSides', …)` clamps to `[3, 64]`.
+`setShapeSetting('cornerRadius', …)` clamps to `[0, 200]`. `setBrushSize`
+clamps to `[1, 2000]`. Check the setter before asserting on the stored
+value — the clamp may silently change what you wrote.
 
 ### 12. Fit-to-view caps zoom at 1.0
 

--- a/e2e/composition-shapes.spec.ts
+++ b/e2e/composition-shapes.spec.ts
@@ -123,6 +123,16 @@ async function setFillSetting(page: Page, key: 'tolerance' | 'contiguous', value
   }, { key, value });
 }
 
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
+}
+
 const toolKeyMap: Record<string, string> = {
   move: 'v',
   brush: 'b',
@@ -370,10 +380,10 @@ test.describe('Composition 2: Geometric Design', () => {
     await setActiveTool(page, 'shape');
     expect(await getActiveTool(page)).toBe('shape');
 
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 220, g: 50, b: 50, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 0 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 0);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 220, g: 50, b: 50, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 0 });
+    await setShapeSetting(page, 'strokeWidth', 0);
 
     await dragAtDoc(page, { x: 200, y: 200 }, { x: 300, y: 300 });
 
@@ -389,12 +399,12 @@ test.describe('Composition 2: Geometric Design', () => {
     const hexLayerId = await addLayer(page);
 
     await setActiveTool(page, 'shape');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 6);
-    await setToolSetting(page, 'setShapeCornerRadius', 8);
-    await setToolSetting(page, 'setShapeFillColor', { r: 50, g: 120, b: 220, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 255, g: 255, b: 255, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 3);
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 6);
+    await setShapeSetting(page, 'cornerRadius', 8);
+    await setShapeSetting(page, 'fillColor', { r: 50, g: 120, b: 220, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 255, g: 255, b: 255, a: 1 });
+    await setShapeSetting(page, 'strokeWidth', 3);
 
     await dragAtDoc(page, { x: 100, y: 100 }, { x: 200, y: 200 });
 
@@ -410,11 +420,11 @@ test.describe('Composition 2: Geometric Design', () => {
     const triLayerId = await addLayer(page);
 
     await setActiveTool(page, 'shape');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 3);
-    await setToolSetting(page, 'setShapeCornerRadius', 0);
-    await setToolSetting(page, 'setShapeFillColor', { r: 50, g: 200, b: 100, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 0 });
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 3);
+    await setShapeSetting(page, 'cornerRadius', 0);
+    await setShapeSetting(page, 'fillColor', { r: 50, g: 200, b: 100, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 0 });
 
     await dragAtDoc(page, { x: 320, y: 80 }, { x: 420, y: 200 });
 

--- a/e2e/delete-inverted-selection.spec.ts
+++ b/e2e/delete-inverted-selection.spec.ts
@@ -132,15 +132,13 @@ test('delete with inverted selection clears only the correct region', async ({ p
     };
     const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
       getState: () => {
-        setShapeMode: (m: string) => void;
-        setShapeFillColor: (c: { r: number; g: number; b: number; a: number }) => void;
-        setShapeOutput: (o: string) => void;
+        setShapeSetting: (key: string, value: unknown) => void;
       };
     };
     ui.getState().setActiveTool('shape');
-    ts.getState().setShapeMode('ellipse');
-    ts.getState().setShapeFillColor({ r: 0, g: 0, b: 0, a: 1 });
-    ts.getState().setShapeOutput('pixels');
+    ts.getState().setShapeSetting('mode', 'ellipse');
+    ts.getState().setShapeSetting('fillColor', { r: 0, g: 0, b: 0, a: 1 });
+    ts.getState().setShapeSetting('output', 'pixels');
   });
   await page.waitForTimeout(100);
 

--- a/e2e/polygon-rotation.spec.ts
+++ b/e2e/polygon-rotation.spec.ts
@@ -41,16 +41,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   );
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -132,7 +130,7 @@ test.describe('Polygon rotation fix (#60)', () => {
     await setForegroundColor(page, 0, 0, 255);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
   });
 
   test('4-sided polygon renders as square with flat top edge', async ({ page }) => {

--- a/e2e/rounded-corners.spec.ts
+++ b/e2e/rounded-corners.spec.ts
@@ -47,16 +47,14 @@ async function dragShape(
   await page.waitForTimeout(300);
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -155,7 +153,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const beforeState = await getEditorState(page);
     // Drag from centre (200, 150) to edge (300, 250) — rx=ry=100, so
@@ -205,7 +203,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag a 40×40 hexagon. halfSize = (20, 20). Cap is min(40, 40)/2 = 20.
     await setToolOption(page, 'Corner Radius', 20);
@@ -250,7 +248,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const beforeState = await getEditorState(page);
     await dragShape(page, { x: 150, y: 150 }, { x: 250, y: 250 });
@@ -293,7 +291,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 40);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag from centre (200, 150) to edge (300, 250) — halfSize (100, 100)
     // → bounding box (100, 50)..(300, 250). cornerRadius = 40 means each
@@ -351,7 +349,7 @@ test.describe('Shape tool corner radius (#62)', () => {
         await setShapeMode(page, 'polygon');
         await setPolygonSides(page, sides);
         await setToolOption(page, 'Corner Radius', cornerRadius);
-        await setToolSetting(page, 'setShapeStrokeColor', null);
+        await setShapeSetting(page, 'strokeColor', null);
         await dragShape(page, { x: 200, y: 150 }, { x: 300, y: 250 });
       };
 

--- a/e2e/shape-center-and-offedge.spec.ts
+++ b/e2e/shape-center-and-offedge.spec.ts
@@ -37,16 +37,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   );
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -104,7 +102,7 @@ test.describe('Shape tool click-to-size centering', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Click (no drag) at doc center (200, 150). The shape tool interprets
     // sub-threshold pointer-ups as "please open the ShapeSizeModal".
@@ -167,7 +165,7 @@ test.describe('Move tool off-edge pixel preservation', () => {
     await setForegroundColor(page, 0, 255, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const dragFrom = await docToScreen(page, 200, 150);
     const dragTo = await docToScreen(page, 260, 200);

--- a/e2e/shape-fill-persists-on-reactivate.spec.ts
+++ b/e2e/shape-fill-persists-on-reactivate.spec.ts
@@ -83,18 +83,18 @@ async function dragShape(
 async function setShapeFillColor(page: Page, color: { r: number; g: number; b: number; a?: number }) {
   await page.evaluate((c) => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { setShapeFillColor: (c: unknown) => void };
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
     };
-    store.getState().setShapeFillColor({ r: c.r, g: c.g, b: c.b, a: c.a ?? 1 });
+    store.getState().setShapeSetting('fillColor', { r: c.r, g: c.g, b: c.b, a: c.a ?? 1 });
   }, color);
 }
 
 async function getShapeFillColor(page: Page) {
   return page.evaluate(() => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { shapeFillColor: { r: number; g: number; b: number; a: number } | null };
+      getState: () => { settings: { shape: { fillColor: { r: number; g: number; b: number; a: number } | null } } };
     };
-    return store.getState().shapeFillColor;
+    return store.getState().settings.shape.fillColor;
   });
 }
 
@@ -128,9 +128,9 @@ test.describe('Shape tool fill color persists on re-activation (#424)', () => {
     // not gold. Disable stroke so only fill matters.
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setShapeStrokeColor: (c: unknown) => void };
+        getState: () => { setShapeSetting: (k: string, v: unknown) => void };
       };
-      store.getState().setShapeStrokeColor(null);
+      store.getState().setShapeSetting('strokeColor', null);
     });
     await page.locator('[aria-labelledby="shape-mode-label"]').selectOption('ellipse');
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });

--- a/e2e/shape-path-output.spec.ts
+++ b/e2e/shape-path-output.spec.ts
@@ -115,18 +115,15 @@ async function setShapeTool(
     ({ mode, output, sides }) => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setShapeMode: (m: string) => void;
-          setShapeOutput: (o: string) => void;
-          setShapeFillColor: (c: { r: number; g: number; b: number; a: number } | null) => void;
-          setShapePolygonSides: (n: number) => void;
+          setShapeSetting: (key: string, value: unknown) => void;
         };
       };
       const settings = ts.getState();
-      settings.setShapeMode(mode);
-      settings.setShapeOutput(output);
-      settings.setShapeFillColor({ r: 255, g: 0, b: 0, a: 1 });
+      settings.setShapeSetting('mode', mode);
+      settings.setShapeSetting('output', output);
+      settings.setShapeSetting('fillColor', { r: 255, g: 0, b: 0, a: 1 });
       if (sides !== undefined) {
-        settings.setShapePolygonSides(sides);
+        settings.setShapeSetting('polygonSides', sides);
       }
     },
     { mode, output, sides: options?.sides ?? null },

--- a/e2e/shape-tool.spec.ts
+++ b/e2e/shape-tool.spec.ts
@@ -56,16 +56,14 @@ async function dragShape(
   await page.waitForTimeout(300);
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -161,7 +159,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 30);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw rectangle: center at (200,150), drag to (300,250)
     // This creates a polygon with ~100px radius in each direction
@@ -193,7 +191,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
     await setToolOption(page, 'Corner Radius', 20);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw hexagon: center at (200,150), drag to (280,230)
     // rx = 80, ry = 80
@@ -220,7 +218,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 15);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw triangle: center at (200,150), drag to (280,230)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 230 });
@@ -261,7 +259,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw an ellipse from center (200,150) to edge (280,220)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });
@@ -296,7 +294,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Simulate a realistic drag where the first mousemove is axis-aligned.
     // In a real browser the mouse often registers horizontal movement before
@@ -345,7 +343,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag purely horizontally — height dimension is 0 throughout
     await dragShape(page, { x: 150, y: 150 }, { x: 300, y: 150 }, 10);
@@ -370,8 +368,8 @@ test.describe('Shape tool click-and-drag', () => {
     // to full opacity after a few frames.
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 255, g: 0, b: 0, a: 0.5 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'fillColor', { r: 255, g: 0, b: 0, a: 0.5 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw with many steps to accumulate renders
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 }, 15);
@@ -397,7 +395,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw on the active layer (Layer 1)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });
@@ -419,7 +417,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag only 2 pixels — below the 4px click threshold
     await dragShape(page, { x: 200, y: 150 }, { x: 201, y: 151 });
@@ -435,8 +433,8 @@ test.describe('Shape tool click-and-drag', () => {
   test('shape with stroke only creates visible outline', async ({ page }) => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 255, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 255, a: 1 });
     await setToolOption(page, 'Width', 4);
 
     // Draw an ellipse from center (200,150) to edge (280,220)
@@ -464,8 +462,8 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 255, g: 0, b: 128, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 255, g: 0, b: 128, a: 1 });
     await setToolOption(page, 'Width', 3);
 
     // Drag from canvas center to lower-right so the bbox sits inside the
@@ -519,8 +517,8 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 1 });
     await setToolOption(page, 'Width', 3);
 
     // Drag from (200, 150) to (260, 210). bbox = (140, 90) → (260, 210).
@@ -542,7 +540,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw first shape
     await dragShape(page, { x: 100, y: 100 }, { x: 150, y: 140 });

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -275,6 +275,16 @@ async function setPencilSetting(page: Page, key: 'size', value: number) {
   }, { key, value });
 }
 
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
+}
+
 async function setUIState(page: Page, setter: string, value: unknown) {
   await page.evaluate(
     ({ setter, value }) => {
@@ -719,10 +729,10 @@ test.describe('Shape Tool', () => {
 
   test('drawing polygon creates filled pixels', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 6);
-    await setToolSetting(page, 'setShapeFillColor', { r: 0, g: 0, b: 255, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 6);
+    await setShapeSetting(page, 'fillColor', { r: 0, g: 0, b: 255, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Center-outward: click center at 125,125, drag to 200,200 (radius ~75px)
     await drawStroke(page, { x: 125, y: 125 }, { x: 200, y: 200 }, 5);
@@ -734,9 +744,9 @@ test.describe('Shape Tool', () => {
 
   test('drawing ellipse creates filled pixels', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 255, g: 0, b: 0, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 255, g: 0, b: 0, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Center-outward: click center at 200,150, drag to 300,250 (100x100 radii)
     await drawStroke(page, { x: 200, y: 150 }, { x: 300, y: 250 }, 5);
@@ -750,10 +760,10 @@ test.describe('Shape Tool', () => {
 
   test('shape tool with stroke only creates outline', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 255, b: 0, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 3);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 255, b: 0, a: 1 });
+    await setShapeSetting(page, 'strokeWidth', 3);
 
     // Center-outward: click center at 125,125, drag to 200,200
     await drawStroke(page, { x: 125, y: 125 }, { x: 200, y: 200 }, 5);
@@ -1860,9 +1870,9 @@ test.describe('Comprehensive Scenarios', () => {
 
     // Draw a filled ellipse
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 100, g: 150, b: 200, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 100, g: 150, b: 200, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
     // Center-outward: center at 100,100, drag to 180,180 (80px radii)
     const beforeShape = await readComposited(page);
     await drawStroke(page, { x: 100, y: 100 }, { x: 180, y: 180 }, 5);

--- a/e2e/transform-user-repro.spec.ts
+++ b/e2e/transform-user-repro.spec.ts
@@ -27,16 +27,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   }, { docX, docY });
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -168,7 +166,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw from center outward
     await drawShape(page, 300, 300, 400, 400);
@@ -212,7 +210,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     const shapePixels = await countActiveLayerPixelsGPU(page);
@@ -253,7 +251,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     const shapePixels = await countActiveLayerPixelsGPU(page);
@@ -300,7 +298,7 @@ test.describe('Perspective mode', { tag: '@chromium' }, () => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     await cmdClickThumbnail(page);

--- a/src/app/OptionsBar/tool-options/ShapeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/ShapeOptions.tsx
@@ -45,21 +45,15 @@ function ColorPopover({ anchorRef, popoverRef, color, onChange, onRemove, remove
 }
 
 export function ShapeOptions() {
-  const shapeMode = useToolSettingsStore((s) => s.shapeMode);
-  const shapeOutput = useToolSettingsStore((s) => s.shapeOutput);
-  const shapeFillColor = useToolSettingsStore((s) => s.shapeFillColor);
-  const shapeStrokeColor = useToolSettingsStore((s) => s.shapeStrokeColor);
-  const shapeStrokeWidth = useToolSettingsStore((s) => s.shapeStrokeWidth);
-  const shapePolygonSides = useToolSettingsStore((s) => s.shapePolygonSides);
-  const shapeCornerRadius = useToolSettingsStore((s) => s.shapeCornerRadius);
-  const setShapeMode = useToolSettingsStore((s) => s.setShapeMode);
-  const setShapeOutput = useToolSettingsStore((s) => s.setShapeOutput);
-  const setShapeFillColor = useToolSettingsStore((s) => s.setShapeFillColor);
-  const setShapeStrokeColor = useToolSettingsStore((s) => s.setShapeStrokeColor);
+  const shapeMode = useToolSettingsStore((s) => s.settings.shape.mode);
+  const shapeOutput = useToolSettingsStore((s) => s.settings.shape.output);
+  const shapeFillColor = useToolSettingsStore((s) => s.settings.shape.fillColor);
+  const shapeStrokeColor = useToolSettingsStore((s) => s.settings.shape.strokeColor);
+  const shapeStrokeWidth = useToolSettingsStore((s) => s.settings.shape.strokeWidth);
+  const shapePolygonSides = useToolSettingsStore((s) => s.settings.shape.polygonSides);
+  const shapeCornerRadius = useToolSettingsStore((s) => s.settings.shape.cornerRadius);
+  const setShapeSetting = useToolSettingsStore((s) => s.setShapeSetting);
   const setForegroundColor = useToolSettingsStore((s) => s.setForegroundColor);
-  const setShapeStrokeWidth = useToolSettingsStore((s) => s.setShapeStrokeWidth);
-  const setShapePolygonSides = useToolSettingsStore((s) => s.setShapePolygonSides);
-  const setShapeCornerRadius = useToolSettingsStore((s) => s.setShapeCornerRadius);
 
   const [openPopover, setOpenPopover] = useState<PopoverTarget>(null);
   const fillRef = useRef<HTMLDivElement>(null);
@@ -85,7 +79,7 @@ export function ShapeOptions() {
       <select
         className={styles.select}
         value={shapeMode}
-        onChange={(e) => setShapeMode(e.target.value as ShapeMode)}
+        onChange={(e) => setShapeSetting('mode', e.target.value as ShapeMode)}
         aria-labelledby="shape-mode-label"
       >
         <option value="ellipse">Ellipse</option>
@@ -96,7 +90,7 @@ export function ShapeOptions() {
       <select
         className={styles.select}
         value={shapeOutput}
-        onChange={(e) => setShapeOutput(e.target.value as ShapeOutput)}
+        onChange={(e) => setShapeSetting('output', e.target.value as ShapeOutput)}
         aria-labelledby="shape-output-label"
       >
         <option value="pixels">Pixels</option>
@@ -113,13 +107,13 @@ export function ShapeOptions() {
             min={3}
             max={64}
             value={shapePolygonSides}
-            onChange={(e) => setShapePolygonSides(Number(e.target.value))}
+            onChange={(e) => setShapeSetting('polygonSides', Number(e.target.value))}
           />
         </>
       )}
 
       {shapeMode !== 'ellipse' && (
-        <Slider label="Corner Radius" value={shapeCornerRadius} min={0} max={200} onChange={setShapeCornerRadius} />
+        <Slider label="Corner Radius" value={shapeCornerRadius} min={0} max={200} onChange={(v) => setShapeSetting('cornerRadius', v)} />
       )}
 
       <AspectRatioControl />
@@ -143,7 +137,7 @@ export function ShapeOptions() {
             type="button"
             aria-label="Add fill color"
             onClick={() => {
-              setShapeFillColor({ r: 255, g: 255, b: 255, a: 1 });
+              setShapeSetting('fillColor', { r: 255, g: 255, b: 255, a: 1 });
               setOpenPopover('fill');
             }}
           >
@@ -155,8 +149,8 @@ export function ShapeOptions() {
             anchorRef={fillRef}
             popoverRef={popoverRef}
             color={shapeFillColor}
-            onChange={setShapeFillColor}
-            onRemove={() => { setShapeFillColor(null); setOpenPopover(null); }}
+            onChange={(c) => setShapeSetting('fillColor', c)}
+            onRemove={() => { setShapeSetting('fillColor', null); setOpenPopover(null); }}
             removeLabel="Remove fill"
           />
         )}
@@ -181,7 +175,7 @@ export function ShapeOptions() {
             type="button"
             aria-label="Add stroke color"
             onClick={() => {
-              setShapeStrokeColor({ r: 0, g: 0, b: 0, a: 1 });
+              setShapeSetting('strokeColor', { r: 0, g: 0, b: 0, a: 1 });
               setOpenPopover('stroke');
             }}
           >
@@ -193,15 +187,15 @@ export function ShapeOptions() {
             anchorRef={strokeRef}
             popoverRef={popoverRef}
             color={shapeStrokeColor}
-            onChange={setShapeStrokeColor}
-            onRemove={() => { setShapeStrokeColor(null); setOpenPopover(null); }}
+            onChange={(c) => setShapeSetting('strokeColor', c)}
+            onRemove={() => { setShapeSetting('strokeColor', null); setOpenPopover(null); }}
             removeLabel="Remove stroke"
           />
         )}
       </div>
 
       {shapeStrokeColor && (
-        <Slider label="Width" value={shapeStrokeWidth} min={1} max={50} onChange={setShapeStrokeWidth} />
+        <Slider label="Width" value={shapeStrokeWidth} min={1} max={50} onChange={(v) => setShapeSetting('strokeWidth', v)} />
       )}
     </>
   );

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -61,7 +61,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'path') {
     ts.setPathSetting('strokeWidth', ts.settings.path.strokeWidth + delta);
   } else if (tool === 'shape') {
-    ts.setShapeStrokeWidth(ts.shapeStrokeWidth + delta);
+    ts.setShapeSetting('strokeWidth', ts.settings.shape.strokeWidth + delta);
   }
   return true;
 }

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { ShapeSettings } from '../tools/shape/shape-settings';
+import { DEFAULT_SHAPE_SETTINGS } from '../tools/shape/shape-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  shape: ShapeSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  shape: DEFAULT_SHAPE_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -2,34 +2,36 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useToolSettingsStore } from './tool-settings-store';
 
-describe('setShapeMode — issue #236 (invalid modes render incorrectly)', () => {
+describe('setShapeSetting mode — issue #236 (invalid modes render incorrectly)', () => {
   it('accepts ellipse', () => {
-    useToolSettingsStore.getState().setShapeMode('ellipse');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+    useToolSettingsStore.getState().setShapeSetting('mode', 'ellipse');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 
   it('accepts polygon', () => {
-    useToolSettingsStore.getState().setShapeMode('polygon');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+    useToolSettingsStore.getState().setShapeSetting('mode', 'polygon');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('polygon');
   });
 
-  it('ignores invalid values like "rectangle" instead of silently storing them', () => {
-    useToolSettingsStore.getState().setShapeMode('ellipse');
+  it('collapses invalid values like "rectangle" to ellipse instead of silently storing them', () => {
+    useToolSettingsStore.getState().setShapeSetting('mode', 'polygon');
     // The setter is typed as ShapeMode but JS callers (and TS @ts-ignore
-    // bypasses) can pass anything. The store must reject invalid values
-    // so the GPU dispatch doesn't render a polygon with stale `sides`
-    // when a caller asked for "rectangle".
-    (useToolSettingsStore.getState().setShapeMode as (m: string) => void)('rectangle');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+    // bypasses) can pass anything. The slice must collapse invalid values
+    // to the documented default ('ellipse') so the GPU dispatch doesn't
+    // render a polygon with stale `sides` when a caller asked for
+    // "rectangle" — same guard as the quick-select slice.
+    (useToolSettingsStore.getState().setShapeSetting as (k: 'mode', m: string) => void)('mode', 'rectangle');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 
-  it('ignores other invalid values (line, arrow, star)', () => {
-    useToolSettingsStore.getState().setShapeMode('polygon');
-    const setter = useToolSettingsStore.getState().setShapeMode as (m: string) => void;
-    setter('line');
-    setter('arrow');
-    setter('star');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+  it('collapses other invalid values (line, arrow, star) to ellipse', () => {
+    const setter = useToolSettingsStore.getState().setShapeSetting as (k: 'mode', m: string) => void;
+    setter('mode', 'line');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
+    setter('mode', 'arrow');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
+    setter('mode', 'star');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 });
 
@@ -860,6 +862,123 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
     expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
     expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: shape (#453)', () => {
+  // Reset to the legacy defaults at the top of each test — prior tests
+  // in this file (including the #236 mode guard suite at the top) and
+  // sibling cases inside this block may have mutated the slice.
+  beforeEach(() => {
+    const set = useToolSettingsStore.getState().setShapeSetting;
+    set('mode', 'ellipse');
+    set('output', 'pixels');
+    set('fillColor', { r: 255, g: 255, b: 255, a: 1 });
+    set('strokeColor', null);
+    set('strokeWidth', 2);
+    set('polygonSides', 6);
+    set('cornerRadius', 0);
+  });
+
+  it('exposes shape settings under settings.shape with the legacy defaults', () => {
+    const { shape } = useToolSettingsStore.getState().settings;
+    expect(shape).toEqual({
+      mode: 'ellipse',
+      output: 'pixels',
+      fillColor: { r: 255, g: 255, b: 255, a: 1 },
+      strokeColor: null,
+      strokeWidth: 2,
+      polygonSides: 6,
+      cornerRadius: 0,
+    });
+  });
+
+  it('setShapeSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.shape;
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 7);
+    const after = useToolSettingsStore.getState().settings.shape;
+    expect(after.strokeWidth).toBe(7);
+    expect(after.mode).toBe(before.mode);
+    expect(after.output).toBe(before.output);
+    expect(after.fillColor).toBe(before.fillColor);
+    expect(after.strokeColor).toBe(before.strokeColor);
+    expect(after.polygonSides).toBe(before.polygonSides);
+    expect(after.cornerRadius).toBe(before.cornerRadius);
+  });
+
+  it('setShapeSetting clamps strokeWidth into [1, 50]', () => {
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 0);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(1);
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(50);
+  });
+
+  it('setShapeSetting rounds and clamps polygonSides into [3, 64]', () => {
+    // Sides must be an integer — fractional sides render as the floor
+    // count with weird seams. Legacy setShapePolygonSides rounded.
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 2);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(3);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(64);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 6.4);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(6);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 6.6);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(7);
+  });
+
+  it('setShapeSetting clamps cornerRadius into [0, 200]', () => {
+    useToolSettingsStore.getState().setShapeSetting('cornerRadius', -10);
+    expect(useToolSettingsStore.getState().settings.shape.cornerRadius).toBe(0);
+    useToolSettingsStore.getState().setShapeSetting('cornerRadius', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.cornerRadius).toBe(200);
+  });
+
+  it('setShapeSetting passes nullable colors through, including null', () => {
+    useToolSettingsStore.getState().setShapeSetting('fillColor', null);
+    expect(useToolSettingsStore.getState().settings.shape.fillColor).toBeNull();
+    const red = { r: 200, g: 30, b: 40, a: 0.5 };
+    useToolSettingsStore.getState().setShapeSetting('strokeColor', red);
+    expect(useToolSettingsStore.getState().settings.shape.strokeColor).toEqual(red);
+  });
+
+  it('setShapeSetting collapses invalid output to "pixels" (mirrors mode guard)', () => {
+    useToolSettingsStore.getState().setShapeSetting('output', 'path');
+    expect(useToolSettingsStore.getState().settings.shape.output).toBe('path');
+    (useToolSettingsStore.getState().setShapeSetting as (k: 'output', v: string) => void)('output', 'vector');
+    expect(useToolSettingsStore.getState().settings.shape.output).toBe('pixels');
+  });
+
+  it('setShapeSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 42);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampShapeSetting } from '../tools/shape/shape-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -45,13 +46,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushSize: 10,
   brushOpacity: 100,
   brushHardness: 80,
-  shapeMode: 'ellipse',
-  shapeOutput: 'pixels' as const,
-  shapeFillColor: { r: 255, g: 255, b: 255, a: 1 },
-  shapeStrokeColor: null,
-  shapeStrokeWidth: 2,
-  shapePolygonSides: 6,
-  shapeCornerRadius: 0,
   aspectRatioW: 1,
   aspectRatioH: 1,
   aspectRatioLocked: false,
@@ -182,20 +176,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       fill: { ...s.settings.fill, [key]: clampFillSetting(key, value) },
     },
   })),
-  setShapeMode: (mode) => {
-    // Guard against invalid values (e.g. 'rectangle', 'line') sneaking in
-    // via store bypass. The shader treats anything-not-ellipse as polygon
-    // and would render a polygon with whatever sides setting is current,
-    // which doesn't match what a caller passing 'rectangle' expects.
-    if (mode !== 'ellipse' && mode !== 'polygon') return;
-    set({ shapeMode: mode });
-  },
-  setShapeOutput: (output) => set({ shapeOutput: output }),
-  setShapeFillColor: (color) => set({ shapeFillColor: color }),
-  setShapeStrokeColor: (color) => set({ shapeStrokeColor: color }),
-  setShapeStrokeWidth: (width) => set({ shapeStrokeWidth: Math.max(1, Math.min(50, width)) }),
-  setShapePolygonSides: (sides) => set({ shapePolygonSides: Math.max(3, Math.min(64, Math.round(sides))) }),
-  setShapeCornerRadius: (radius) => set({ shapeCornerRadius: Math.max(0, Math.min(200, radius)) }),
+  setShapeSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      shape: { ...s.settings.shape, [key]: clampShapeSetting(key, value) },
+    },
+  })),
   setAspectRatioW: (w) => set({ aspectRatioW: Math.max(0.01, w) }),
   setAspectRatioH: (h) => set({ aspectRatioH: Math.max(0.01, h) }),
   setAspectRatioLocked: (locked) => set({ aspectRatioLocked: locked }),

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,6 +1,5 @@
 import type { Color } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
-import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
@@ -16,6 +15,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { ShapeSettings } from '../tools/shape/shape-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -32,13 +32,6 @@ export interface ToolSettings {
   brushSize: number;
   brushOpacity: number;
   brushHardness: number;
-  shapeMode: ShapeMode;
-  shapeOutput: ShapeOutput;
-  shapeFillColor: Color | null;
-  shapeStrokeColor: Color | null;
-  shapeStrokeWidth: number;
-  shapePolygonSides: number;
-  shapeCornerRadius: number;
   aspectRatioW: number;
   aspectRatioH: number;
   aspectRatioLocked: boolean;
@@ -120,13 +113,7 @@ export interface ToolSettings {
   setEraserSetting: <K extends keyof EraserSettings>(key: K, value: EraserSettings[K]) => void;
   setPathSetting: <K extends keyof PathSettings>(key: K, value: PathSettings[K]) => void;
   setFillSetting: <K extends keyof FillSettings>(key: K, value: FillSettings[K]) => void;
-  setShapeMode: (mode: ShapeMode) => void;
-  setShapeOutput: (output: ShapeOutput) => void;
-  setShapeFillColor: (color: Color | null) => void;
-  setShapeStrokeColor: (color: Color | null) => void;
-  setShapeStrokeWidth: (width: number) => void;
-  setShapePolygonSides: (sides: number) => void;
-  setShapeCornerRadius: (radius: number) => void;
+  setShapeSetting: <K extends keyof ShapeSettings>(key: K, value: ShapeSettings[K]) => void;
   setAspectRatioW: (w: number) => void;
   setAspectRatioH: (h: number) => void;
   setAspectRatioLocked: (locked: boolean) => void;

--- a/src/tools/shape/shape-interaction.test.ts
+++ b/src/tools/shape/shape-interaction.test.ts
@@ -75,13 +75,17 @@ vi.mock('../../app/ui-store', () => ({
 import type { Color } from '../../types';
 
 const ts = {
-  shapeMode: 'ellipse' as 'ellipse' | 'polygon',
-  shapeOutput: 'pixels' as 'pixels' | 'path',
-  shapeFillColor: { r: 255, g: 0, b: 0, a: 1 } as Color | null,
-  shapeStrokeColor: { r: 0, g: 0, b: 255, a: 0.5 } as Color | null,
-  shapeStrokeWidth: 2,
-  shapePolygonSides: 5,
-  shapeCornerRadius: 0,
+  settings: {
+    shape: {
+      mode: 'ellipse' as 'ellipse' | 'polygon',
+      output: 'pixels' as 'pixels' | 'path',
+      fillColor: { r: 255, g: 0, b: 0, a: 1 } as Color | null,
+      strokeColor: { r: 0, g: 0, b: 255, a: 0.5 } as Color | null,
+      strokeWidth: 2,
+      polygonSides: 5,
+      cornerRadius: 0,
+    },
+  },
   aspectRatioLocked: false,
   aspectRatioW: 1,
   aspectRatioH: 1,
@@ -160,13 +164,13 @@ beforeEach(() => {
   editorState.addPath.mockClear();
   setState.mockClear();
   uiState.setPendingShapeClick.mockClear();
-  ts.shapeMode = 'ellipse';
-  ts.shapeOutput = 'pixels';
-  ts.shapeFillColor = { r: 255, g: 0, b: 0, a: 1 };
-  ts.shapeStrokeColor = { r: 0, g: 0, b: 255, a: 0.5 };
-  ts.shapeStrokeWidth = 2;
-  ts.shapePolygonSides = 5;
-  ts.shapeCornerRadius = 0;
+  ts.settings.shape.mode = 'ellipse';
+  ts.settings.shape.output = 'pixels';
+  ts.settings.shape.fillColor = { r: 255, g: 0, b: 0, a: 1 };
+  ts.settings.shape.strokeColor = { r: 0, g: 0, b: 255, a: 0.5 };
+  ts.settings.shape.strokeWidth = 2;
+  ts.settings.shape.polygonSides = 5;
+  ts.settings.shape.cornerRadius = 0;
   ts.aspectRatioLocked = false;
   ts.addRecentColor.mockClear();
 });
@@ -189,8 +193,8 @@ describe('shape down', () => {
   });
 
   it('does not record recent colors when fill and stroke are disabled', () => {
-    ts.shapeFillColor = null;
-    ts.shapeStrokeColor = null;
+    ts.settings.shape.fillColor = null;
+    ts.settings.shape.strokeColor = null;
     handleShapeDown(makeCtx());
     expect(ts.addRecentColor).not.toHaveBeenCalled();
   });
@@ -239,7 +243,7 @@ describe('shape move', () => {
   });
 
   it('renders polygons with mode 1', () => {
-    ts.shapeMode = 'polygon';
+    ts.settings.shape.mode = 'polygon';
     handleShapeMove(makeState(), { x: 80, y: 70 });
     expect(renderShape.mock.calls[0]![2]).toBe(1);
   });
@@ -264,14 +268,14 @@ describe('shape move', () => {
   });
 
   it('caps the corner radius at half the smaller dimension', () => {
-    ts.shapeCornerRadius = 50;
+    ts.settings.shape.cornerRadius = 50;
     handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 60 });
     // w 60, h 20 => cap is 10.
     expect(renderShape.mock.calls[0]![17]).toBe(10);
   });
 
   it('renders a transparent fill when the fill color is disabled', () => {
-    ts.shapeFillColor = null;
+    ts.settings.shape.fillColor = null;
     handleShapeMove(makeState(), { x: 80, y: 70 });
     const args = renderShape.mock.calls[0]!;
     expect(args[7]).toBe(0);
@@ -314,7 +318,7 @@ describe('shape up — click vs drag', () => {
   });
 
   it('a click in path-output mode undoes without opening the size modal', () => {
-    ts.shapeOutput = 'path';
+    ts.settings.shape.output = 'path';
     handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 51, y: 51 });
     expect(editorState.undo).toHaveBeenCalledTimes(1);
     expect(uiState.setPendingShapeClick).not.toHaveBeenCalled();
@@ -383,7 +387,7 @@ describe('shape up — committing pixels', () => {
 
 describe('shape up — path output', () => {
   beforeEach(() => {
-    ts.shapeOutput = 'path';
+    ts.settings.shape.output = 'path';
   });
 
   it('undoes the raster preview and adds a closed ellipse path', () => {
@@ -411,8 +415,8 @@ describe('shape up — path output', () => {
   });
 
   it('adds a polygon path with one anchor per side', () => {
-    ts.shapeMode = 'polygon';
-    ts.shapePolygonSides = 3;
+    ts.settings.shape.mode = 'polygon';
+    ts.settings.shape.polygonSides = 3;
     handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 70 });
     const [anchors] = editorState.addPath.mock.calls[0]! as [PathAnchor[]];
     expect(anchors).toHaveLength(3);
@@ -455,7 +459,7 @@ describe('confirmShapeSize', () => {
   });
 
   it('caps the corner radius at half the smaller dimension', () => {
-    ts.shapeCornerRadius = 100;
+    ts.settings.shape.cornerRadius = 100;
     confirmShapeSize(60, 40, click);
     expect(renderShapeExpanded.mock.calls[0]![17]).toBe(20);
   });

--- a/src/tools/shape/shape-interaction.ts
+++ b/src/tools/shape/shape-interaction.ts
@@ -81,8 +81,9 @@ export function handleShapeDown(ctx: InteractionContext): InteractionState {
   editorState.pushHistory('Shape');
 
   const ts = useToolSettingsStore.getState();
-  if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
-  if (ts.shapeStrokeColor) ts.addRecentColor(ts.shapeStrokeColor);
+  const shape = ts.settings.shape;
+  if (shape.fillColor) ts.addRecentColor(shape.fillColor);
+  if (shape.strokeColor) ts.addRecentColor(shape.strokeColor);
   const engine = getEngine();
   if (engine) gpuSaveShapePreview(engine, activeLayerId);
 
@@ -101,7 +102,7 @@ export function handleShapeDown(ctx: InteractionContext): InteractionState {
 export function handleShapeMove(state: InteractionState, layerLocalPos: Point, metaKey = false): void {
   if (!state.startPoint || !state.layerId) return;
 
-  const toolSettings = useToolSettingsStore.getState();
+  const shape = useToolSettingsStore.getState().settings.shape;
   const constrainedEdge = constrainToAspectRatio(state.startPoint, layerLocalPos, metaKey);
   const rx = Math.abs(constrainedEdge.x - state.startPoint.x);
   const ry = Math.abs(constrainedEdge.y - state.startPoint.y);
@@ -110,11 +111,11 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
   const engine = getEngine();
   if (!engine) return;
 
-  const fillColor = toolSettings.shapeFillColor;
-  const strokeColor = toolSettings.shapeStrokeColor;
+  const fillColor = shape.fillColor;
+  const strokeColor = shape.strokeColor;
   gpuRenderShape(
     engine, state.layerId,
-    shapeModeToU32(toolSettings.shapeMode),
+    shapeModeToU32(shape.mode),
     state.startPoint.x + state.layerStartX,
     state.startPoint.y + state.layerStartY,
     rx * 2, ry * 2,
@@ -122,8 +123,8 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
     fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
     strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
     strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-    toolSettings.shapeStrokeWidth, toolSettings.shapePolygonSides,
-    Math.min(toolSettings.shapeCornerRadius, Math.min(rx * 2, ry * 2) / 2),
+    shape.strokeWidth, shape.polygonSides,
+    Math.min(shape.cornerRadius, Math.min(rx * 2, ry * 2) / 2),
   );
   clearJsPixelData(state.layerId);
   useEditorStore.getState().notifyRender();
@@ -137,10 +138,11 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
 export function confirmShapeSize(width: number, height: number, click: ShapeSizeClick): void {
   const editorState = useEditorStore.getState();
   const ts = useToolSettingsStore.getState();
+  const shape = ts.settings.shape;
 
   editorState.pushHistory('Shape');
-  if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
-  if (ts.shapeStrokeColor) ts.addRecentColor(ts.shapeStrokeColor);
+  if (shape.fillColor) ts.addRecentColor(shape.fillColor);
+  if (shape.strokeColor) ts.addRecentColor(shape.strokeColor);
 
   const engine = getEngine();
   if (!engine) return;
@@ -148,18 +150,18 @@ export function confirmShapeSize(width: number, height: number, click: ShapeSize
   const cx = click.center.x + click.layerX;
   const cy = click.center.y + click.layerY;
 
-  const fillColor = ts.shapeFillColor;
-  const strokeColor = ts.shapeStrokeColor;
+  const fillColor = shape.fillColor;
+  const strokeColor = shape.strokeColor;
   gpuRenderShapeExpanded(
     engine, click.layerId,
-    shapeModeToU32(ts.shapeMode),
+    shapeModeToU32(shape.mode),
     cx, cy, width, height,
     fillColor ? fillColor.r / 255 : 0, fillColor ? fillColor.g / 255 : 0,
     fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
     strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
     strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-    ts.shapeStrokeWidth, ts.shapePolygonSides,
-    Math.min(ts.shapeCornerRadius, Math.min(width, height) / 2),
+    shape.strokeWidth, shape.polygonSides,
+    Math.min(shape.cornerRadius, Math.min(width, height) / 2),
   );
   syncLayerBoundsFromEngine(engine, click.layerId);
   clearJsPixelData(click.layerId);
@@ -174,11 +176,11 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
 
   const dx = layerLocalPos.x - state.startPoint.x;
   const dy = layerLocalPos.y - state.startPoint.y;
-  const toolSettings = useToolSettingsStore.getState();
+  const shape = useToolSettingsStore.getState().settings.shape;
 
   if (Math.sqrt(dx * dx + dy * dy) < CLICK_THRESHOLD) {
     useEditorStore.getState().undo();
-    if (toolSettings.shapeOutput === 'path') return;
+    if (shape.output === 'path') return;
     useUIStore.getState().setPendingShapeClick({
       center: state.startPoint,
       layerId: state.layerId!,
@@ -188,34 +190,34 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
     return;
   }
 
-  if (engine && state.layerId && toolSettings.shapeOutput !== 'path') {
+  if (engine && state.layerId && shape.output !== 'path') {
     const constrainedEdge = constrainToAspectRatio(state.startPoint, layerLocalPos, metaKey);
     const rx = Math.abs(constrainedEdge.x - state.startPoint.x);
     const ry = Math.abs(constrainedEdge.y - state.startPoint.y);
     const docCx = state.startPoint.x + state.layerStartX;
     const docCy = state.startPoint.y + state.layerStartY;
-    const sw = toolSettings.shapeStrokeWidth;
+    const sw = shape.strokeWidth;
     const { width: docW, height: docH } = useEditorStore.getState().document;
     if (docCx - rx - sw < 0 || docCy - ry - sw < 0
         || docCx + rx + sw > docW || docCy + ry + sw > docH) {
-      const fillColor = toolSettings.shapeFillColor;
-      const strokeColor = toolSettings.shapeStrokeColor;
+      const fillColor = shape.fillColor;
+      const strokeColor = shape.strokeColor;
       gpuRenderShapeExpanded(
         engine, state.layerId,
-        shapeModeToU32(toolSettings.shapeMode),
+        shapeModeToU32(shape.mode),
         docCx, docCy, rx * 2, ry * 2,
         fillColor ? fillColor.r / 255 : 0, fillColor ? fillColor.g / 255 : 0,
         fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
         strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
         strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-        sw, toolSettings.shapePolygonSides,
-        Math.min(toolSettings.shapeCornerRadius, Math.min(rx * 2, ry * 2) / 2),
+        sw, shape.polygonSides,
+        Math.min(shape.cornerRadius, Math.min(rx * 2, ry * 2) / 2),
       );
     }
     syncLayerBoundsFromEngine(engine, state.layerId);
   }
 
-  if (toolSettings.shapeOutput === 'path') {
+  if (shape.output === 'path') {
     // Undo the raster preview that was rendered during drag.
     useEditorStore.getState().undo();
 
@@ -229,10 +231,10 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
 
     const editorState = useEditorStore.getState();
     let anchors: PathAnchor[];
-    if (toolSettings.shapeMode === 'ellipse') {
+    if (shape.mode === 'ellipse') {
       anchors = ellipseToPathAnchors(cx, cy, rx, ry);
     } else {
-      anchors = polygonToPathAnchors(cx, cy, rx, ry, toolSettings.shapePolygonSides);
+      anchors = polygonToPathAnchors(cx, cy, rx, ry, shape.polygonSides);
     }
     editorState.addPath(anchors, true);
     editorState.notifyRender();

--- a/src/tools/shape/shape-settings.test.ts
+++ b/src/tools/shape/shape-settings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SHAPE_SETTINGS,
+  clampShapeSetting,
+  type ShapeSettings,
+} from './shape-settings';
+
+describe('shape-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_SHAPE_SETTINGS).toEqual({
+      mode: 'ellipse',
+      output: 'pixels',
+      fillColor: { r: 255, g: 255, b: 255, a: 1 },
+      strokeColor: null,
+      strokeWidth: 2,
+      polygonSides: 6,
+      cornerRadius: 0,
+    } satisfies ShapeSettings);
+  });
+
+  it('mode collapses unknown strings to "ellipse" rather than letting a typed-string bypass leave a polygon-with-stale-sides render (#236)', () => {
+    expect(clampShapeSetting('mode', 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'polygon')).toBe('polygon');
+    // The shader treats anything-not-ellipse as polygon. A bypass passing
+    // 'rectangle' must not silently render a polygon with whatever sides
+    // value is current — fall back to the documented default instead.
+    expect(clampShapeSetting('mode', 'rectangle' as 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'line' as 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'arrow' as 'ellipse')).toBe('ellipse');
+  });
+
+  it('output collapses unknown strings to "pixels" for the same reason', () => {
+    expect(clampShapeSetting('output', 'pixels')).toBe('pixels');
+    expect(clampShapeSetting('output', 'path')).toBe('path');
+    expect(clampShapeSetting('output', 'vector' as 'pixels')).toBe('pixels');
+    expect(clampShapeSetting('output', '' as 'pixels')).toBe('pixels');
+  });
+
+  it('clamps strokeWidth into [1, 50]', () => {
+    expect(clampShapeSetting('strokeWidth', 0)).toBe(1);
+    expect(clampShapeSetting('strokeWidth', -5)).toBe(1);
+    expect(clampShapeSetting('strokeWidth', 999)).toBe(50);
+    expect(clampShapeSetting('strokeWidth', 2)).toBe(2);
+    expect(clampShapeSetting('strokeWidth', 50)).toBe(50);
+    expect(clampShapeSetting('strokeWidth', 1)).toBe(1);
+  });
+
+  it('clamps and rounds polygonSides into [3, 64]', () => {
+    // Sides must be an integer — fractional sides would render as the
+    // floor count with weird seams. The legacy setter rounded, preserve.
+    expect(clampShapeSetting('polygonSides', 2)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 0)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 99)).toBe(64);
+    expect(clampShapeSetting('polygonSides', 6.4)).toBe(6);
+    expect(clampShapeSetting('polygonSides', 6.6)).toBe(7);
+    expect(clampShapeSetting('polygonSides', 3)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 64)).toBe(64);
+  });
+
+  it('clamps cornerRadius into [0, 200]', () => {
+    expect(clampShapeSetting('cornerRadius', -1)).toBe(0);
+    expect(clampShapeSetting('cornerRadius', 0)).toBe(0);
+    expect(clampShapeSetting('cornerRadius', 99999)).toBe(200);
+    expect(clampShapeSetting('cornerRadius', 100)).toBe(100);
+    expect(clampShapeSetting('cornerRadius', 200)).toBe(200);
+  });
+
+  it('does not round numeric fields outside polygonSides', () => {
+    // Sub-pixel stroke widths and corner radii are meaningful for HDPI
+    // rendering and animations, so the clamps guard the bounds without
+    // forcing integers (polygonSides is the lone exception — see above).
+    expect(clampShapeSetting('strokeWidth', 2.5)).toBe(2.5);
+    expect(clampShapeSetting('cornerRadius', 12.75)).toBe(12.75);
+  });
+
+  it('passes fillColor and strokeColor through unchanged, including null', () => {
+    const red = { r: 255, g: 0, b: 0, a: 1 };
+    expect(clampShapeSetting('fillColor', red)).toBe(red);
+    expect(clampShapeSetting('fillColor', null)).toBe(null);
+    expect(clampShapeSetting('strokeColor', null)).toBe(null);
+    expect(clampShapeSetting('strokeColor', red)).toBe(red);
+  });
+});

--- a/src/tools/shape/shape-settings.ts
+++ b/src/tools/shape/shape-settings.ts
@@ -1,0 +1,77 @@
+import type { Color } from '../../types';
+import type { ShapeMode, ShapeOutput } from './shape';
+
+/**
+ * Per-tool settings slice for the Shape tool.
+ *
+ * Authoritative settings type for shape. The slice lives under
+ * `settings.shape` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Seven fields covering geometry (mode,
+ * output, polygonSides, cornerRadius) and appearance (fillColor,
+ * strokeColor, strokeWidth) — the largest slice by field count so
+ * far, and the first slice to mix three rectangular numeric clamps
+ * with two nullable-color fields and two tagged-union enums in one
+ * shape.
+ *
+ * The `mode` field rejects invalid strings (`'rectangle'`, `'line'`,
+ * etc.) by falling back to `'ellipse'` rather than letting a
+ * `@ts-ignore` bypass leave the GPU shader rendering a polygon with
+ * stale `sides` — the same guard the legacy `setShapeMode` carried
+ * (issue #236). `output` collapses unknown values to `'pixels'` for
+ * the same reason.
+ */
+export interface ShapeSettings {
+  mode: ShapeMode;
+  output: ShapeOutput;
+  fillColor: Color | null;
+  strokeColor: Color | null;
+  strokeWidth: number;
+  polygonSides: number;
+  cornerRadius: number;
+}
+
+export const DEFAULT_SHAPE_SETTINGS: ShapeSettings = {
+  mode: 'ellipse',
+  output: 'pixels',
+  fillColor: { r: 255, g: 255, b: 255, a: 1 },
+  strokeColor: null,
+  strokeWidth: 2,
+  polygonSides: 6,
+  cornerRadius: 0,
+};
+
+export function clampShapeSetting<K extends keyof ShapeSettings>(
+  key: K,
+  value: ShapeSettings[K],
+): ShapeSettings[K] {
+  if (key === 'mode') {
+    const m = value as string;
+    if (m !== 'ellipse' && m !== 'polygon') return 'ellipse' as ShapeSettings[K];
+    return value;
+  }
+  if (key === 'output') {
+    const o = value as string;
+    if (o !== 'pixels' && o !== 'path') return 'pixels' as ShapeSettings[K];
+    return value;
+  }
+  if (key === 'strokeWidth') {
+    const n = value as number;
+    return Math.max(1, Math.min(50, n)) as ShapeSettings[K];
+  }
+  if (key === 'polygonSides') {
+    const n = value as number;
+    return Math.max(3, Math.min(64, Math.round(n))) as ShapeSettings[K];
+  }
+  if (key === 'cornerRadius') {
+    const n = value as number;
+    return Math.max(0, Math.min(200, n)) as ShapeSettings[K];
+  }
+  return value;
+}

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -292,7 +292,7 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
       if (shapeFillSeededFromForeground) return;
       shapeFillSeededFromForeground = true;
       const ts = useToolSettingsStore.getState();
-      ts.setShapeFillColor(ts.foregroundColor);
+      ts.setShapeSetting('fillColor', ts.foregroundColor);
     },
   },
   text: {


### PR DESCRIPTION
## Summary

Fifteenth per-tool settings slice in the #453 rollout — **shape**. Migrates the seven flat-bag fields (`shapeMode`, `shapeOutput`, `shapeFillColor`, `shapeStrokeColor`, `shapeStrokeWidth`, `shapePolygonSides`, `shapeCornerRadius`) and their seven setters to a single `settings.shape.*` slice with one typed `setShapeSetting<K>(key, value)` setter, following the established template.

Largest slice by field count to date, and the first slice to carry **three rectangular numeric clamps** (`strokeWidth` [1,50], `polygonSides` [3,64] with rounding, `cornerRadius` [0,200]) in one shape, plus two nullable-color fields (`fillColor`, `strokeColor`) and two tagged-union enums (`mode`, `output`).

The enum guards mirror the quick-select slice (#608): `mode` collapses unknown strings to `'ellipse'` and `output` collapses to `'pixels'` rather than no-opping silently — the legacy `setShapeMode` rejected `'rectangle'`/`'line'`/etc. by early-return (issue #236), keeping the previous value. The slice tightens that to a documented default so a typed-string `@ts-ignore` bypass can't leave the GPU dispatch rendering a polygon with stale `sides`.

Read sites in `ShapeOptions.tsx`, `shape-interaction.ts` (down/move/up + `confirmShapeSize`), `tool-registry.ts` (the once-per-session "seed fill from foreground" onActivate hook for issue #424), and `tool-shortcuts.ts` (the `[`/`]` ± stroke-width shortcut) now access `settings.shape.{mode,output,fillColor,strokeColor,strokeWidth,polygonSides,cornerRadius}`.

Ten e2e specs drove the legacy setters via `setToolSetting(page, 'setShape…', …)`. Each now has a typed `setShapeSetting(page, key, value)` helper (matching the per-tool helper pattern in `composition-shapes.spec.ts`'s `setWandSetting` / `setFillSetting`). Three specs that drove the setters via inline `page.evaluate` (`delete-inverted-selection.spec.ts`, `shape-path-output.spec.ts`, `shape-fill-persists-on-reactivate.spec.ts`) were retargeted to `setShapeSetting`. The `e2e/GUIDE.md` clamp reference was updated for the new setter shape.

7 new unit tests in `src/tools/shape/shape-settings.test.ts` (defaults round-trip, both enum-collapse guards, each of the three clamp ranges including the `polygonSides` rounding, sub-pixel preservation outside the rounded field, nullable-color passthrough). 7 new tests in `tool-settings-store.test.ts` under a new `per-tool slice: shape (#453)` describe block (defaults, single-field isolation across all 7 fields, each clamp range, the `output` enum guard, sibling-slice referential identity across all twelve `main`-side slices). The existing `setShapeMode — issue #236` describe block was retargeted to the new typed setter and reframed as "collapses to ellipse" rather than "ignores invalid", reflecting the slice's tightened semantics.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 1348 unit tests pass (added 14 new tests across `shape-settings.test.ts` and the new `per-tool slice: shape (#453)` block)
- [x] `npm run lint` clean (0 errors, only pre-existing warnings)
- [x] All shape read sites updated: `ShapeOptions.tsx`, `shape-interaction.ts`, `tool-registry.ts`, `tool-shortcuts.ts`
- [x] All ten shape-touching e2e specs retargeted to the new typed setter
- [x] `e2e/GUIDE.md` clamp reference updated
- [ ] Manual smoke: draw an ellipse, switch to polygon, draw a hexagon, draw a triangle with `Sides: 3`, draw a rounded polygon, change fill/stroke colors, toggle to path output

Part of #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LubWuCEd13HZkzh8MZbyTa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LubWuCEd13HZkzh8MZbyTa)_