### PR TITLE
refactor(brush): extract speed dynamics into per-tool slice (#453)

### DIFF
--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { BrushSpeedSettings } from '../tools/brush/brush-speed-settings';
+import { DEFAULT_BRUSH_SPEED_SETTINGS } from '../tools/brush/brush-speed-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  brushSpeed: BrushSpeedSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  brushSpeed: DEFAULT_BRUSH_SPEED_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,102 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: brushSpeed (#453)', () => {
+  // First sub-slice carved out of the flat `brushSpeed*` brush fields.
+  // Same shape as the per-tool slices above: read via
+  // `settings.brushSpeed.<field>`, write via `setBrushSpeedSetting`.
+  // The remaining brush sub-slices (jitter, texture, tip/presets/
+  // sub-brushes) still live flat on the store and land in follow-up
+  // PRs.
+  it('exposes brushSpeed settings under settings.brushSpeed with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setBrushSpeedSetting or setActivePreset.
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 0);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sizeInvert', false);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'med');
+    const { brushSpeed } = useToolSettingsStore.getState().settings;
+    expect(brushSpeed).toEqual({ size: 0, sizeInvert: false, sensitivity: 'med' });
+  });
+
+  it('setBrushSpeedSetting updates one field without disturbing the others', () => {
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 50);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sizeInvert', true);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    const before = useToolSettingsStore.getState().settings.brushSpeed;
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 120);
+    const after = useToolSettingsStore.getState().settings.brushSpeed;
+    expect(after.size).toBe(120);
+    expect(after.sizeInvert).toBe(before.sizeInvert);
+    expect(after.sensitivity).toBe(before.sensitivity);
+  });
+
+  it('setBrushSpeedSetting clamps size into [0, 300]', () => {
+    // The UI surfaces 0–100 with sizeInvert=false and 0–300 with
+    // sizeInvert=true. The store-level clamp is the looser bound so
+    // flipping the invert toggle never truncates the slider value.
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', -10);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(0);
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 9999);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(300);
+  });
+
+  it('setBrushSpeedSetting accepts the three documented sensitivity values', () => {
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'low');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('low');
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'med');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('high');
+  });
+
+  it('setBrushSpeedSetting collapses unknown sensitivity strings to "med"', () => {
+    // brush-stroke.ts maps sensitivity to a moving-average window
+    // (low → 6, med → 3, high → 2). An unrecognised enum would leave
+    // the ternary on the `med` branch silently, so the slice collapses
+    // unknown strings to 'med' explicitly — same enum-guard policy as
+    // shape/quickSelect/gradient.
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    const setter = useToolSettingsStore.getState().setBrushSpeedSetting as (
+      key: 'sensitivity',
+      value: string,
+    ) => void;
+    setter('sensitivity', 'medium');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+    setter('sensitivity', 'turbo');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+  });
+
+  it('setBrushSpeedSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampBrushSpeedSetting } from '../tools/brush/brush-speed-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -114,9 +115,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushAngleJitter: 0,
   brushOpacityJitter: 0,
   brushHardnessJitter: 0,
-  brushSpeedSize: 0,
-  brushSpeedSizeInvert: false,
-  brushSpeedSensitivity: 'med',
   brushTextureData: null,
   brushTextureBlendMode: 'multiply',
   brushTextureScale: 100,
@@ -129,9 +127,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setBrushAngleJitter: (jitter) => set({ brushAngleJitter: Math.max(0, Math.min(100, jitter)) }),
   setBrushOpacityJitter: (jitter) => set({ brushOpacityJitter: Math.max(0, Math.min(100, jitter)) }),
   setBrushHardnessJitter: (jitter) => set({ brushHardnessJitter: Math.max(0, Math.min(100, jitter)) }),
-  setBrushSpeedSize: (value) => set({ brushSpeedSize: Math.max(0, Math.min(300, value)) }),
-  setBrushSpeedSizeInvert: (invert) => set({ brushSpeedSizeInvert: invert }),
-  setBrushSpeedSensitivity: (sensitivity) => set({ brushSpeedSensitivity: sensitivity }),
+  setBrushSpeedSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      brushSpeed: { ...s.settings.brushSpeed, [key]: clampBrushSpeedSetting(key, value) },
+    },
+  })),
   setBrushTextureData: (texture) => set({ brushTextureData: texture }),
   setBrushTextureBlendMode: (mode) => set({ brushTextureBlendMode: mode }),
   setBrushTextureScale: (scale) => set({ brushTextureScale: Math.max(10, Math.min(300, scale)) }),
@@ -344,9 +345,9 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       hardnessJitter: s.brushHardnessJitter,
       angleJitter: s.brushAngleJitter,
       opacityJitter: s.brushOpacityJitter,
-      speedSize: s.brushSpeedSize,
-      speedSizeInvert: s.brushSpeedSizeInvert,
-      speedSensitivity: s.brushSpeedSensitivity,
+      speedSize: s.settings.brushSpeed.size,
+      speedSizeInvert: s.settings.brushSpeed.sizeInvert,
+      speedSensitivity: s.settings.brushSpeed.sensitivity,
       fade: s.brushFade,
       taper: s.brushTaper,
       subBrushes: s.activeSubBrushes.length > 0 ? s.activeSubBrushes : undefined,
@@ -366,7 +367,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     const state = get();
     const preset = state.presets.find((p) => p.id === id);
     if (!preset) return;
-    set({
+    set((s) => ({
       activePresetId: id,
       brushSize: preset.size,
       brushHardness: preset.hardness,
@@ -379,16 +380,21 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushHardnessJitter: preset.hardnessJitter ?? 0,
       brushAngleJitter: preset.angleJitter ?? 0,
       brushOpacityJitter: preset.opacityJitter ?? 0,
-      brushSpeedSize: preset.speedSize ?? 0,
-      brushSpeedSizeInvert: preset.speedSizeInvert ?? false,
-      brushSpeedSensitivity: preset.speedSensitivity ?? 'med',
       brushFade: preset.fade ?? 0,
       brushTaper: preset.taper ?? 0,
       brushTextureData: null,
       brushTextureBlendMode: 'multiply',
       brushTextureScale: 100,
       activeSubBrushes: preset.subBrushes ?? [],
-    });
+      settings: {
+        ...s.settings,
+        brushSpeed: {
+          size: clampBrushSpeedSetting('size', preset.speedSize ?? 0),
+          sizeInvert: preset.speedSizeInvert ?? false,
+          sensitivity: clampBrushSpeedSetting('sensitivity', preset.speedSensitivity ?? 'med'),
+        },
+      },
+    }));
   },
   setTipFromPreset: (id) => {
     const state = get();

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { BrushSpeedSettings } from '../tools/brush/brush-speed-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -69,9 +70,6 @@ export interface ToolSettings {
   brushAngleJitter: number;
   brushOpacityJitter: number;
   brushHardnessJitter: number;
-  brushSpeedSize: number;
-  brushSpeedSizeInvert: boolean;
-  brushSpeedSensitivity: 'low' | 'med' | 'high';
   brushTextureData: BrushTextureData | null;
   brushTextureBlendMode: BrushTextureBlendMode;
   brushTextureScale: number;
@@ -84,9 +82,7 @@ export interface ToolSettings {
   setBrushAngleJitter: (jitter: number) => void;
   setBrushOpacityJitter: (jitter: number) => void;
   setBrushHardnessJitter: (jitter: number) => void;
-  setBrushSpeedSize: (value: number) => void;
-  setBrushSpeedSizeInvert: (invert: boolean) => void;
-  setBrushSpeedSensitivity: (sensitivity: 'low' | 'med' | 'high') => void;
+  setBrushSpeedSetting: <K extends keyof BrushSpeedSettings>(key: K, value: BrushSpeedSettings[K]) => void;
   setBrushTextureData: (texture: BrushTextureData | null) => void;
   setBrushTextureBlendMode: (mode: BrushTextureBlendMode) => void;
   setBrushTextureScale: (scale: number) => void;

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -64,16 +64,14 @@ export function BrushModal() {
   const hardnessJitter = useToolSettingsStore((s) => s.brushHardnessJitter);
   const angleJitter = useToolSettingsStore((s) => s.brushAngleJitter);
   const opacityJitter = useToolSettingsStore((s) => s.brushOpacityJitter);
-  const speedSize = useToolSettingsStore((s) => s.brushSpeedSize);
-  const speedSizeInvert = useToolSettingsStore((s) => s.brushSpeedSizeInvert);
-  const speedSensitivity = useToolSettingsStore((s) => s.brushSpeedSensitivity);
+  const speedSize = useToolSettingsStore((s) => s.settings.brushSpeed.size);
+  const speedSizeInvert = useToolSettingsStore((s) => s.settings.brushSpeed.sizeInvert);
+  const speedSensitivity = useToolSettingsStore((s) => s.settings.brushSpeed.sensitivity);
   const setSizeJitter = useToolSettingsStore((s) => s.setBrushSizeJitter);
   const setHardnessJitter = useToolSettingsStore((s) => s.setBrushHardnessJitter);
   const setAngleJitter = useToolSettingsStore((s) => s.setBrushAngleJitter);
   const setOpacityJitter = useToolSettingsStore((s) => s.setBrushOpacityJitter);
-  const setSpeedSize = useToolSettingsStore((s) => s.setBrushSpeedSize);
-  const setSpeedSizeInvert = useToolSettingsStore((s) => s.setBrushSpeedSizeInvert);
-  const setSpeedSensitivity = useToolSettingsStore((s) => s.setBrushSpeedSensitivity);
+  const setBrushSpeedSetting = useToolSettingsStore((s) => s.setBrushSpeedSetting);
 
   const textureData = useToolSettingsStore((s) => s.brushTextureData);
   const textureBlendMode = useToolSettingsStore((s) => s.brushTextureBlendMode);
@@ -295,19 +293,19 @@ export function BrushModal() {
             <Slider label="Hardness Jitter" value={hardnessJitter} min={0} max={100} onChange={setHardnessJitter} />
             <Slider label="Angle Jitter" value={angleJitter} min={0} max={100} onChange={setAngleJitter} />
             <Slider label="Opacity Jitter" value={opacityJitter} min={0} max={100} onChange={setOpacityJitter} />
-            <Slider label="Speed Size" value={speedSize} min={0} max={speedSizeInvert ? 300 : 100} onChange={setSpeedSize} />
+            <Slider label="Speed Size" value={speedSize} min={0} max={speedSizeInvert ? 300 : 100} onChange={(v) => setBrushSpeedSetting('size', v)} />
             <div className={styles.speedToggleRow}>
               <span className={styles.speedToggleLabel}>Faster is</span>
               <div className={styles.speedToggleGroup}>
                 <button
                   className={`${styles.speedToggle}${!speedSizeInvert ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => { setSpeedSizeInvert(false); if (speedSize > 100) setSpeedSize(100); }}
+                  onClick={() => { setBrushSpeedSetting('sizeInvert', false); if (speedSize > 100) setBrushSpeedSetting('size', 100); }}
                 >
                   Thinner
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSizeInvert ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSizeInvert(true)}
+                  onClick={() => setBrushSpeedSetting('sizeInvert', true)}
                 >
                   Wider
                 </button>
@@ -316,19 +314,19 @@ export function BrushModal() {
               <div className={styles.speedToggleGroup}>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'low' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('low')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'low')}
                 >
                   Low
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'med' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('med')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'med')}
                 >
                   Med
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'high' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('high')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'high')}
                 >
                   High
                 </button>

--- a/src/tools/brush/brush-speed-settings.test.ts
+++ b/src/tools/brush/brush-speed-settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampBrushSpeedSetting,
+  DEFAULT_BRUSH_SPEED_SETTINGS,
+} from './brush-speed-settings';
+
+describe('brush-speed-settings', () => {
+  it('defaults match the legacy flat-store brush-speed defaults', () => {
+    expect(DEFAULT_BRUSH_SPEED_SETTINGS).toEqual({
+      size: 0,
+      sizeInvert: false,
+      sensitivity: 'med',
+    });
+  });
+
+  it('clamps size into [0, 300]', () => {
+    // Range matches the legacy setBrushSpeedSize: [0, 300]. The UI
+    // surfaces [0, 100] when `sizeInvert` is false and [0, 300] when
+    // it's true, but the store-level clamp is the looser bound so the
+    // UI can flip the toggle without truncating the value.
+    expect(clampBrushSpeedSetting('size', -10)).toBe(0);
+    expect(clampBrushSpeedSetting('size', 0)).toBe(0);
+    expect(clampBrushSpeedSetting('size', 100)).toBe(100);
+    expect(clampBrushSpeedSetting('size', 300)).toBe(300);
+    expect(clampBrushSpeedSetting('size', 9999)).toBe(300);
+  });
+
+  it('coerces sizeInvert to a boolean', () => {
+    expect(clampBrushSpeedSetting('sizeInvert', true)).toBe(true);
+    expect(clampBrushSpeedSetting('sizeInvert', false)).toBe(false);
+  });
+
+  it('accepts low / med / high for sensitivity and falls back to med for unknown strings', () => {
+    // brush-stroke.ts maps sensitivity to a moving-average window
+    // (low → 6, med → 3, high → 2). An unrecognised enum would leave
+    // that ternary on the `med` branch silently, so the clamp
+    // collapses unknown strings to 'med' explicitly.
+    expect(clampBrushSpeedSetting('sensitivity', 'low')).toBe('low');
+    expect(clampBrushSpeedSetting('sensitivity', 'med')).toBe('med');
+    expect(clampBrushSpeedSetting('sensitivity', 'high')).toBe('high');
+    expect(
+      clampBrushSpeedSetting(
+        'sensitivity',
+        'medium' as unknown as 'low' | 'med' | 'high',
+      ),
+    ).toBe('med');
+  });
+});

--- a/src/tools/brush/brush-speed-settings.ts
+++ b/src/tools/brush/brush-speed-settings.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-tool settings slice for the Brush "speed dynamics" sub-tool.
+ *
+ * Carved out of the flat `brushSpeed*` fields on the ToolSettings store
+ * as the brush's first sub-slice (see #453). The remaining brush
+ * sub-slices — jitter, texture, tip / presets / sub-brushes — land in
+ * follow-up PRs. The slice lives under `settings.brushSpeed` on the
+ * global store; reads go through `s.settings.brushSpeed.<field>` and
+ * writes through the typed `setBrushSpeedSetting(key, value)` setter.
+ *
+ * `sensitivity` is an enum, not a number: the brush-stroke hot path
+ * maps it to a moving-average window (low → 6, med → 3, high → 2)
+ * inside `brush-stroke.ts`. Unknown enum strings collapse to the
+ * documented default ('med') here rather than no-op silently, so a
+ * `@ts-ignore` bypass can't leave the stroke loop staring at a stale
+ * enum.
+ */
+export type BrushSpeedSensitivity = 'low' | 'med' | 'high';
+
+export interface BrushSpeedSettings {
+  size: number;
+  sizeInvert: boolean;
+  sensitivity: BrushSpeedSensitivity;
+}
+
+export const DEFAULT_BRUSH_SPEED_SETTINGS: BrushSpeedSettings = {
+  size: 0,
+  sizeInvert: false,
+  sensitivity: 'med',
+};
+
+const SENSITIVITIES: readonly BrushSpeedSensitivity[] = ['low', 'med', 'high'];
+
+export function clampBrushSpeedSetting<K extends keyof BrushSpeedSettings>(
+  key: K,
+  value: BrushSpeedSettings[K],
+): BrushSpeedSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(0, Math.min(300, n)) as BrushSpeedSettings[K];
+  }
+  if (key === 'sizeInvert') {
+    return Boolean(value) as BrushSpeedSettings[K];
+  }
+  if (key === 'sensitivity') {
+    const s = value as BrushSpeedSensitivity;
+    return (SENSITIVITIES.includes(s) ? s : 'med') as BrushSpeedSettings[K];
+  }
+  return value;
+}

--- a/src/tools/brush/brush-stroke.ts
+++ b/src/tools/brush/brush-stroke.ts
@@ -37,7 +37,7 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
   const hardnessJitter = toolSettings.brushHardnessJitter / 100;
   const aJ = toolSettings.brushAngleJitter / 100;
   const oJ = toolSettings.brushOpacityJitter / 100;
-  const speedSize = toolSettings.brushSpeedSize / 100;
+  const speedSize = toolSettings.settings.brushSpeed.size / 100;
   const color = state.strokeColor ?? useToolSettingsStore.getState().foregroundColor;
   const r = color.r / 255;
   const g = color.g / 255;
@@ -56,15 +56,16 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
     const maxSpeed = 5;
     const normalizedSpeed = Math.min(rawSpeed / maxSpeed, 1);
 
-    const maWindow = toolSettings.brushSpeedSensitivity === 'high' ? 2
-      : toolSettings.brushSpeedSensitivity === 'low' ? 6 : 3;
+    const sensitivity = toolSettings.settings.brushSpeed.sensitivity;
+    const maWindow = sensitivity === 'high' ? 2
+      : sensitivity === 'low' ? 6 : 3;
     if (!state.speedHistory) state.speedHistory = [];
     state.speedHistory.push(normalizedSpeed);
     if (state.speedHistory.length > maWindow) state.speedHistory.shift();
 
     const avgSpeed = state.speedHistory.reduce((a, b) => a + b, 0) / state.speedHistory.length;
 
-    const invert = toolSettings.brushSpeedSizeInvert;
+    const invert = toolSettings.settings.brushSpeed.sizeInvert;
     const targetScale = invert
       ? 1 + speedSize * avgSpeed
       : 1 - speedSize * avgSpeed;


### PR DESCRIPTION
## Summary

First brush sub-slice carved out of the flat `brushSpeed*` fields on the ToolSettings store, continuing the per-tool slice rollout tracked in #453.

- `BrushSpeedSettings` interface + `DEFAULT_BRUSH_SPEED_SETTINGS` + `clampBrushSpeedSetting` land in `src/tools/brush/brush-speed-settings.ts`, registered in `tool-settings-slices.ts` under `settings.brushSpeed`.
- Three flat fields (`brushSpeedSize`, `brushSpeedSizeInvert`, `brushSpeedSensitivity`) and their three setters collapse into a typed `setBrushSpeedSetting(key, value)` setter — same template as `setSpraySetting` / `setHealingSetting` / `setTextSetting`.
- Read sites in `BrushModal.tsx` and `brush-stroke.ts` retargeted to the slice. `setActivePreset` rebuilds the `brushSpeed` slice from the preset rather than writing the legacy flat fields.
- Unknown `sensitivity` strings collapse to `'med'` explicitly so a `@ts-ignore` bypass can't leave the brush-stroke moving-average ternary staring at a stale enum (matches the shape / quickSelect / gradient enum-guard policy).

Remaining brush sub-slices — `jitter`, `texture`, `tip / presets / sub-brushes` — still live flat on the store and land in follow-up PRs.

## Test plan

- [x] `brush-speed-settings.test.ts` covers defaults, clamps, boolean coercion, and the unknown-enum collapse to `'med'`.
- [x] New `per-tool slice: brushSpeed (#453)` describe in `tool-settings-store.test.ts` covers defaults, single-field isolation, clamps, the enum guard, and sibling-slice referential identity (asserts `settings.wand`, `settings.fill`, …, `settings.healing` are not re-created on a brushSpeed write).
- [x] Full unit suite passes locally (1342/1342 via the pre-push hook).
- [x] `npm run typecheck` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ6a5XkXcVsxayKq21qg9Q)_