### PR TITLE
refactor(dodge): extract settings into per-tool slice (#453)

### DIFF
--- a/e2e/composition-painting.spec.ts
+++ b/e2e/composition-painting.spec.ts
@@ -101,6 +101,16 @@ async function setToolSetting(page: Page, setter: string, value: unknown) {
   }, { setter, value });
 }
 
+/** Typed-slice setter wrapper for the per-tool `set<Tool>Setting(key, value)` shape. */
+async function setSliceSetting(page: Page, setter: string, key: string, value: unknown) {
+  await page.evaluate(({ setter, key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => Record<string, (k: string, v: unknown) => void>;
+    };
+    store.getState()[setter]!(key, value);
+  }, { setter, key, value });
+}
+
 const toolKeyMap: Record<string, string> = {
   move: 'v', brush: 'b', fill: 'g', shape: 'u', text: 't', eraser: 'e',
   'marquee-rect': 'm', wand: 'w', lasso: 'l', stamp: 's', dodge: 'o',
@@ -443,7 +453,7 @@ test.describe('Composition 1: Painted Landscape', () => {
     // Dodge (lighten) the left side of mountains
     await setToolOption(page, 'Size', 50);
     await setToolOption(page, 'Exposure', 60);
-    await setToolSetting(page, 'setDodgeMode', 'dodge');
+    await setSliceSetting(page, 'setDodgeSetting', 'mode', 'dodge');
 
     const beforeDodge = await snapshot(page);
     await drawStroke(page, { x: 160, y: 180 }, { x: 200, y: 240 }, 8);
@@ -452,7 +462,7 @@ test.describe('Composition 1: Painted Landscape', () => {
     expect(pixelDiff(beforeDodge, afterDodge)).toBeGreaterThan(20);
 
     // Burn (darken) the right side
-    await setToolSetting(page, 'setDodgeMode', 'burn');
+    await setSliceSetting(page, 'setDodgeSetting', 'mode', 'burn');
     const beforeBurn = await snapshot(page);
     await drawStroke(page, { x: 370, y: 160 }, { x: 420, y: 220 }, 8);
     const afterBurn = await snapshot(page);

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -6,11 +6,10 @@ import type { DodgeMode } from '../../../tools/dodge/dodge';
 import styles from '../OptionsBar.module.css';
 
 export function DodgeOptions() {
-  const dodgeExposure = useToolSettingsStore((s) => s.dodgeExposure);
-  const dodgeMode = useToolSettingsStore((s) => s.dodgeMode);
+  const dodgeExposure = useToolSettingsStore((s) => s.settings.dodge.exposure);
+  const dodgeMode = useToolSettingsStore((s) => s.settings.dodge.mode);
   const brushSize = useToolSettingsStore((s) => s.brushSize);
-  const setDodgeExposure = useToolSettingsStore((s) => s.setDodgeExposure);
-  const setDodgeMode = useToolSettingsStore((s) => s.setDodgeMode);
+  const setDodgeSetting = useToolSettingsStore((s) => s.setDodgeSetting);
   const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
@@ -22,13 +21,13 @@ export function DodgeOptions() {
       <select
         className={styles.select}
         value={dodgeMode}
-        onChange={(e) => setDodgeMode(e.target.value as DodgeMode)}
+        onChange={(e) => setDodgeSetting('mode', e.target.value as DodgeMode)}
         aria-labelledby="dodge-mode-label"
       >
         <option value="dodge">Dodge</option>
         <option value="burn">Burn</option>
       </select>
-      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={setDodgeExposure} />
+      <Slider label="Exposure" value={dodgeExposure} min={1} max={100} onChange={(v) => setDodgeSetting('exposure', v)} />
       <Slider label="Size" value={brushSize} min={1} max={sizeMax} sliderMax={300} onChange={setBrushSize} />
     </>
   );

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -26,6 +26,8 @@ import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
 import type { BrushTextureSettings } from '../tools/brush/brush-texture-settings';
 import { DEFAULT_BRUSH_TEXTURE_SETTINGS } from '../tools/brush/brush-texture-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
+import { DEFAULT_DODGE_SETTINGS } from '../tools/dodge/dodge-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -51,6 +53,7 @@ export interface ToolSettingsSlices {
   spray: SpraySettings;
   healing: HealingSettings;
   brushTexture: BrushTextureSettings;
+  dodge: DodgeSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -68,4 +71,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
   brushTexture: DEFAULT_BRUSH_TEXTURE_SETTINGS,
+  dodge: DEFAULT_DODGE_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -1015,3 +1015,77 @@ describe('per-tool slice: brushTexture (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: dodge (#453)', () => {
+  it('exposes dodge settings under settings.dodge with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setDodgeSetting.
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 50);
+    const { dodge } = useToolSettingsStore.getState().settings;
+    expect(dodge).toEqual({ mode: 'dodge', exposure: 50 });
+  });
+
+  it('setDodgeSetting updates one field without disturbing the other', () => {
+    const before = useToolSettingsStore.getState().settings.dodge;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 75);
+    const after = useToolSettingsStore.getState().settings.dodge;
+    expect(after.exposure).toBe(75);
+    expect(after.mode).toBe(before.mode);
+  });
+
+  it('setDodgeSetting toggles mode between dodge and burn', () => {
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'burn');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('burn');
+    useToolSettingsStore.getState().setDodgeSetting('mode', 'dodge');
+    expect(useToolSettingsStore.getState().settings.dodge.mode).toBe('dodge');
+  });
+
+  it('setDodgeSetting clamps exposure into [1, 100]', () => {
+    // The legacy setDodgeExposure clamped to [1, 100], not [0, 100] —
+    // a 0 here would silently produce a no-op dodge stroke, the same
+    // percent-vs-normalised footgun guarded by the warn-once dedupe.
+    // Preserve that range under the slice.
+    useToolSettingsStore.getState().setDodgeSetting('exposure', -10);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(1);
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 0);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(1);
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 200);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(100);
+  });
+
+  it('setDodgeSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushTexture = useToolSettingsStore.getState().settings.brushTexture;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setDodgeSetting('exposure', 42);
+    expect(useToolSettingsStore.getState().settings.dodge.exposure).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().settings.brushTexture).toBe(beforeBrushTexture);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -18,6 +18,7 @@ import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
 import { clampBrushTextureSetting } from '../tools/brush/brush-texture-settings';
+import { clampDodgeSetting } from '../tools/dodge/dodge-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -63,8 +64,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
   ],
   gradientReverse: false,
-  dodgeExposure: 50,
-  dodgeMode: 'dodge',
   quickSelectSize: 20,
   quickSelectTolerance: 32,
   quickSelectEdgeStrength: 50,
@@ -258,8 +257,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       path: { ...s.settings.path, [key]: clampPathSetting(key, value) },
     },
   })),
-  setDodgeExposure: (exposure) => set({ dodgeExposure: Math.max(1, Math.min(100, exposure)) }),
-  setDodgeMode: (mode) => set({ dodgeMode: mode }),
+  setDodgeSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      dodge: { ...s.settings.dodge, [key]: clampDodgeSetting(key, value) },
+    },
+  })),
   setSpongeSetting: (key, value) => set((s) => ({
     settings: {
       ...s.settings,

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,7 +1,6 @@
 import type { Color } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
-import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
@@ -17,6 +16,7 @@ import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import type { BrushTextureSettings } from '../tools/brush/brush-texture-settings';
+import type { DodgeSettings } from '../tools/dodge/dodge-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -47,8 +47,6 @@ export interface ToolSettings {
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
-  dodgeExposure: number;
-  dodgeMode: DodgeMode;
   quickSelectSize: number;
   quickSelectTolerance: number;
   quickSelectEdgeStrength: number;
@@ -98,8 +96,7 @@ export interface ToolSettings {
   setActiveBrushTip: (tip: BrushTipData | null) => void;
   setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
   setHealingSetting: <K extends keyof HealingSettings>(key: K, value: HealingSettings[K]) => void;
-  setDodgeExposure: (exposure: number) => void;
-  setDodgeMode: (mode: DodgeMode) => void;
+  setDodgeSetting: <K extends keyof DodgeSettings>(key: K, value: DodgeSettings[K]) => void;
   setSpongeSetting: <K extends keyof SpongeSettings>(key: K, value: SpongeSettings[K]) => void;
   setSmudgeSetting: <K extends keyof SmudgeSettings>(key: K, value: SmudgeSettings[K]) => void;
   setMarqueeSetting: <K extends keyof MarqueeSettings>(key: K, value: MarqueeSettings[K]) => void;

--- a/src/tools/dodge/dodge-interaction.test.ts
+++ b/src/tools/dodge/dodge-interaction.test.ts
@@ -31,8 +31,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  dodgeMode: 'dodge' as 'dodge' | 'burn',
-  dodgeExposure: 50,
+  settings: {
+    dodge: { mode: 'dodge' as 'dodge' | 'burn', exposure: 50 },
+  },
   brushSize: 20,
 };
 vi.mock('../../app/tool-settings-store', () => ({
@@ -88,8 +89,8 @@ beforeEach(() => {
   clearPendingDodgeStroke.mockClear();
   editorState.pushHistory.mockClear();
   editorState.notifyRender.mockClear();
-  ts.dodgeMode = 'dodge';
-  ts.dodgeExposure = 50;
+  ts.settings.dodge.mode = 'dodge';
+  ts.settings.dodge.exposure = 50;
   ts.brushSize = 20;
 });
 
@@ -109,7 +110,7 @@ describe('dodge down', () => {
   });
 
   it('burn mode uses mode 1 and the Burn history label', () => {
-    ts.dodgeMode = 'burn';
+    ts.settings.dodge.mode = 'burn';
     handleDodgeDown(makeCtx());
     expect(editorState.pushHistory).toHaveBeenCalledWith('Burn');
     expect(beginDodgeBurnStroke).toHaveBeenCalledWith(expect.anything(), 'layer-1', 1);
@@ -157,7 +158,7 @@ describe('dodge move', () => {
   });
 
   it('passes the current exposure setting on every move', () => {
-    ts.dodgeExposure = 80;
+    ts.settings.dodge.exposure = 80;
     handleDodgeMove(makeState({ lastPoint: { x: 0, y: 0 } }), { x: 10, y: 0 });
     expect(applyDodgeBurnDabBatch.mock.calls[0]![5]).toBeCloseTo(0.8);
   });

--- a/src/tools/dodge/dodge-interaction.ts
+++ b/src/tools/dodge/dodge-interaction.ts
@@ -26,9 +26,9 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
   const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
   const editorState = useEditorStore.getState();
   const toolSettings = useToolSettingsStore.getState();
-  const dodgeMode = toolSettings.dodgeMode;
+  const dodgeMode = toolSettings.settings.dodge.mode;
   editorState.pushHistory(dodgeMode === 'dodge' ? 'Dodge' : 'Burn');
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeShiftLine = shiftKey
     && ctx.lastPaintPointRef.current
@@ -64,7 +64,7 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
 export function handleDodgeMove(state: InteractionState, layerLocalPos: Point): void {
   if (!state.lastPoint) return;
   const toolSettings = useToolSettingsStore.getState();
-  const exposure = toolSettings.dodgeExposure / 100;
+  const exposure = toolSettings.settings.dodge.exposure / 100;
   const dodgeSize = toolSettings.brushSize;
   const dodgeSpacing = Math.max(1, dodgeSize * 0.25);
 

--- a/src/tools/dodge/dodge-settings.test.ts
+++ b/src/tools/dodge/dodge-settings.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DODGE_SETTINGS,
+  clampDodgeSetting,
+  type DodgeSettings,
+} from './dodge-settings';
+
+describe('dodge-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_DODGE_SETTINGS).toEqual({
+      mode: 'dodge',
+      exposure: 50,
+    } satisfies DodgeSettings);
+  });
+
+  it('clamps exposure into [1, 100]', () => {
+    // Range starts at 1, not 0 — a 0 here would silently produce a
+    // no-op dodge stroke, the same percent-vs-normalised footgun
+    // guarded for opacity setters by the warn-once dedupe.
+    expect(clampDodgeSetting('exposure', -10)).toBe(1);
+    expect(clampDodgeSetting('exposure', 0)).toBe(1);
+    expect(clampDodgeSetting('exposure', 200)).toBe(100);
+    expect(clampDodgeSetting('exposure', 50)).toBe(50);
+    expect(clampDodgeSetting('exposure', 1)).toBe(1);
+    expect(clampDodgeSetting('exposure', 100)).toBe(100);
+  });
+
+  it('passes mode through untouched', () => {
+    expect(clampDodgeSetting('mode', 'dodge')).toBe('dodge');
+    expect(clampDodgeSetting('mode', 'burn')).toBe('burn');
+  });
+
+  it('does not round exposure — preserves fractional values inside the range', () => {
+    expect(clampDodgeSetting('exposure', 42.5)).toBe(42.5);
+    expect(clampDodgeSetting('exposure', 75.25)).toBe(75.25);
+  });
+});

--- a/src/tools/dodge/dodge-settings.ts
+++ b/src/tools/dodge/dodge-settings.ts
@@ -1,0 +1,44 @@
+import type { DodgeMode } from './dodge';
+
+/**
+ * Per-tool settings slice for the Dodge / Burn tool.
+ *
+ * Authoritative settings type for dodge. The slice lives under
+ * `settings.dodge` on the global ToolSettings store (see #453). Same
+ * pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Two fields: the `mode` (dodge or burn) and
+ * the `exposure` percent. Exposure clamps to `[1, 100]` — a 0 here
+ * would silently produce a no-op stroke, the same percent-vs-normalised
+ * footgun guarded for the opacity setters by the warn-once dedupe in
+ * the store.
+ *
+ * Brush size for dodge still rides on the shared `brushSize` flat
+ * field by design — the dodge UI presents it as a "Size" slider sibling
+ * to the brush, and that field has not yet been sliced.
+ */
+export interface DodgeSettings {
+  mode: DodgeMode;
+  exposure: number;
+}
+
+export const DEFAULT_DODGE_SETTINGS: DodgeSettings = {
+  mode: 'dodge',
+  exposure: 50,
+};
+
+export function clampDodgeSetting<K extends keyof DodgeSettings>(
+  key: K,
+  value: DodgeSettings[K],
+): DodgeSettings[K] {
+  if (key === 'exposure') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as DodgeSettings[K];
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Per-tool slice migration for the **dodge / burn** tool, the next slot in the #453 rollout after the brush-texture slice landed in #633.

The `dodgeExposure` / `dodgeMode` flat fields and their two single-purpose setters collapse to a single `settings.dodge.*` slice with one typed `setDodgeSetting<K>(key, value)` setter, following the established per-tool slice template (`<Tool>Settings` + `DEFAULT_<TOOL>_SETTINGS` + `clamp<Tool>Setting`, registered in `tool-settings-slices.ts`).

Two fields: `mode` (`dodge` | `burn`) and `exposure` percent. Exposure clamps to `[1, 100]` — a `0` here would silently produce a no-op stroke, the same percent-vs-normalised footgun guarded by the warn-once dedupe in the store. Brush size for dodge still rides on the shared `brushSize` flat field by design — the dodge UI presents it as a "Size" slider sibling to the brush, and that field has not yet been sliced.

Read sites in `DodgeOptions.tsx` and `dodge-interaction.ts` (both `handleDodgeDown` and `handleDodgeMove`) now access `settings.dodge.{mode, exposure}`. The `dodge-interaction` test mock was retargeted to the new slice shape. The `composition-painting` e2e gains a small `setSliceSetting` helper alongside `setToolSetting` so the typed `(key, value)` setters can be exercised from Playwright with the same dynamic-name plumbing.

## Test plan

- [x] 4 new clamp / defaults tests in `src/tools/dodge/dodge-settings.test.ts`
- [x] 5 new per-tool slice tests in `src/app/tool-settings-store.test.ts` (defaults round-trip, single-field isolation, mode toggle, exposure clamp, sibling-slice referential identity across all fourteen `main`-side slices)
- [x] Existing dodge interaction tests retargeted and still passing
- [x] Full unit suite (1355 tests) green
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean (0 errors)
- [x] `pixel-debt` check OK
- [ ] e2e suite (`composition-painting.spec.ts`) needs a CI run — the `setDodgeMode` call site migrated to `setSliceSetting(page, 'setDodgeSetting', 'mode', ...)` and exercises both dodge and burn paths

Closes part of #453.

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0127VjWPNx5FVwgaBvn34xqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0127VjWPNx5FVwgaBvn34xqA)_