### PR TITLE
refactor(brush): extract texture settings into per-tool slice (#453)

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -31,6 +31,7 @@ const ALLOWLIST = {
   // paths. These don't ship to users; they only need to round-trip.
   // ──────────────────────────────────────────────────────────────────────
   'src/app/editor-store.test.ts': 5,
+  'src/app/tool-settings-store.test.ts': 5,
   'src/app/interactions/quick-mask-move.test.ts': 2,
   'src/app/store/actions/align-layer.test.ts': 2,
   'src/app/store/actions/crop-canvas.test.ts': 1,
@@ -59,6 +60,7 @@ const ALLOWLIST = {
   'src/test-setup.ts': 1,
   'src/test/canvas-mock.ts': 3,
   'src/tools/brush/brush-from-selection.test.ts': 3,
+  'src/tools/brush/brush-texture-settings.test.ts': 1,
   'src/tools/crop/perspective-crop-interaction.test.ts': 1,
   'src/tools/crop/perspective-crop.test.ts': 3,             // see #441 (delete with prod file)
   'src/tools/fill/fill-interaction.test.ts': 3,

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { BrushTextureSettings } from '../tools/brush/brush-texture-settings';
+import { DEFAULT_BRUSH_TEXTURE_SETTINGS } from '../tools/brush/brush-texture-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  brushTexture: BrushTextureSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  brushTexture: DEFAULT_BRUSH_TEXTURE_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,155 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: brushTexture (#453)', () => {
+  it('exposes brushTexture settings under settings.brushTexture with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setBrushTextureSetting (or through the
+    // setActivePreset round-trip path, which also resets the slice).
+    useToolSettingsStore.getState().setBrushTextureSetting('data', null);
+    useToolSettingsStore.getState().setBrushTextureSetting('blendMode', 'multiply');
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 100);
+    const { brushTexture } = useToolSettingsStore.getState().settings;
+    expect(brushTexture).toEqual({ data: null, blendMode: 'multiply', scale: 100 });
+  });
+
+  it('setBrushTextureSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.brushTexture;
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 150);
+    const after = useToolSettingsStore.getState().settings.brushTexture;
+    expect(after.scale).toBe(150);
+    expect(after.data).toBe(before.data);
+    expect(after.blendMode).toBe(before.blendMode);
+  });
+
+  it('setBrushTextureSetting clamps scale into [10, 300]', () => {
+    // The legacy setBrushTextureScale floored at 10, not 0 — a 0 scale
+    // collapses the texture sampler. Preserve that range under the slice.
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 0);
+    expect(useToolSettingsStore.getState().settings.brushTexture.scale).toBe(10);
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 9999);
+    expect(useToolSettingsStore.getState().settings.brushTexture.scale).toBe(300);
+  });
+
+  it('setBrushTextureSetting accepts all three blend modes', () => {
+    for (const mode of ['multiply', 'subtract', 'overlay'] as const) {
+      useToolSettingsStore.getState().setBrushTextureSetting('blendMode', mode);
+      expect(useToolSettingsStore.getState().settings.brushTexture.blendMode).toBe(mode);
+    }
+  });
+
+  it('setBrushTextureSetting can clear data back to null', () => {
+    const tex = {
+      id: 'texture-clear-test',
+      name: 'Test',
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(4),
+    };
+    useToolSettingsStore.getState().setBrushTextureSetting('data', tex);
+    expect(useToolSettingsStore.getState().settings.brushTexture.data).toBe(tex);
+    useToolSettingsStore.getState().setBrushTextureSetting('data', null);
+    expect(useToolSettingsStore.getState().settings.brushTexture.data).toBe(null);
+  });
+
+  it('removeBrushTexture clears settings.brushTexture.data when the active texture is removed', () => {
+    // The remove-active-texture invariant predates the slice — without
+    // it, a stale BrushTextureData would survive after its underlying
+    // entry was deleted from the available-textures catalogue, and the
+    // engine sync would still try to upload a now-orphaned reference.
+    const tex = {
+      id: 'texture-remove-test',
+      name: 'Test',
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(4),
+    };
+    useToolSettingsStore.getState().addBrushTexture(tex);
+    useToolSettingsStore.getState().setBrushTextureSetting('data', tex);
+    expect(useToolSettingsStore.getState().settings.brushTexture.data).toBe(tex);
+    useToolSettingsStore.getState().removeBrushTexture(tex.id);
+    expect(useToolSettingsStore.getState().settings.brushTexture.data).toBe(null);
+    expect(useToolSettingsStore.getState().brushTextures.find((t) => t.id === tex.id)).toBeUndefined();
+  });
+
+  it('removeBrushTexture leaves settings.brushTexture.data alone when a different texture is removed', () => {
+    const active = {
+      id: 'texture-active',
+      name: 'Active',
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(4),
+    };
+    const other = {
+      id: 'texture-other',
+      name: 'Other',
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(4),
+    };
+    useToolSettingsStore.getState().addBrushTexture(active);
+    useToolSettingsStore.getState().addBrushTexture(other);
+    useToolSettingsStore.getState().setBrushTextureSetting('data', active);
+    useToolSettingsStore.getState().removeBrushTexture(other.id);
+    expect(useToolSettingsStore.getState().settings.brushTexture.data).toBe(active);
+  });
+
+  it('setActivePreset resets the brushTexture slice to defaults', () => {
+    // The setActivePreset path was the audit's largest single-`set`
+    // cluster of brush flat-field writes that crossed the slice
+    // boundary. Locking this in a test means the round-trip preset
+    // path stays correct after future slice migrations.
+    const tex = {
+      id: 'texture-preset-test',
+      name: 'Test',
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(4),
+    };
+    useToolSettingsStore.getState().setBrushTextureSetting('data', tex);
+    useToolSettingsStore.getState().setBrushTextureSetting('blendMode', 'overlay');
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 200);
+    const firstPresetId = useToolSettingsStore.getState().presets[0]?.id;
+    if (!firstPresetId) throw new Error('No built-in presets available');
+    useToolSettingsStore.getState().setActivePreset(firstPresetId);
+    expect(useToolSettingsStore.getState().settings.brushTexture).toEqual({
+      data: null,
+      blendMode: 'multiply',
+      scale: 100,
+    });
+  });
+
+  it('setBrushTextureSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setBrushTextureSetting('scale', 175);
+    expect(useToolSettingsStore.getState().settings.brushTexture.scale).toBe(175);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampBrushTextureSetting } from '../tools/brush/brush-texture-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -117,9 +118,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushSpeedSize: 0,
   brushSpeedSizeInvert: false,
   brushSpeedSensitivity: 'med',
-  brushTextureData: null,
-  brushTextureBlendMode: 'multiply',
-  brushTextureScale: 100,
   brushTextures: BUILTIN_TEXTURES,
   presets: BUILTIN_PRESETS,
   activePresetId: 'builtin-hard-round',
@@ -132,13 +130,18 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setBrushSpeedSize: (value) => set({ brushSpeedSize: Math.max(0, Math.min(300, value)) }),
   setBrushSpeedSizeInvert: (invert) => set({ brushSpeedSizeInvert: invert }),
   setBrushSpeedSensitivity: (sensitivity) => set({ brushSpeedSensitivity: sensitivity }),
-  setBrushTextureData: (texture) => set({ brushTextureData: texture }),
-  setBrushTextureBlendMode: (mode) => set({ brushTextureBlendMode: mode }),
-  setBrushTextureScale: (scale) => set({ brushTextureScale: Math.max(10, Math.min(300, scale)) }),
+  setBrushTextureSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      brushTexture: { ...s.settings.brushTexture, [key]: clampBrushTextureSetting(key, value) },
+    },
+  })),
   addBrushTexture: (texture) => set((s) => ({ brushTextures: [...s.brushTextures, texture] })),
   removeBrushTexture: (id) => set((s) => ({
     brushTextures: s.brushTextures.filter((t) => t.id !== id),
-    brushTextureData: s.brushTextureData?.id === id ? null : s.brushTextureData,
+    settings: s.settings.brushTexture.data?.id === id
+      ? { ...s.settings, brushTexture: { ...s.settings.brushTexture, data: null } }
+      : s.settings,
   })),
   setSpraySetting: (key, value) => {
     if (key === 'opacity') warnIfNormalisedOpacity('setSpraySetting(opacity)', value as number);
@@ -366,7 +369,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     const state = get();
     const preset = state.presets.find((p) => p.id === id);
     if (!preset) return;
-    set({
+    set((s) => ({
       activePresetId: id,
       brushSize: preset.size,
       brushHardness: preset.hardness,
@@ -384,11 +387,9 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushSpeedSensitivity: preset.speedSensitivity ?? 'med',
       brushFade: preset.fade ?? 0,
       brushTaper: preset.taper ?? 0,
-      brushTextureData: null,
-      brushTextureBlendMode: 'multiply',
-      brushTextureScale: 100,
+      settings: { ...s.settings, brushTexture: { data: null, blendMode: 'multiply', scale: 100 } },
       activeSubBrushes: preset.subBrushes ?? [],
-    });
+    }));
   },
   setTipFromPreset: (id) => {
     const state = get();

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -2,7 +2,7 @@ import type { Color } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
-import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
+import type { BrushPreset, BrushTipData, BrushTextureData, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
 import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { BrushTextureSettings } from '../tools/brush/brush-texture-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -72,9 +73,6 @@ export interface ToolSettings {
   brushSpeedSize: number;
   brushSpeedSizeInvert: boolean;
   brushSpeedSensitivity: 'low' | 'med' | 'high';
-  brushTextureData: BrushTextureData | null;
-  brushTextureBlendMode: BrushTextureBlendMode;
-  brushTextureScale: number;
   brushTextures: BrushTextureData[];
   presets: BrushPreset[];
   activePresetId: string | null;
@@ -87,9 +85,7 @@ export interface ToolSettings {
   setBrushSpeedSize: (value: number) => void;
   setBrushSpeedSizeInvert: (invert: boolean) => void;
   setBrushSpeedSensitivity: (sensitivity: 'low' | 'med' | 'high') => void;
-  setBrushTextureData: (texture: BrushTextureData | null) => void;
-  setBrushTextureBlendMode: (mode: BrushTextureBlendMode) => void;
-  setBrushTextureScale: (scale: number) => void;
+  setBrushTextureSetting: <K extends keyof BrushTextureSettings>(key: K, value: BrushTextureSettings[K]) => void;
   addBrushTexture: (texture: BrushTextureData) => void;
   removeBrushTexture: (id: string) => void;
   setSpraySetting: <K extends keyof SpraySettings>(key: K, value: SpraySettings[K]) => void;

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -207,7 +207,7 @@ function renderFrameGpu(
   syncGroupAdjustments(engine, layers);
   syncMaskEditMode(engine, uiState.maskMode === 'layerMask', doc.activeLayerId);
   syncBrushTip(engine, toolState.activeBrushTip, -toolState.brushAngle * Math.PI / 180, toolState.brushHardness);
-  syncBrushTexture(engine, toolState.brushTextureData, toolState.brushTextureScale, toolState.brushTextureBlendMode);
+  syncBrushTexture(engine, toolState.settings.brushTexture.data, toolState.settings.brushTexture.scale, toolState.settings.brushTexture.blendMode);
 
   renderEngine(engine);
 

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -75,13 +75,11 @@ export function BrushModal() {
   const setSpeedSizeInvert = useToolSettingsStore((s) => s.setBrushSpeedSizeInvert);
   const setSpeedSensitivity = useToolSettingsStore((s) => s.setBrushSpeedSensitivity);
 
-  const textureData = useToolSettingsStore((s) => s.brushTextureData);
-  const textureBlendMode = useToolSettingsStore((s) => s.brushTextureBlendMode);
-  const textureScale = useToolSettingsStore((s) => s.brushTextureScale);
+  const textureData = useToolSettingsStore((s) => s.settings.brushTexture.data);
+  const textureBlendMode = useToolSettingsStore((s) => s.settings.brushTexture.blendMode);
+  const textureScale = useToolSettingsStore((s) => s.settings.brushTexture.scale);
   const textures = useToolSettingsStore((s) => s.brushTextures);
-  const setTextureData = useToolSettingsStore((s) => s.setBrushTextureData);
-  const setTextureBlendMode = useToolSettingsStore((s) => s.setBrushTextureBlendMode);
-  const setTextureScale = useToolSettingsStore((s) => s.setBrushTextureScale);
+  const setBrushTextureSetting = useToolSettingsStore((s) => s.setBrushTextureSetting);
   const addBrushTexture = useToolSettingsStore((s) => s.addBrushTexture);
   const removeBrushTexture = useToolSettingsStore((s) => s.removeBrushTexture);
 
@@ -169,16 +167,16 @@ export function BrushModal() {
   const handleTextureChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const id = e.target.value;
     if (id === 'none') {
-      setTextureData(null);
+      setBrushTextureSetting('data', null);
     } else {
       const tex = textures.find((t) => t.id === id);
-      if (tex) setTextureData(tex);
+      if (tex) setBrushTextureSetting('data', tex);
     }
-  }, [textures, setTextureData]);
+  }, [textures, setBrushTextureSetting]);
 
   const handleBlendModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    setTextureBlendMode(e.target.value as BrushTextureBlendMode);
-  }, [setTextureBlendMode]);
+    setBrushTextureSetting('blendMode', e.target.value as BrushTextureBlendMode);
+  }, [setBrushTextureSetting]);
 
   const handleTextureImportClick = useCallback(() => {
     textureFileInputRef.current?.click();
@@ -208,14 +206,14 @@ export function BrushModal() {
       const name = file.name.replace(/\.[^.]+$/, '');
       const tex = { id: `texture-custom-${nextTextureId++}`, name, width: img.width, height: img.height, data: grayscale };
       addBrushTexture(tex);
-      setTextureData(tex);
+      setBrushTextureSetting('data', tex);
       URL.revokeObjectURL(url);
       setTextureImporting(false);
     };
     img.onerror = () => { notifyError('Failed to load texture image.'); URL.revokeObjectURL(url); setTextureImporting(false); };
     img.src = url;
     if (textureFileInputRef.current) textureFileInputRef.current.value = '';
-  }, [addBrushTexture, setTextureData]);
+  }, [addBrushTexture, setBrushTextureSetting]);
 
   const handleTextureDelete = useCallback(() => {
     if (textureData && textureData.id.startsWith('texture-custom-')) removeBrushTexture(textureData.id);
@@ -378,7 +376,7 @@ export function BrushModal() {
                   <option value="subtract">Subtract</option>
                   <option value="overlay">Overlay</option>
                 </select>
-                <Slider label="Scale" value={textureScale} min={10} max={300} onChange={setTextureScale} />
+                <Slider label="Scale" value={textureScale} min={10} max={300} onChange={(v) => setBrushTextureSetting('scale', v)} />
               </>
             )}
           </div>

--- a/src/tools/brush/brush-texture-settings.test.ts
+++ b/src/tools/brush/brush-texture-settings.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_BRUSH_TEXTURE_SETTINGS,
+  clampBrushTextureSetting,
+  type BrushTextureSettings,
+} from './brush-texture-settings';
+import type { BrushTextureData } from '../../types/brush';
+
+describe('brush-texture-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_BRUSH_TEXTURE_SETTINGS).toEqual({
+      data: null,
+      blendMode: 'multiply',
+      scale: 100,
+    } satisfies BrushTextureSettings);
+  });
+
+  it('clamps scale into [10, 300]', () => {
+    // The legacy setBrushTextureScale floored at 10 (not 0) — a 0 scale
+    // collapses the texture sampler to a single texel and silently
+    // produces an unusable preview. Preserve that range under the slice.
+    expect(clampBrushTextureSetting('scale', 0)).toBe(10);
+    expect(clampBrushTextureSetting('scale', -50)).toBe(10);
+    expect(clampBrushTextureSetting('scale', 9999)).toBe(300);
+    expect(clampBrushTextureSetting('scale', 100)).toBe(100);
+    expect(clampBrushTextureSetting('scale', 10)).toBe(10);
+    expect(clampBrushTextureSetting('scale', 300)).toBe(300);
+  });
+
+  it('does not round scale — preserves fractional values', () => {
+    // Sub-percent texture scaling is meaningful for tuning the seamless
+    // tile period precisely, so the clamp range guards the bounds
+    // without forcing integer values.
+    expect(clampBrushTextureSetting('scale', 100.5)).toBe(100.5);
+    expect(clampBrushTextureSetting('scale', 42.25)).toBe(42.25);
+  });
+
+  it('passes blendMode through untouched', () => {
+    expect(clampBrushTextureSetting('blendMode', 'multiply')).toBe('multiply');
+    expect(clampBrushTextureSetting('blendMode', 'subtract')).toBe('subtract');
+    expect(clampBrushTextureSetting('blendMode', 'overlay')).toBe('overlay');
+  });
+
+  it('passes data through untouched (including null)', () => {
+    expect(clampBrushTextureSetting('data', null)).toBe(null);
+    const tex: BrushTextureData = {
+      id: 'texture-test',
+      name: 'Test',
+      width: 4,
+      height: 4,
+      data: new Uint8ClampedArray(16),
+    };
+    expect(clampBrushTextureSetting('data', tex)).toBe(tex);
+  });
+});

--- a/src/tools/brush/brush-texture-settings.ts
+++ b/src/tools/brush/brush-texture-settings.ts
@@ -1,0 +1,43 @@
+import type { BrushTextureData, BrushTextureBlendMode } from '../../types/brush';
+
+/**
+ * Per-tool settings slice for the Brush tool's **texture** sub-namespace.
+ *
+ * Authoritative settings type for the brush-texture overlay (the grayscale
+ * tileable texture multiplied / subtracted / overlaid onto each dab). The
+ * slice lives under `settings.brushTexture` on the global ToolSettings store
+ * (see #453). Same pattern as the other per-tool slices:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in `tool-settings-slices.ts`.
+ *
+ * Three fields cover the per-stroke texture configuration: the active
+ * `data` (or `null` for no texture), the `blendMode` it composites with,
+ * and the `scale` percent applied to the texture's UVs in the shader.
+ *
+ * The available-textures catalogue (`brushTextures: BrushTextureData[]`)
+ * stays at the store root by design — it's a cross-tool collection of
+ * importable assets, sibling to `presets` and `activeSubBrushes`, not a
+ * per-stroke setting.
+ */
+export interface BrushTextureSettings {
+  data: BrushTextureData | null;
+  blendMode: BrushTextureBlendMode;
+  scale: number;
+}
+
+export const DEFAULT_BRUSH_TEXTURE_SETTINGS: BrushTextureSettings = {
+  data: null,
+  blendMode: 'multiply',
+  scale: 100,
+};
+
+export function clampBrushTextureSetting<K extends keyof BrushTextureSettings>(
+  key: K,
+  value: BrushTextureSettings[K],
+): BrushTextureSettings[K] {
+  if (key === 'scale') {
+    const n = value as number;
+    return Math.max(10, Math.min(300, n)) as BrushTextureSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Tonight's autofix pass shipped the per-tool settings slice for **brush texture**, the next brush sub-namespace following the brush dab-dynamics (#628) and brush jitter (#630) work that's still in flight. Three fields and three single-purpose setters collapse to a single `settings.brushTexture.*` slice with one typed `setBrushTextureSetting<K>(key, value)` setter, following the established per-tool slice template (wand / fill / marquee / smudge / pencil / sponge / eraser / path / stamp / magneticLasso / text / spray / healing).

The `brushTextures` collection (the available-textures catalogue) stays at the store root by design — it is cross-tool brush infrastructure sibling to `presets` and `activeSubBrushes`, not a per-stroke setting. The `removeBrushTexture` remove-active-texture invariant is preserved: deleting an entry that is also the active brush texture clears the slice's `data` field to `null` in the same `set()` so `engine-sync` does not try to upload an orphaned reference.

`setActivePreset` now resets the slice via a spread on `settings` instead of writing three flat fields, preserving sibling-slice referential identity. Readers in `BrushModal.tsx` (the texture tab's three controls) and `useCanvasRendering.ts` (the `syncBrushTexture` call site) migrate to `settings.brushTexture.{data,blendMode,scale}`.

The `scale` clamp range `[10, 300]` (not `[0, 300]`) is preserved — a 0 scale collapses the texture sampler to a single texel and silently produces an unusable preview. The clamp lives in `clampBrushTextureSetting` next to the type that owns it.

## Test plan

- [x] 5 new unit tests in `brush-texture-settings.test.ts` (defaults, scale clamp range, fractional preservation, blendMode pass-through, data pass-through including null)
- [x] 8 new unit tests in `tool-settings-store.test.ts` (defaults, single-field isolation, scale clamp, every blend mode, clear data to null, remove-active vs remove-other texture invariants, the `setActivePreset` reset round-trip, sibling-slice referential identity)
- [x] Full unit suite green (1346 tests, +13 from this PR)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors, pixel-debt OK after allowlist refresh for the two new test fixtures)

## Notes

Sibling to the seven in-flight brush slice PRs (#608 quick-select, #606 dodge, #623 shape, #626 gradient, #627 crop, #628 brush dab-dynamics, #630 brush jitter, #631 brush speed). None of those touch the texture sub-namespace, so this lands independently. Remaining brush sub-slices after this: brush tip / presets / sub-brushes (cross-cutting infra — needs design pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9k427xNJWzX5Tep15GKUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9k427xNJWzX5Tep15GKUD)_