### PR TITLE
refactor(crop): extract settings into per-tool slice (#453)

### DIFF
--- a/src/app/OptionsBar/tool-options/CropOptions.tsx
+++ b/src/app/OptionsBar/tool-options/CropOptions.tsx
@@ -5,14 +5,14 @@ import { AspectRatioControl } from './AspectRatioControl';
 import styles from '../OptionsBar.module.css';
 
 export function CropOptions() {
-  const cropMode = useToolSettingsStore((s) => s.cropMode);
-  const setCropMode = useToolSettingsStore((s) => s.setCropMode);
+  const cropMode = useToolSettingsStore((s) => s.settings.crop.mode);
+  const setCropSetting = useToolSettingsStore((s) => s.setCropSetting);
   const perspectiveCropQuad = useUIStore((s) => s.perspectiveCropQuad);
   const setPerspectiveCropQuad = useUIStore((s) => s.setPerspectiveCropQuad);
   const setPerspectiveCropDragging = useUIStore((s) => s.setPerspectiveCropDragging);
 
   function handleModeChange(mode: 'normal' | 'perspective') {
-    setCropMode(mode);
+    setCropSetting('mode', mode);
     // Clear any active overlay when switching modes
     setPerspectiveCropQuad(null);
     setPerspectiveCropDragging(null);

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { CropSettings } from '../tools/crop/crop-settings';
+import { DEFAULT_CROP_SETTINGS } from '../tools/crop/crop-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  crop: CropSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  crop: DEFAULT_CROP_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,70 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: crop (#453)', () => {
+  it('exposes crop settings under settings.crop with the legacy default', () => {
+    // Reset to the legacy default — prior tests in this file may have
+    // mutated the slice through setCropSetting.
+    useToolSettingsStore.getState().setCropSetting('mode', 'normal');
+    const { crop } = useToolSettingsStore.getState().settings;
+    expect(crop).toEqual({ mode: 'normal' });
+  });
+
+  it('setCropSetting toggles mode between normal and perspective', () => {
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('perspective');
+    useToolSettingsStore.getState().setCropSetting('mode', 'normal');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+  });
+
+  it('setCropSetting rejects unknown mode values and falls back to "normal"', () => {
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    // The setter is typed as CropSettings['mode'] but JS callers (and
+    // any `as` cast in TS) can pass anything. The store must reject
+    // unknown values so the crop dispatcher doesn't read a state that
+    // neither the rect nor the perspective handler will service —
+    // mirrors the setShapeMode reject-and-reset behaviour from #236.
+    const setter = useToolSettingsStore.getState().setCropSetting as (
+      key: 'mode',
+      value: string,
+    ) => void;
+    setter('mode', 'rect');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+    setter('mode', 'free');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+  });
+
+  it('setCropSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('perspective');
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampCropSetting } from '../tools/crop/crop-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -55,7 +56,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   aspectRatioW: 1,
   aspectRatioH: 1,
   aspectRatioLocked: false,
-  cropMode: 'normal' as const,
   gradientType: 'linear',
   gradientStops: [
     { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
@@ -199,7 +199,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setAspectRatioW: (w) => set({ aspectRatioW: Math.max(0.01, w) }),
   setAspectRatioH: (h) => set({ aspectRatioH: Math.max(0.01, h) }),
   setAspectRatioLocked: (locked) => set({ aspectRatioLocked: locked }),
-  setCropMode: (mode) => set({ cropMode: mode }),
+  setCropSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      crop: { ...s.settings.crop, [key]: clampCropSetting(key, value) },
+    },
+  })),
   setGradientType: (type) => set({ gradientType: type }),
   setGradientStops: (stops) => {
     const clamped = stops.length < 2

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { CropSettings } from '../tools/crop/crop-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -42,7 +43,6 @@ export interface ToolSettings {
   aspectRatioW: number;
   aspectRatioH: number;
   aspectRatioLocked: boolean;
-  cropMode: 'normal' | 'perspective';
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
@@ -130,7 +130,7 @@ export interface ToolSettings {
   setAspectRatioW: (w: number) => void;
   setAspectRatioH: (h: number) => void;
   setAspectRatioLocked: (locked: boolean) => void;
-  setCropMode: (mode: 'normal' | 'perspective') => void;
+  setCropSetting: <K extends keyof CropSettings>(key: K, value: CropSettings[K]) => void;
   setGradientType: (type: 'linear' | 'radial') => void;
   setGradientStops: (stops: readonly GradientStop[]) => void;
   setGradientReverse: (reverse: boolean) => void;

--- a/src/tools/crop/crop-interaction.test.ts
+++ b/src/tools/crop/crop-interaction.test.ts
@@ -45,7 +45,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  cropMode: 'rect' as 'rect' | 'perspective',
+  settings: {
+    crop: { mode: 'normal' as 'normal' | 'perspective' },
+  },
   aspectRatioLocked: false,
   aspectRatioW: 1,
   aspectRatioH: 1,
@@ -103,7 +105,7 @@ beforeEach(() => {
   uiState.setPerspectiveCropDragging.mockClear();
   editorState.cropCanvas.mockClear();
   editorState.notifyRender.mockClear();
-  ts.cropMode = 'rect';
+  ts.settings.crop.mode = 'normal';
   ts.aspectRatioLocked = false;
 });
 
@@ -121,7 +123,7 @@ describe('crop down', () => {
   });
 
   it('delegates to the perspective handler in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     const state = handleCropDown(makeCtx());
     // The perspective handler seeds the quad from the full document.
     expect(uiState.setPerspectiveCropQuad).toHaveBeenCalledWith({
@@ -180,7 +182,7 @@ describe('crop move', () => {
   });
 
   it('routes to the perspective handler in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     uiState.perspectiveCropQuad = {
       topLeft: { x: 0, y: 0 },
       topRight: { x: 200, y: 0 },
@@ -219,7 +221,7 @@ describe('crop up', () => {
   });
 
   it('releases the perspective drag in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     uiState.cropRect = { x: 10, y: 10, width: 50, height: 40 };
     handleCropUp(makeState());
     expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(null);

--- a/src/tools/crop/crop-interaction.ts
+++ b/src/tools/crop/crop-interaction.ts
@@ -11,7 +11,7 @@ import {
 } from './perspective-crop-interaction';
 
 export function handleCropDown(ctx: InteractionContext): InteractionState {
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     return handlePerspectiveCropDown(ctx);
   }
 
@@ -30,7 +30,7 @@ export function handleCropDown(ctx: InteractionContext): InteractionState {
 }
 
 export function handleCropMove(state: InteractionState, canvasPos: Point): void {
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     handlePerspectiveCropMove(state, canvasPos);
     return;
   }
@@ -61,7 +61,7 @@ export function handleCropMove(state: InteractionState, canvasPos: Point): void 
 export function handleCropUp(state: InteractionState): void {
   if (state.tool !== 'crop') return;
 
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     handlePerspectiveCropUp(state);
     return;
   }

--- a/src/tools/crop/crop-settings.test.ts
+++ b/src/tools/crop/crop-settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_CROP_SETTINGS,
+  clampCropSetting,
+  type CropSettings,
+} from './crop-settings';
+
+describe('crop-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_CROP_SETTINGS).toEqual({
+      mode: 'normal',
+    } satisfies CropSettings);
+  });
+
+  it('passes through valid modes unchanged', () => {
+    expect(clampCropSetting('mode', 'normal')).toBe('normal');
+    expect(clampCropSetting('mode', 'perspective')).toBe('perspective');
+  });
+
+  it('falls back to "normal" for unknown mode values', () => {
+    // The setter is typed as CropSettings['mode'] but JS callers (and
+    // any `as` cast in TS) can pass anything. The clamp must reject
+    // unknown values so the crop dispatcher doesn't read a state that
+    // neither the rect nor the perspective handler will service.
+    expect(clampCropSetting('mode', 'rect' as CropSettings['mode'])).toBe('normal');
+    expect(clampCropSetting('mode', '' as CropSettings['mode'])).toBe('normal');
+    expect(clampCropSetting('mode', 'free' as CropSettings['mode'])).toBe('normal');
+  });
+});

--- a/src/tools/crop/crop-settings.ts
+++ b/src/tools/crop/crop-settings.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-tool settings slice for the Crop tool.
+ *
+ * Authoritative settings type for crop. The slice lives under
+ * `settings.crop` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` +
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Single discriminated field — `mode`
+ * picks between the rectangular crop and the perspective-quad crop;
+ * aspect-ratio fields stay flat for now since they are shared with
+ * Shape / Marquee / Lasso and aren't crop-owned.
+ */
+export interface CropSettings {
+  mode: 'normal' | 'perspective';
+}
+
+export const DEFAULT_CROP_SETTINGS: CropSettings = {
+  mode: 'normal',
+};
+
+export function clampCropSetting<K extends keyof CropSettings>(
+  key: K,
+  value: CropSettings[K],
+): CropSettings[K] {
+  if (key === 'mode') {
+    const v = value as CropSettings['mode'];
+    if (v !== 'normal' && v !== 'perspective') {
+      return 'normal' as CropSettings[K];
+    }
+    return v as CropSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Sixteenth per-tool slice in the #453 rollout. Crop mode moves from the flat `cropMode` field and its setter to a single `settings.crop.*` slice with one typed `setCropSetting<K>(key, value)` setter, following the established slice template (`<Tool>Settings` + `DEFAULT_<TOOL>_SETTINGS` + `clamp<Tool>Setting`, registered in `tool-settings-slices.ts`).

Single discriminated field (`mode: 'normal' | 'perspective'`). The clamp mirrors the `setShapeMode` reject-and-reset behaviour from issue #236: unknown values fall back to `'normal'` so the crop dispatcher in `crop-interaction.ts` never reads a state that neither the rect nor the perspective handler will service. The shared aspect-ratio fields stay flat for now — they're used by Shape / Marquee / Lasso too and aren't crop-owned, so they belong in a later cross-tool slice rather than under `settings.crop`.

Read sites in `CropOptions.tsx` and `crop-interaction.ts` (three `getState().cropMode` checks across down / move / up) now access `settings.crop.mode`. The crop-interaction test mock was retargeted to the new slice shape.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (0 errors; pre-existing warnings only; pixel-debt check OK)
- [x] `npm run test` — 1339 / 1339 unit tests pass
- [x] 3 new clamp/default unit tests in `crop-settings.test.ts`
- [x] 4 new tests in `tool-settings-store.test.ts`: defaults round-trip, mode toggle, unknown-mode fallback to `'normal'` (mirrors issue #236 reject-and-reset), sibling-slice referential identity across all thirteen `main`-side slices
- [x] Crop-tool e2e flow exercised via existing `crop-interaction.test.ts` (14 tests still pass) and `perspective-crop-interaction.test.ts` (15 tests still pass) — the dispatcher branch is covered.

Part of #453.