### PR TITLE
refactor(tool-settings): combine remaining per-tool slices to close out #453

### DIFF
--- a/e2e/GUIDE.md
+++ b/e2e/GUIDE.md
@@ -460,10 +460,10 @@ instead. `sides=6` works for the polygon SDF and can be used for
 
 ### 11. Tool-settings store expects specific ranges
 
-`setShapePolygonSides` clamps to `[3, 64]`. `setShapeCornerRadius`
-clamps to `[0, 200]`. `setBrushSize` clamps to `[1, 2000]`. Check the
-setter before asserting on the stored value — the clamp may silently
-change what you wrote.
+`setShapeSetting('polygonSides', …)` clamps to `[3, 64]`.
+`setShapeSetting('cornerRadius', …)` clamps to `[0, 200]`. `setBrushSize`
+clamps to `[1, 2000]`. Check the setter before asserting on the stored
+value — the clamp may silently change what you wrote.
 
 ### 12. Fit-to-view caps zoom at 1.0
 

--- a/e2e/align-brush.spec.ts
+++ b/e2e/align-brush.spec.ts
@@ -94,12 +94,11 @@ test.describe('Align after brush stroke (GPU-only content)', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushHardness: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      store.getState().setBrushSize(20);
-      store.getState().setBrushHardness(100);
+      store.getState().setBrushSetting('size', 20);
+      store.getState().setBrushSetting('hardness', 100);
     });
     await setForegroundColor(page, 0, 0, 0);
   });

--- a/e2e/align-fill.spec.ts
+++ b/e2e/align-fill.spec.ts
@@ -79,12 +79,11 @@ test('align bottom, then fill center — spiral stays visible', async ({ page, i
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
       getState: () => {
-        setBrushSize: (v: number) => void;
-        setBrushHardness: (v: number) => void;
+        setBrushSetting: (key: string, value: number) => void;
       };
     };
-    store.getState().setBrushSize(6);
-    store.getState().setBrushHardness(100);
+    store.getState().setBrushSetting('size', 6);
+    store.getState().setBrushSetting('hardness', 100);
   });
   await setForegroundColor(page, 0, 0, 0);
   await drawSpiral(page, 150, 150, 80);

--- a/e2e/align-sequence.spec.ts
+++ b/e2e/align-sequence.spec.ts
@@ -78,12 +78,11 @@ async function paintRectWithBrush(page: Page, docX: number, docY: number, w: num
   await page.evaluate(() => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
       getState: () => {
-        setBrushSize: (v: number) => void;
-        setBrushHardness: (v: number) => void;
+        setBrushSetting: (key: string, value: number) => void;
       };
     };
-    store.getState().setBrushSize(8);
-    store.getState().setBrushHardness(100);
+    store.getState().setBrushSetting('size', 8);
+    store.getState().setBrushSetting('hardness', 100);
   });
   await setForegroundColor(page, 0, 0, 0);
   for (let yy = docY; yy <= docY + h; yy += 4) {

--- a/e2e/align-then-brush.spec.ts
+++ b/e2e/align-then-brush.spec.ts
@@ -64,12 +64,11 @@ async function setBrush(page: Page, size: number) {
     ({ size }) => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushHardness: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      store.getState().setBrushSize(size);
-      store.getState().setBrushHardness(100);
+      store.getState().setBrushSetting('size', size);
+      store.getState().setBrushSetting('hardness', 100);
     },
     { size },
   );

--- a/e2e/align-then-stroke-scale.spec.ts
+++ b/e2e/align-then-stroke-scale.spec.ts
@@ -59,12 +59,11 @@ async function setBrush(page: Page, size: number) {
     ({ size }) => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushHardness: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      store.getState().setBrushSize(size);
-      store.getState().setBrushHardness(100);
+      store.getState().setBrushSetting('size', size);
+      store.getState().setBrushSetting('hardness', 100);
     },
     { size },
   );

--- a/e2e/brush-abr-spacing.spec.ts
+++ b/e2e/brush-abr-spacing.spec.ts
@@ -195,25 +195,17 @@ test.describe('ABR Import & Brush Properties', () => {
     // Verify tool settings were synced
     const settings = await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, unknown>;
+        getState: () => { settings: { brush: Record<string, unknown> } };
       };
-      const s = store.getState();
-      return {
-        brushSize: s.brushSize,
-        brushHardness: s.brushHardness,
-        brushSpacing: s.brushSpacing,
-        brushScatter: s.brushScatter,
-        brushAngle: s.brushAngle,
-        brushOpacity: s.brushOpacity,
-      };
+      return store.getState().settings.brush;
     });
 
-    expect(settings.brushSize).toBe(48);
-    expect(settings.brushHardness).toBe(80);
-    expect(settings.brushSpacing).toBe(35);
-    expect(settings.brushScatter).toBe(15);
-    expect(settings.brushAngle).toBe(45);
-    expect(settings.brushOpacity).toBe(90);
+    expect(settings.size).toBe(48);
+    expect(settings.hardness).toBe(80);
+    expect(settings.spacing).toBe(35);
+    expect(settings.scatter).toBe(15);
+    expect(settings.angle).toBe(45);
+    expect(settings.opacity).toBe(90);
   });
 
   test('ABR import — drawing with imported brush produces visible marks', async ({ page }) => {
@@ -500,7 +492,12 @@ test.describe('ABR Import & Brush Properties', () => {
     await setForegroundColor(page, 255, 128, 0);
 
     // Angle 0
-    await setToolSetting(page, 'setBrushAngle', 0);
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setBrushSetting: (k: 'angle', v: number) => void };
+      };
+      store.getState().setBrushSetting('angle', 0);
+    });
     const before0 = await snapshot(page);
     await drawStroke(page, { x: 100, y: 200 }, { x: 700, y: 200 }, 20);
     const after0 = await snapshot(page);
@@ -508,7 +505,12 @@ test.describe('ABR Import & Brush Properties', () => {
     await page.screenshot({ path: 'test-results/screenshots/props-08-angle-0.png' });
 
     // Angle 90 on a different line
-    await setToolSetting(page, 'setBrushAngle', 90);
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setBrushSetting: (k: 'angle', v: number) => void };
+      };
+      store.getState().setBrushSetting('angle', 90);
+    });
     const before90 = await snapshot(page);
     await drawStroke(page, { x: 100, y: 400 }, { x: 700, y: 400 }, 20);
     const after90 = await snapshot(page);

--- a/e2e/brush-hardness-bounds.spec.ts
+++ b/e2e/brush-hardness-bounds.spec.ts
@@ -76,9 +76,9 @@ async function selectTriangleBrush(page: Page) {
 async function setHardness(page: Page, value: number) {
   await page.evaluate((v) => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { setBrushHardness: (v: number) => void };
+      getState: () => { setBrushSetting: (k: 'hardness', v: number) => void };
     };
-    store.getState().setBrushHardness(v);
+    store.getState().setBrushSetting('hardness', v);
   }, value);
   await page.waitForTimeout(100);
 }

--- a/e2e/brush-perf-1080.spec.ts
+++ b/e2e/brush-perf-1080.spec.ts
@@ -36,10 +36,10 @@ test.describe('Brush perf — 1080x1080 profile', () => {
     await page.keyboard.press('b');
     await page.evaluate(() => {
       const toolStore = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setBrushSize: (s: number) => void; setBrushHardness: (h: number) => void };
+        getState: () => { setBrushSetting: (key: string, value: number) => void };
       };
-      toolStore.getState().setBrushSize(10);
-      toolStore.getState().setBrushHardness(80);
+      toolStore.getState().setBrushSetting('size', 10);
+      toolStore.getState().setBrushSetting('hardness', 80);
     });
 
     const container = page.locator('[data-testid="canvas-container"]');

--- a/e2e/brush-perf-6k.spec.ts
+++ b/e2e/brush-perf-6k.spec.ts
@@ -135,12 +135,11 @@ test.describe('Brush perf — 6000x4000 cross-hatch', () => {
     await page.evaluate(() => {
       const toolStore = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (s: number) => void;
-          setBrushHardness: (h: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      toolStore.getState().setBrushSize(12);
-      toolStore.getState().setBrushHardness(90);
+      toolStore.getState().setBrushSetting('size', 12);
+      toolStore.getState().setBrushSetting('hardness', 90);
     });
 
     const container = page.locator('[data-testid="canvas-container"]');

--- a/e2e/brush-perf.spec.ts
+++ b/e2e/brush-perf.spec.ts
@@ -48,10 +48,10 @@ test.describe('Brush performance', () => {
     await page.keyboard.press('b');
     await page.evaluate(() => {
       const toolStore = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setBrushSize: (s: number) => void; setBrushHardness: (h: number) => void };
+        getState: () => { setBrushSetting: (k: 'size' | 'hardness', v: number) => void };
       };
-      toolStore.getState().setBrushSize(40);
-      toolStore.getState().setBrushHardness(80);
+      toolStore.getState().setBrushSetting('size', 40);
+      toolStore.getState().setBrushSetting('hardness', 80);
     });
 
     // Get the canvas container position

--- a/e2e/brush-symmetry-render.spec.ts
+++ b/e2e/brush-symmetry-render.spec.ts
@@ -29,13 +29,12 @@ test.describe('Brush symmetry renders immediately (#119)', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushOpacity: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
       const state = store.getState();
-      state.setBrushSize(20);
-      state.setBrushOpacity(100);
+      state.setBrushSetting('size', 20);
+      state.setBrushSetting('opacity', 100);
     });
 
     // Select brush tool
@@ -120,13 +119,12 @@ test.describe('Brush symmetry renders immediately (#119)', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushOpacity: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
       const state = store.getState();
-      state.setBrushSize(20);
-      state.setBrushOpacity(100);
+      state.setBrushSetting('size', 20);
+      state.setBrushSetting('opacity', 100);
     });
 
     // Draw a stroke

--- a/e2e/brush-system.spec.ts
+++ b/e2e/brush-system.spec.ts
@@ -253,7 +253,12 @@ test.describe('Brush System', () => {
     await page.keyboard.press('Control+z');
     await page.waitForTimeout(300);
 
-    await setToolSetting(page, 'setBrushAngle', 90);
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+        getState: () => { setBrushSetting: (k: 'angle', v: number) => void };
+      };
+      store.getState().setBrushSetting('angle', 90);
+    });
     await page.waitForTimeout(200);
     const base90 = await snapshot(page);
     await drawStroke(page, { x: 100, y: 200 }, { x: 500, y: 200 }, 20);
@@ -348,9 +353,9 @@ test.describe('Brush System', () => {
 
     const newSize = await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { brushSize: number };
+        getState: () => { settings: { brush: { size: number } } };
       };
-      return store.getState().brushSize;
+      return store.getState().settings.brush.size;
     });
     expect(newSize).toBe(60);
 

--- a/e2e/brush-taper-shift.spec.ts
+++ b/e2e/brush-taper-shift.spec.ts
@@ -169,18 +169,17 @@ test('shift-click taper density matches drag with custom bitmap tip', async ({ p
       getState: () => {
         presets: Array<{ id: string; name: string }>;
         setActivePreset: (id: string) => void;
-        setBrushSize: (s: number) => void;
-        setBrushTaper: (t: number) => void;
+        setBrushSetting: (key: string, value: number) => void;
         setForegroundColor: (c: { r: number; g: number; b: number; a: number }) => void;
       };
     };
     const s = ts.getState();
     const star = s.presets.find((p) => p.name === 'Star');
     if (star) s.setActivePreset(star.id);
-    s.setBrushSize(30);
-    s.setBrushTaper(400);
+    s.setBrushSetting('size', 30);
+    s.setBrushSetting('taper', 400);
     // Star preset has scatter=0, but test with scatter to cover that path
-    (s as unknown as { setBrushScatter: (v: number) => void }).setBrushScatter(20);
+    s.setBrushSetting('scatter', 20);
     s.setForegroundColor({ r: 0, g: 0, b: 0, a: 1 });
   });
   await page.waitForTimeout(200);

--- a/e2e/composition-painting.spec.ts
+++ b/e2e/composition-painting.spec.ts
@@ -269,13 +269,12 @@ test.describe('Composition 1: Painted Landscape', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setGradientType: (t: string) => void;
-          setGradientStops: (s: Array<{ position: number; color: { r: number; g: number; b: number; a: number } }>) => void;
+          setGradientSetting: (key: 'type' | 'stops', value: unknown) => void;
         };
       };
       const s = store.getState();
-      s.setGradientType('linear');
-      s.setGradientStops([
+      s.setGradientSetting('type', 'linear');
+      s.setGradientSetting('stops', [
         { position: 0, color: { r: 25, g: 25, b: 112, a: 1 } },
         { position: 0.4, color: { r: 135, g: 206, b: 235, a: 1 } },
         { position: 0.7, color: { r: 255, g: 165, b: 0, a: 1 } },
@@ -303,13 +302,12 @@ test.describe('Composition 1: Painted Landscape', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setGradientType: (t: string) => void;
-          setGradientStops: (s: Array<{ position: number; color: { r: number; g: number; b: number; a: number } }>) => void;
+          setGradientSetting: (key: 'type' | 'stops', value: unknown) => void;
         };
       };
       const s = store.getState();
-      s.setGradientType('radial');
-      s.setGradientStops([
+      s.setGradientSetting('type', 'radial');
+      s.setGradientSetting('stops', [
         { position: 0, color: { r: 255, g: 255, b: 200, a: 1 } },
         { position: 0.5, color: { r: 255, g: 200, b: 50, a: 0.6 } },
         { position: 1, color: { r: 255, g: 100, b: 0, a: 0 } },

--- a/e2e/composition-shapes.spec.ts
+++ b/e2e/composition-shapes.spec.ts
@@ -123,6 +123,16 @@ async function setFillSetting(page: Page, key: 'tolerance' | 'contiguous', value
   }, { key, value });
 }
 
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
+}
+
 const toolKeyMap: Record<string, string> = {
   move: 'v',
   brush: 'b',
@@ -370,10 +380,10 @@ test.describe('Composition 2: Geometric Design', () => {
     await setActiveTool(page, 'shape');
     expect(await getActiveTool(page)).toBe('shape');
 
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 220, g: 50, b: 50, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 0 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 0);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 220, g: 50, b: 50, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 0 });
+    await setShapeSetting(page, 'strokeWidth', 0);
 
     await dragAtDoc(page, { x: 200, y: 200 }, { x: 300, y: 300 });
 
@@ -389,12 +399,12 @@ test.describe('Composition 2: Geometric Design', () => {
     const hexLayerId = await addLayer(page);
 
     await setActiveTool(page, 'shape');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 6);
-    await setToolSetting(page, 'setShapeCornerRadius', 8);
-    await setToolSetting(page, 'setShapeFillColor', { r: 50, g: 120, b: 220, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 255, g: 255, b: 255, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 3);
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 6);
+    await setShapeSetting(page, 'cornerRadius', 8);
+    await setShapeSetting(page, 'fillColor', { r: 50, g: 120, b: 220, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 255, g: 255, b: 255, a: 1 });
+    await setShapeSetting(page, 'strokeWidth', 3);
 
     await dragAtDoc(page, { x: 100, y: 100 }, { x: 200, y: 200 });
 
@@ -410,11 +420,11 @@ test.describe('Composition 2: Geometric Design', () => {
     const triLayerId = await addLayer(page);
 
     await setActiveTool(page, 'shape');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 3);
-    await setToolSetting(page, 'setShapeCornerRadius', 0);
-    await setToolSetting(page, 'setShapeFillColor', { r: 50, g: 200, b: 100, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 0 });
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 3);
+    await setShapeSetting(page, 'cornerRadius', 0);
+    await setShapeSetting(page, 'fillColor', { r: 50, g: 200, b: 100, a: 1 });
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 0 });
 
     await dragAtDoc(page, { x: 320, y: 80 }, { x: 420, y: 200 });
 

--- a/e2e/delete-inverted-selection.spec.ts
+++ b/e2e/delete-inverted-selection.spec.ts
@@ -132,15 +132,13 @@ test('delete with inverted selection clears only the correct region', async ({ p
     };
     const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
       getState: () => {
-        setShapeMode: (m: string) => void;
-        setShapeFillColor: (c: { r: number; g: number; b: number; a: number }) => void;
-        setShapeOutput: (o: string) => void;
+        setShapeSetting: (key: string, value: unknown) => void;
       };
     };
     ui.getState().setActiveTool('shape');
-    ts.getState().setShapeMode('ellipse');
-    ts.getState().setShapeFillColor({ r: 0, g: 0, b: 0, a: 1 });
-    ts.getState().setShapeOutput('pixels');
+    ts.getState().setShapeSetting('mode', 'ellipse');
+    ts.getState().setShapeSetting('fillColor', { r: 0, g: 0, b: 0, a: 1 });
+    ts.getState().setShapeSetting('output', 'pixels');
   });
   await page.waitForTimeout(100);
 

--- a/e2e/gradient-multi-stop.spec.ts
+++ b/e2e/gradient-multi-stop.spec.ts
@@ -81,9 +81,9 @@ async function setGradientStops(
   await page.evaluate(
     (stops) => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setGradientStops: (s: typeof stops) => void };
+        getState: () => { setGradientSetting: (k: 'stops', v: typeof stops) => void };
       };
-      store.getState().setGradientStops(stops);
+      store.getState().setGradientSetting('stops', stops);
     },
     stops,
   );
@@ -93,9 +93,9 @@ async function setGradientType(page: Page, type: 'linear' | 'radial') {
   await page.evaluate(
     (t) => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setGradientType: (t: string) => void };
+        getState: () => { setGradientSetting: (k: 'type', v: string) => void };
       };
-      store.getState().setGradientType(t);
+      store.getState().setGradientSetting('type', t);
     },
     type,
   );
@@ -294,9 +294,9 @@ test.describe('Multi-step gradient', () => {
 
     const stopCount = await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { gradientStops: Array<{ position: number }> };
+        getState: () => { settings: { gradient: { stops: Array<{ position: number }> } } };
       };
-      return store.getState().gradientStops.length;
+      return store.getState().settings.gradient.stops.length;
     });
 
     expect(stopCount).toBe(3);

--- a/e2e/memory-retouch-session.spec.ts
+++ b/e2e/memory-retouch-session.spec.ts
@@ -320,13 +320,12 @@ test.describe('Memory: retouching session', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setGradientType: (t: string) => void;
-          setGradientStops: (s: Array<{ position: number; color: { r: number; g: number; b: number; a: number } }>) => void;
+          setGradientSetting: (key: 'type' | 'stops', value: unknown) => void;
         };
       };
       const s = store.getState();
-      s.setGradientType('linear');
-      s.setGradientStops([
+      s.setGradientSetting('type', 'linear');
+      s.setGradientSetting('stops', [
         { position: 0, color: { r: 255, g: 200, b: 50, a: 1 } },
         { position: 0.5, color: { r: 200, g: 100, b: 150, a: 0.5 } },
         { position: 1, color: { r: 50, g: 100, b: 200, a: 0 } },

--- a/e2e/polygon-rotation.spec.ts
+++ b/e2e/polygon-rotation.spec.ts
@@ -41,16 +41,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   );
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -132,7 +130,7 @@ test.describe('Polygon rotation fix (#60)', () => {
     await setForegroundColor(page, 0, 0, 255);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
   });
 
   test('4-sided polygon renders as square with flat top edge', async ({ page }) => {

--- a/e2e/quick-selection.spec.ts
+++ b/e2e/quick-selection.spec.ts
@@ -179,17 +179,14 @@ test.describe('Quick Selection tool', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setQuickSelectSize: (v: number) => void;
-          setQuickSelectTolerance: (v: number) => void;
-          setQuickSelectEdgeStrength: (v: number) => void;
-          setQuickSelectMode: (m: 'add' | 'subtract') => void;
+          setQuickSelectSetting: (key: 'size' | 'tolerance' | 'edgeStrength' | 'mode', value: number | 'add' | 'subtract') => void;
         };
       };
       const state = ts.getState();
-      state.setQuickSelectSize(15);
-      state.setQuickSelectTolerance(60);
-      state.setQuickSelectEdgeStrength(80);
-      state.setQuickSelectMode('add');
+      state.setQuickSelectSetting('size', 15);
+      state.setQuickSelectSetting('tolerance', 60);
+      state.setQuickSelectSetting('edgeStrength', 80);
+      state.setQuickSelectSetting('mode', 'add');
     });
 
     // Drag across the red half (stay well away from the center boundary)
@@ -251,17 +248,14 @@ test.describe('Quick Selection tool', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setQuickSelectSize: (v: number) => void;
-          setQuickSelectTolerance: (v: number) => void;
-          setQuickSelectEdgeStrength: (v: number) => void;
-          setQuickSelectMode: (m: 'add' | 'subtract') => void;
+          setQuickSelectSetting: (key: 'size' | 'tolerance' | 'edgeStrength' | 'mode', value: number | 'add' | 'subtract') => void;
         };
       };
       const state = ts.getState();
-      state.setQuickSelectSize(20);
-      state.setQuickSelectTolerance(50);
-      state.setQuickSelectEdgeStrength(0);
-      state.setQuickSelectMode('add');
+      state.setQuickSelectSetting('size', 20);
+      state.setQuickSelectSetting('tolerance', 50);
+      state.setQuickSelectSetting('edgeStrength', 0);
+      state.setQuickSelectSetting('mode', 'add');
     });
 
     // First stroke: add — drag across the left portion
@@ -288,9 +282,9 @@ test.describe('Quick Selection tool', () => {
     // Switch to subtract mode
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setQuickSelectMode: (m: 'add' | 'subtract') => void };
+        getState: () => { setQuickSelectSetting: (key: 'mode', value: 'add' | 'subtract') => void };
       };
-      ts.getState().setQuickSelectMode('subtract');
+      ts.getState().setQuickSelectSetting('mode', 'subtract');
     });
 
     // Second stroke: subtract — drag over the center of the added region

--- a/e2e/rounded-corners.spec.ts
+++ b/e2e/rounded-corners.spec.ts
@@ -47,16 +47,14 @@ async function dragShape(
   await page.waitForTimeout(300);
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -155,7 +153,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const beforeState = await getEditorState(page);
     // Drag from centre (200, 150) to edge (300, 250) — rx=ry=100, so
@@ -205,7 +203,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag a 40×40 hexagon. halfSize = (20, 20). Cap is min(40, 40)/2 = 20.
     await setToolOption(page, 'Corner Radius', 20);
@@ -250,7 +248,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const beforeState = await getEditorState(page);
     await dragShape(page, { x: 150, y: 150 }, { x: 250, y: 250 });
@@ -293,7 +291,7 @@ test.describe('Shape tool corner radius (#62)', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 40);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag from centre (200, 150) to edge (300, 250) — halfSize (100, 100)
     // → bounding box (100, 50)..(300, 250). cornerRadius = 40 means each
@@ -351,7 +349,7 @@ test.describe('Shape tool corner radius (#62)', () => {
         await setShapeMode(page, 'polygon');
         await setPolygonSides(page, sides);
         await setToolOption(page, 'Corner Radius', cornerRadius);
-        await setToolSetting(page, 'setShapeStrokeColor', null);
+        await setShapeSetting(page, 'strokeColor', null);
         await dragShape(page, { x: 200, y: 150 }, { x: 300, y: 250 });
       };
 

--- a/e2e/shape-center-and-offedge.spec.ts
+++ b/e2e/shape-center-and-offedge.spec.ts
@@ -37,16 +37,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   );
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -104,7 +102,7 @@ test.describe('Shape tool click-to-size centering', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Click (no drag) at doc center (200, 150). The shape tool interprets
     // sub-threshold pointer-ups as "please open the ShapeSizeModal".
@@ -167,7 +165,7 @@ test.describe('Move tool off-edge pixel preservation', () => {
     await setForegroundColor(page, 0, 255, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     const dragFrom = await docToScreen(page, 200, 150);
     const dragTo = await docToScreen(page, 260, 200);

--- a/e2e/shape-fill-persists-on-reactivate.spec.ts
+++ b/e2e/shape-fill-persists-on-reactivate.spec.ts
@@ -83,18 +83,18 @@ async function dragShape(
 async function setShapeFillColor(page: Page, color: { r: number; g: number; b: number; a?: number }) {
   await page.evaluate((c) => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { setShapeFillColor: (c: unknown) => void };
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
     };
-    store.getState().setShapeFillColor({ r: c.r, g: c.g, b: c.b, a: c.a ?? 1 });
+    store.getState().setShapeSetting('fillColor', { r: c.r, g: c.g, b: c.b, a: c.a ?? 1 });
   }, color);
 }
 
 async function getShapeFillColor(page: Page) {
   return page.evaluate(() => {
     const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-      getState: () => { shapeFillColor: { r: number; g: number; b: number; a: number } | null };
+      getState: () => { settings: { shape: { fillColor: { r: number; g: number; b: number; a: number } | null } } };
     };
-    return store.getState().shapeFillColor;
+    return store.getState().settings.shape.fillColor;
   });
 }
 
@@ -128,9 +128,9 @@ test.describe('Shape tool fill color persists on re-activation (#424)', () => {
     // not gold. Disable stroke so only fill matters.
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => { setShapeStrokeColor: (c: unknown) => void };
+        getState: () => { setShapeSetting: (k: string, v: unknown) => void };
       };
-      store.getState().setShapeStrokeColor(null);
+      store.getState().setShapeSetting('strokeColor', null);
     });
     await page.locator('[aria-labelledby="shape-mode-label"]').selectOption('ellipse');
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });

--- a/e2e/shape-path-output.spec.ts
+++ b/e2e/shape-path-output.spec.ts
@@ -115,18 +115,15 @@ async function setShapeTool(
     ({ mode, output, sides }) => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setShapeMode: (m: string) => void;
-          setShapeOutput: (o: string) => void;
-          setShapeFillColor: (c: { r: number; g: number; b: number; a: number } | null) => void;
-          setShapePolygonSides: (n: number) => void;
+          setShapeSetting: (key: string, value: unknown) => void;
         };
       };
       const settings = ts.getState();
-      settings.setShapeMode(mode);
-      settings.setShapeOutput(output);
-      settings.setShapeFillColor({ r: 255, g: 0, b: 0, a: 1 });
+      settings.setShapeSetting('mode', mode);
+      settings.setShapeSetting('output', output);
+      settings.setShapeSetting('fillColor', { r: 255, g: 0, b: 0, a: 1 });
       if (sides !== undefined) {
-        settings.setShapePolygonSides(sides);
+        settings.setShapeSetting('polygonSides', sides);
       }
     },
     { mode, output, sides: options?.sides ?? null },

--- a/e2e/shape-tool.spec.ts
+++ b/e2e/shape-tool.spec.ts
@@ -56,16 +56,14 @@ async function dragShape(
   await page.waitForTimeout(300);
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -161,7 +159,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 30);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw rectangle: center at (200,150), drag to (300,250)
     // This creates a polygon with ~100px radius in each direction
@@ -193,7 +191,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
     await setToolOption(page, 'Corner Radius', 20);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw hexagon: center at (200,150), drag to (280,230)
     // rx = 80, ry = 80
@@ -220,7 +218,7 @@ test.describe('Shape tool corner radius', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 15);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw triangle: center at (200,150), drag to (280,230)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 230 });
@@ -261,7 +259,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw an ellipse from center (200,150) to edge (280,220)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });
@@ -296,7 +294,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Simulate a realistic drag where the first mousemove is axis-aligned.
     // In a real browser the mouse often registers horizontal movement before
@@ -345,7 +343,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 6);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag purely horizontally — height dimension is 0 throughout
     await dragShape(page, { x: 150, y: 150 }, { x: 300, y: 150 }, 10);
@@ -370,8 +368,8 @@ test.describe('Shape tool click-and-drag', () => {
     // to full opacity after a few frames.
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 255, g: 0, b: 0, a: 0.5 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'fillColor', { r: 255, g: 0, b: 0, a: 0.5 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw with many steps to accumulate renders
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 }, 15);
@@ -397,7 +395,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw on the active layer (Layer 1)
     await dragShape(page, { x: 200, y: 150 }, { x: 280, y: 220 });
@@ -419,7 +417,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Drag only 2 pixels — below the 4px click threshold
     await dragShape(page, { x: 200, y: 150 }, { x: 201, y: 151 });
@@ -435,8 +433,8 @@ test.describe('Shape tool click-and-drag', () => {
   test('shape with stroke only creates visible outline', async ({ page }) => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 255, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 255, a: 1 });
     await setToolOption(page, 'Width', 4);
 
     // Draw an ellipse from center (200,150) to edge (280,220)
@@ -464,8 +462,8 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 255, g: 0, b: 128, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 255, g: 0, b: 128, a: 1 });
     await setToolOption(page, 'Width', 3);
 
     // Drag from canvas center to lower-right so the bbox sits inside the
@@ -519,8 +517,8 @@ test.describe('Shape tool click-and-drag', () => {
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 3);
     await setToolOption(page, 'Corner Radius', 0);
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 0, b: 0, a: 1 });
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 0, b: 0, a: 1 });
     await setToolOption(page, 'Width', 3);
 
     // Drag from (200, 150) to (260, 210). bbox = (140, 90) → (260, 210).
@@ -542,7 +540,7 @@ test.describe('Shape tool click-and-drag', () => {
     await setForegroundColor(page, 255, 0, 0);
     await selectTool(page, 'shape');
     await setShapeMode(page, 'ellipse');
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw first shape
     await dragShape(page, { x: 100, y: 100 }, { x: 150, y: 140 });

--- a/e2e/stroke-effect-live.spec.ts
+++ b/e2e/stroke-effect-live.spec.ts
@@ -100,12 +100,11 @@ test.describe('Stroke effect on in-progress brush stroke', () => {
     await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (v: number) => void;
-          setBrushHardness: (v: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      store.getState().setBrushSize(30);
-      store.getState().setBrushHardness(100);
+      store.getState().setBrushSetting('size', 30);
+      store.getState().setBrushSetting('hardness', 100);
     });
     await setForegroundColor(page, 0, 0, 0);
 

--- a/e2e/text-brush-merge.spec.ts
+++ b/e2e/text-brush-merge.spec.ts
@@ -139,10 +139,10 @@ test.describe('Text + brush + merge down', () => {
     await page.evaluate(() => {
       const ts = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
         getState: () => {
-          setBrushSize: (s: number) => void;
+          setBrushSetting: (key: string, value: number) => void;
         };
       };
-      ts.getState().setBrushSize(8);
+      ts.getState().setBrushSetting('size', 8);
     });
     await setForegroundColor(page, 0, 0, 255);
 

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -245,6 +245,20 @@ async function setToolSetting(page: Page, setter: string, value: unknown) {
   );
 }
 
+/** Write to the gradient per-tool settings slice; see #453. */
+async function setGradientSetting(
+  page: Page,
+  key: 'type' | 'stops' | 'reverse',
+  value: unknown,
+) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setGradientSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setGradientSetting(key, value);
+  }, { key, value });
+}
+
 /** Write to a per-tool settings slice (wand, …); see #453. */
 async function setWandSetting(page: Page, key: 'tolerance' | 'contiguous' | 'graduated', value: number | boolean) {
   await page.evaluate(({ key, value }) => {
@@ -635,8 +649,8 @@ test.describe('Gradient Tool', () => {
 
   test('linear gradient creates smooth transition', async ({ page }) => {
     await page.locator('[data-tool-id="gradient"]').click();
-    await setToolSetting(page, 'setGradientType', 'linear');
-    await setToolSetting(page, 'setGradientStops', [
+    await setGradientSetting(page, 'type', 'linear');
+    await setGradientSetting(page, 'stops', [
       { position: 0, color: { r: 255, g: 0, b: 0, a: 1 } },
       { position: 1, color: { r: 0, g: 0, b: 255, a: 1 } },
     ]);
@@ -652,8 +666,8 @@ test.describe('Gradient Tool', () => {
 
   test('radial gradient creates circular pattern', async ({ page }) => {
     await page.locator('[data-tool-id="gradient"]').click();
-    await setToolSetting(page, 'setGradientType', 'radial');
-    await setToolSetting(page, 'setGradientStops', [
+    await setGradientSetting(page, 'type', 'radial');
+    await setGradientSetting(page, 'stops', [
       { position: 0, color: { r: 255, g: 0, b: 0, a: 1 } },
       { position: 1, color: { r: 0, g: 0, b: 255, a: 1 } },
     ]);
@@ -1992,8 +2006,8 @@ test.describe('Comprehensive Scenarios', () => {
 
     // Apply gradient across the canvas (no selection needed)
     await page.locator('[data-tool-id="gradient"]').click();
-    await setToolSetting(page, 'setGradientType', 'linear');
-    await setToolSetting(page, 'setGradientStops', [
+    await setGradientSetting(page, 'type', 'linear');
+    await setGradientSetting(page, 'stops', [
       { position: 0, color: { r: 255, g: 0, b: 0, a: 1 } },
       { position: 1, color: { r: 0, g: 0, b: 255, a: 1 } },
     ]);

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -275,6 +275,16 @@ async function setPencilSetting(page: Page, key: 'size', value: number) {
   }, { key, value });
 }
 
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
+}
+
 async function setUIState(page: Page, setter: string, value: unknown) {
   await page.evaluate(
     ({ setter, value }) => {
@@ -719,10 +729,10 @@ test.describe('Shape Tool', () => {
 
   test('drawing polygon creates filled pixels', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'polygon');
-    await setToolSetting(page, 'setShapePolygonSides', 6);
-    await setToolSetting(page, 'setShapeFillColor', { r: 0, g: 0, b: 255, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'polygon');
+    await setShapeSetting(page, 'polygonSides', 6);
+    await setShapeSetting(page, 'fillColor', { r: 0, g: 0, b: 255, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Center-outward: click center at 125,125, drag to 200,200 (radius ~75px)
     await drawStroke(page, { x: 125, y: 125 }, { x: 200, y: 200 }, 5);
@@ -734,9 +744,9 @@ test.describe('Shape Tool', () => {
 
   test('drawing ellipse creates filled pixels', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 255, g: 0, b: 0, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 255, g: 0, b: 0, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Center-outward: click center at 200,150, drag to 300,250 (100x100 radii)
     await drawStroke(page, { x: 200, y: 150 }, { x: 300, y: 250 }, 5);
@@ -750,10 +760,10 @@ test.describe('Shape Tool', () => {
 
   test('shape tool with stroke only creates outline', async ({ page }) => {
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', null);
-    await setToolSetting(page, 'setShapeStrokeColor', { r: 0, g: 255, b: 0, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeWidth', 3);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', null);
+    await setShapeSetting(page, 'strokeColor', { r: 0, g: 255, b: 0, a: 1 });
+    await setShapeSetting(page, 'strokeWidth', 3);
 
     // Center-outward: click center at 125,125, drag to 200,200
     await drawStroke(page, { x: 125, y: 125 }, { x: 200, y: 200 }, 5);
@@ -1860,9 +1870,9 @@ test.describe('Comprehensive Scenarios', () => {
 
     // Draw a filled ellipse
     await page.keyboard.press('u');
-    await setToolSetting(page, 'setShapeMode', 'ellipse');
-    await setToolSetting(page, 'setShapeFillColor', { r: 100, g: 150, b: 200, a: 1 });
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'mode', 'ellipse');
+    await setShapeSetting(page, 'fillColor', { r: 100, g: 150, b: 200, a: 1 });
+    await setShapeSetting(page, 'strokeColor', null);
     // Center-outward: center at 100,100, drag to 180,180 (80px radii)
     const beforeShape = await readComposited(page);
     await drawStroke(page, { x: 100, y: 100 }, { x: 180, y: 180 }, 5);

--- a/e2e/transform-user-repro.spec.ts
+++ b/e2e/transform-user-repro.spec.ts
@@ -27,16 +27,14 @@ async function docToScreen(page: Page, docX: number, docY: number) {
   }, { docX, docY });
 }
 
-async function setToolSetting(page: Page, setter: string, value: unknown) {
-  await page.evaluate(
-    ({ setter, value }) => {
-      const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
-        getState: () => Record<string, (v: unknown) => void>;
-      };
-      store.getState()[setter]!(value);
-    },
-    { setter, value },
-  );
+/** Write to the shape per-tool settings slice; see #453. */
+async function setShapeSetting(page: Page, key: string, value: unknown) {
+  await page.evaluate(({ key, value }) => {
+    const store = (window as unknown as Record<string, unknown>).__toolSettingsStore as {
+      getState: () => { setShapeSetting: (k: string, v: unknown) => void };
+    };
+    store.getState().setShapeSetting(key, value);
+  }, { key, value });
 }
 
 async function setShapeMode(page: Page, mode: string) {
@@ -168,7 +166,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
 
     // Draw from center outward
     await drawShape(page, 300, 300, 400, 400);
@@ -212,7 +210,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     const shapePixels = await countActiveLayerPixelsGPU(page);
@@ -253,7 +251,7 @@ test.describe('User repro: shape tool + transform', { tag: '@chromium' }, () => 
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     const shapePixels = await countActiveLayerPixelsGPU(page);
@@ -300,7 +298,7 @@ test.describe('Perspective mode', { tag: '@chromium' }, () => {
     await selectTool(page, 'shape');
     await setShapeMode(page, 'polygon');
     await setPolygonSides(page, 4);
-    await setToolSetting(page, 'setShapeStrokeColor', null);
+    await setShapeSetting(page, 'strokeColor', null);
     await drawShape(page, 300, 300, 400, 400);
 
     await cmdClickThumbnail(page);

--- a/src/app/OptionsBar/tool-options/BrushOptions.tsx
+++ b/src/app/OptionsBar/tool-options/BrushOptions.tsx
@@ -9,14 +9,15 @@ import { docScaledMax } from '../../../utils/slider-ranges';
 import styles from './BrushOptions.module.css';
 
 export function BrushOptions() {
-  const brushSize = useToolSettingsStore((s) => s.brushSize);
-  const brushOpacity = useToolSettingsStore((s) => s.brushOpacity);
-  const brushHardness = useToolSettingsStore((s) => s.brushHardness);
-  const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
-  const setBrushOpacity = useToolSettingsStore((s) => s.setBrushOpacity);
-  const setBrushHardness = useToolSettingsStore((s) => s.setBrushHardness);
-  const brushFade = useToolSettingsStore((s) => s.brushFade);
-  const setBrushFade = useToolSettingsStore((s) => s.setBrushFade);
+  const brushSize = useToolSettingsStore((s) => s.settings.brush.size);
+  const brushOpacity = useToolSettingsStore((s) => s.settings.brush.opacity);
+  const brushHardness = useToolSettingsStore((s) => s.settings.brush.hardness);
+  const brushFade = useToolSettingsStore((s) => s.settings.brush.fade);
+  const setBrushSetting = useToolSettingsStore((s) => s.setBrushSetting);
+  const setBrushSize = useCallback((v: number) => setBrushSetting('size', v), [setBrushSetting]);
+  const setBrushOpacity = useCallback((v: number) => setBrushSetting('opacity', v), [setBrushSetting]);
+  const setBrushHardness = useCallback((v: number) => setBrushSetting('hardness', v), [setBrushSetting]);
+  const setBrushFade = useCallback((v: number) => setBrushSetting('fade', v), [setBrushSetting]);
 
   const presets = useToolSettingsStore((s) => s.presets);
   const activePresetId = useToolSettingsStore((s) => s.activePresetId);

--- a/src/app/OptionsBar/tool-options/CropOptions.tsx
+++ b/src/app/OptionsBar/tool-options/CropOptions.tsx
@@ -5,14 +5,14 @@ import { AspectRatioControl } from './AspectRatioControl';
 import styles from '../OptionsBar.module.css';
 
 export function CropOptions() {
-  const cropMode = useToolSettingsStore((s) => s.cropMode);
-  const setCropMode = useToolSettingsStore((s) => s.setCropMode);
+  const cropMode = useToolSettingsStore((s) => s.settings.crop.mode);
+  const setCropSetting = useToolSettingsStore((s) => s.setCropSetting);
   const perspectiveCropQuad = useUIStore((s) => s.perspectiveCropQuad);
   const setPerspectiveCropQuad = useUIStore((s) => s.setPerspectiveCropQuad);
   const setPerspectiveCropDragging = useUIStore((s) => s.setPerspectiveCropDragging);
 
   function handleModeChange(mode: 'normal' | 'perspective') {
-    setCropMode(mode);
+    setCropSetting('mode', mode);
     // Clear any active overlay when switching modes
     setPerspectiveCropQuad(null);
     setPerspectiveCropDragging(null);

--- a/src/app/OptionsBar/tool-options/DodgeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/DodgeOptions.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useToolSettingsStore } from '../../tool-settings-store';
 import { useEditorStore } from '../../editor-store';
 import { Slider } from '../../../components/Slider/Slider';
@@ -8,10 +9,11 @@ import styles from '../OptionsBar.module.css';
 export function DodgeOptions() {
   const dodgeExposure = useToolSettingsStore((s) => s.dodgeExposure);
   const dodgeMode = useToolSettingsStore((s) => s.dodgeMode);
-  const brushSize = useToolSettingsStore((s) => s.brushSize);
+  const brushSize = useToolSettingsStore((s) => s.settings.brush.size);
   const setDodgeExposure = useToolSettingsStore((s) => s.setDodgeExposure);
   const setDodgeMode = useToolSettingsStore((s) => s.setDodgeMode);
-  const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
+  const setBrushSetting = useToolSettingsStore((s) => s.setBrushSetting);
+  const setBrushSize = useCallback((v: number) => setBrushSetting('size', v), [setBrushSetting]);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
   const sizeMax = docScaledMax(docWidth, docHeight, 200);

--- a/src/app/OptionsBar/tool-options/GradientOptions.tsx
+++ b/src/app/OptionsBar/tool-options/GradientOptions.tsx
@@ -7,11 +7,10 @@ import styles from '../OptionsBar.module.css';
 import gradientStyles from './GradientOptions.module.css';
 
 export function GradientOptions() {
-  const gradientType = useToolSettingsStore((s) => s.gradientType);
-  const setGradientType = useToolSettingsStore((s) => s.setGradientType);
-  const gradientStops = useToolSettingsStore((s) => s.gradientStops);
-  const gradientReverse = useToolSettingsStore((s) => s.gradientReverse);
-  const setGradientReverse = useToolSettingsStore((s) => s.setGradientReverse);
+  const gradientType = useToolSettingsStore((s) => s.settings.gradient.type);
+  const gradientStops = useToolSettingsStore((s) => s.settings.gradient.stops);
+  const gradientReverse = useToolSettingsStore((s) => s.settings.gradient.reverse);
+  const setGradientSetting = useToolSettingsStore((s) => s.setGradientSetting);
   const [showModal, setShowModal] = useState(false);
 
   const handleOpenModal = useCallback(() => {
@@ -30,7 +29,7 @@ export function GradientOptions() {
       <select
         className={styles.select}
         value={gradientType}
-        onChange={(e) => setGradientType(e.target.value as GradientType)}
+        onChange={(e) => setGradientSetting('type', e.target.value as GradientType)}
         aria-labelledby="gradient-type-label"
       >
         <option value="linear">Linear</option>
@@ -62,7 +61,7 @@ export function GradientOptions() {
         <input
           type="checkbox"
           checked={gradientReverse}
-          onChange={(e) => setGradientReverse(e.target.checked)}
+          onChange={(e) => setGradientSetting('reverse', e.target.checked)}
         />
         Reverse
       </label>

--- a/src/app/OptionsBar/tool-options/ShapeOptions.tsx
+++ b/src/app/OptionsBar/tool-options/ShapeOptions.tsx
@@ -45,21 +45,15 @@ function ColorPopover({ anchorRef, popoverRef, color, onChange, onRemove, remove
 }
 
 export function ShapeOptions() {
-  const shapeMode = useToolSettingsStore((s) => s.shapeMode);
-  const shapeOutput = useToolSettingsStore((s) => s.shapeOutput);
-  const shapeFillColor = useToolSettingsStore((s) => s.shapeFillColor);
-  const shapeStrokeColor = useToolSettingsStore((s) => s.shapeStrokeColor);
-  const shapeStrokeWidth = useToolSettingsStore((s) => s.shapeStrokeWidth);
-  const shapePolygonSides = useToolSettingsStore((s) => s.shapePolygonSides);
-  const shapeCornerRadius = useToolSettingsStore((s) => s.shapeCornerRadius);
-  const setShapeMode = useToolSettingsStore((s) => s.setShapeMode);
-  const setShapeOutput = useToolSettingsStore((s) => s.setShapeOutput);
-  const setShapeFillColor = useToolSettingsStore((s) => s.setShapeFillColor);
-  const setShapeStrokeColor = useToolSettingsStore((s) => s.setShapeStrokeColor);
+  const shapeMode = useToolSettingsStore((s) => s.settings.shape.mode);
+  const shapeOutput = useToolSettingsStore((s) => s.settings.shape.output);
+  const shapeFillColor = useToolSettingsStore((s) => s.settings.shape.fillColor);
+  const shapeStrokeColor = useToolSettingsStore((s) => s.settings.shape.strokeColor);
+  const shapeStrokeWidth = useToolSettingsStore((s) => s.settings.shape.strokeWidth);
+  const shapePolygonSides = useToolSettingsStore((s) => s.settings.shape.polygonSides);
+  const shapeCornerRadius = useToolSettingsStore((s) => s.settings.shape.cornerRadius);
+  const setShapeSetting = useToolSettingsStore((s) => s.setShapeSetting);
   const setForegroundColor = useToolSettingsStore((s) => s.setForegroundColor);
-  const setShapeStrokeWidth = useToolSettingsStore((s) => s.setShapeStrokeWidth);
-  const setShapePolygonSides = useToolSettingsStore((s) => s.setShapePolygonSides);
-  const setShapeCornerRadius = useToolSettingsStore((s) => s.setShapeCornerRadius);
 
   const [openPopover, setOpenPopover] = useState<PopoverTarget>(null);
   const fillRef = useRef<HTMLDivElement>(null);
@@ -85,7 +79,7 @@ export function ShapeOptions() {
       <select
         className={styles.select}
         value={shapeMode}
-        onChange={(e) => setShapeMode(e.target.value as ShapeMode)}
+        onChange={(e) => setShapeSetting('mode', e.target.value as ShapeMode)}
         aria-labelledby="shape-mode-label"
       >
         <option value="ellipse">Ellipse</option>
@@ -96,7 +90,7 @@ export function ShapeOptions() {
       <select
         className={styles.select}
         value={shapeOutput}
-        onChange={(e) => setShapeOutput(e.target.value as ShapeOutput)}
+        onChange={(e) => setShapeSetting('output', e.target.value as ShapeOutput)}
         aria-labelledby="shape-output-label"
       >
         <option value="pixels">Pixels</option>
@@ -113,13 +107,13 @@ export function ShapeOptions() {
             min={3}
             max={64}
             value={shapePolygonSides}
-            onChange={(e) => setShapePolygonSides(Number(e.target.value))}
+            onChange={(e) => setShapeSetting('polygonSides', Number(e.target.value))}
           />
         </>
       )}
 
       {shapeMode !== 'ellipse' && (
-        <Slider label="Corner Radius" value={shapeCornerRadius} min={0} max={200} onChange={setShapeCornerRadius} />
+        <Slider label="Corner Radius" value={shapeCornerRadius} min={0} max={200} onChange={(v) => setShapeSetting('cornerRadius', v)} />
       )}
 
       <AspectRatioControl />
@@ -143,7 +137,7 @@ export function ShapeOptions() {
             type="button"
             aria-label="Add fill color"
             onClick={() => {
-              setShapeFillColor({ r: 255, g: 255, b: 255, a: 1 });
+              setShapeSetting('fillColor', { r: 255, g: 255, b: 255, a: 1 });
               setOpenPopover('fill');
             }}
           >
@@ -155,8 +149,8 @@ export function ShapeOptions() {
             anchorRef={fillRef}
             popoverRef={popoverRef}
             color={shapeFillColor}
-            onChange={setShapeFillColor}
-            onRemove={() => { setShapeFillColor(null); setOpenPopover(null); }}
+            onChange={(c) => setShapeSetting('fillColor', c)}
+            onRemove={() => { setShapeSetting('fillColor', null); setOpenPopover(null); }}
             removeLabel="Remove fill"
           />
         )}
@@ -181,7 +175,7 @@ export function ShapeOptions() {
             type="button"
             aria-label="Add stroke color"
             onClick={() => {
-              setShapeStrokeColor({ r: 0, g: 0, b: 0, a: 1 });
+              setShapeSetting('strokeColor', { r: 0, g: 0, b: 0, a: 1 });
               setOpenPopover('stroke');
             }}
           >
@@ -193,15 +187,15 @@ export function ShapeOptions() {
             anchorRef={strokeRef}
             popoverRef={popoverRef}
             color={shapeStrokeColor}
-            onChange={setShapeStrokeColor}
-            onRemove={() => { setShapeStrokeColor(null); setOpenPopover(null); }}
+            onChange={(c) => setShapeSetting('strokeColor', c)}
+            onRemove={() => { setShapeSetting('strokeColor', null); setOpenPopover(null); }}
             removeLabel="Remove stroke"
           />
         )}
       </div>
 
       {shapeStrokeColor && (
-        <Slider label="Width" value={shapeStrokeWidth} min={1} max={50} onChange={setShapeStrokeWidth} />
+        <Slider label="Width" value={shapeStrokeWidth} min={1} max={50} onChange={(v) => setShapeSetting('strokeWidth', v)} />
       )}
     </>
   );

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -142,9 +142,9 @@ export function handlePaintDown(
     const mode = getQuickMaskPaintMode(tool, toolSettings.foregroundColor);
 
     if (tool === 'brush') {
-      const size = toolSettings.brushSize;
-      const hardness = toolSettings.brushHardness / 100;
-      const opacity = toolSettings.brushOpacity / 100;
+      const size = toolSettings.settings.brush.size;
+      const hardness = toolSettings.settings.brush.hardness / 100;
+      const opacity = toolSettings.settings.brush.opacity / 100;
       if (shiftLine) {
         const arr = packDabLine(qmShiftFrom, canvasPos, size);
         gpuQuickMaskDabBatch(engine, arr, size, hardness, opacity, mode);
@@ -207,9 +207,9 @@ export function handlePaintDown(
     const mode = tool === 'eraser' ? 0 : 1;
 
     if (tool === 'brush') {
-      const size = toolSettings.brushSize;
-      const hardness = toolSettings.brushHardness / 100;
-      const opacity = toolSettings.brushOpacity / 100;
+      const size = toolSettings.settings.brush.size;
+      const hardness = toolSettings.settings.brush.hardness / 100;
+      const opacity = toolSettings.settings.brush.opacity / 100;
       if (shiftLine) {
         const arr = packDabLine(lineFrom, layerPos, size);
         gpuMaskDabBatch(engine, activeLayerId, arr, size, hardness, opacity, mode);
@@ -279,17 +279,18 @@ export function handlePaintDown(
   const sym = getSymmetryConfig(docCenter);
 
   if (tool === 'brush') {
-    const baseSize = toolSettings.brushSize;
-    const baseHardness = toolSettings.brushHardness / 100;
-    const opacity = toolSettings.brushOpacity / 100;
-    const brushSpacing = toolSettings.brushSpacing;
-    const brushScatter = toolSettings.brushScatter;
-    const brushFade = toolSettings.brushFade;
+    const brush = toolSettings.settings.brush;
+    const baseSize = brush.size;
+    const baseHardness = brush.hardness / 100;
+    const opacity = brush.opacity / 100;
+    const brushSpacing = brush.spacing;
+    const brushScatter = brush.scatter;
+    const brushFade = brush.fade;
     const sizeJitter = toolSettings.brushSizeJitter / 100;
     const hardnessJitter = toolSettings.brushHardnessJitter / 100;
     const aJ = toolSettings.brushAngleJitter / 100;
     const oJ = toolSettings.brushOpacityJitter / 100;
-    const brushTaper = toolSettings.brushTaper;
+    const brushTaper = brush.taper;
     const needsPerDab = sizeJitter > 0 || hardnessJitter > 0 || brushTaper > 0;
     const color = strokeColor;
     useToolSettingsStore.getState().addRecentColor(color);
@@ -657,7 +658,7 @@ function handleMaskPaintMoveUnified(
 
   switch (state.tool) {
     case 'brush':
-      emitDabs(toolSettings.brushSize, toolSettings.brushHardness / 100, toolSettings.brushOpacity / 100);
+      emitDabs(toolSettings.settings.brush.size, toolSettings.settings.brush.hardness / 100, toolSettings.settings.brush.opacity / 100);
       break;
     case 'pencil': {
       const size = toolSettings.settings.pencil.size;

--- a/src/app/interactions/paint-handlers.ts
+++ b/src/app/interactions/paint-handlers.ts
@@ -285,10 +285,10 @@ export function handlePaintDown(
     const brushSpacing = toolSettings.brushSpacing;
     const brushScatter = toolSettings.brushScatter;
     const brushFade = toolSettings.brushFade;
-    const sizeJitter = toolSettings.brushSizeJitter / 100;
-    const hardnessJitter = toolSettings.brushHardnessJitter / 100;
-    const aJ = toolSettings.brushAngleJitter / 100;
-    const oJ = toolSettings.brushOpacityJitter / 100;
+    const sizeJitter = toolSettings.settings.brushJitter.size / 100;
+    const hardnessJitter = toolSettings.settings.brushJitter.hardness / 100;
+    const aJ = toolSettings.settings.brushJitter.angle / 100;
+    const oJ = toolSettings.settings.brushJitter.opacity / 100;
     const brushTaper = toolSettings.brushTaper;
     const needsPerDab = sizeJitter > 0 || hardnessJitter > 0 || brushTaper > 0;
     const color = strokeColor;

--- a/src/app/rendering/render-overlay-frame.ts
+++ b/src/app/rendering/render-overlay-frame.ts
@@ -150,7 +150,7 @@ export function renderOverlayFrame(overlayCanvas: HTMLCanvasElement, antPhase: n
 
   const brushCursorInfo = getBrushCursorInfo(activeTool);
   if (brushCursorInfo !== null && cursorOnCanvas) {
-    const size = activeTool === 'brush' ? toolState.brushSize
+    const size = activeTool === 'brush' ? toolState.settings.brush.size
       : activeTool === 'pencil' ? toolState.settings.pencil.size
       : activeTool === 'eraser' ? toolState.settings.eraser.size
       : activeTool === 'stamp' ? toolState.settings.stamp.size

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -61,7 +61,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   } else if (tool === 'path') {
     ts.setPathSetting('strokeWidth', ts.settings.path.strokeWidth + delta);
   } else if (tool === 'shape') {
-    ts.setShapeStrokeWidth(ts.shapeStrokeWidth + delta);
+    ts.setShapeSetting('strokeWidth', ts.settings.shape.strokeWidth + delta);
   }
   return true;
 }

--- a/src/app/shortcuts/tool-shortcuts.ts
+++ b/src/app/shortcuts/tool-shortcuts.ts
@@ -47,7 +47,7 @@ export function handleSizeShortcut(e: KeyboardEvent): boolean {
   const ts = useToolSettingsStore.getState();
 
   if (tool === 'brush' || tool === 'dodge') {
-    ts.setBrushSize(ts.brushSize + delta);
+    ts.setBrushSetting('size', ts.settings.brush.size + delta);
   } else if (tool === 'smudge') {
     ts.setSmudgeSetting('size', ts.settings.smudge.size + delta);
   } else if (tool === 'pencil') {

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { CropSettings } from '../tools/crop/crop-settings';
+import { DEFAULT_CROP_SETTINGS } from '../tools/crop/crop-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  crop: CropSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  crop: DEFAULT_CROP_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { BrushSettings } from '../tools/brush/brush-settings';
+import { DEFAULT_BRUSH_SETTINGS } from '../tools/brush/brush-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  brush: BrushSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  brush: DEFAULT_BRUSH_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { BrushJitterSettings } from '../tools/brush/brush-jitter-settings';
+import { DEFAULT_BRUSH_JITTER_SETTINGS } from '../tools/brush/brush-jitter-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  brushJitter: BrushJitterSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  brushJitter: DEFAULT_BRUSH_JITTER_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -18,6 +18,8 @@ import type { StampSettings } from '../tools/stamp/stamp-settings';
 import { DEFAULT_STAMP_SETTINGS } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
 import { DEFAULT_MAGNETIC_LASSO_SETTINGS } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { QuickSelectSettings } from '../tools/quick-select/quick-select-settings';
+import { DEFAULT_QUICK_SELECT_SETTINGS } from '../tools/quick-select/quick-select-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -39,6 +41,7 @@ export interface ToolSettingsSlices {
   path: PathSettings;
   stamp: StampSettings;
   magneticLasso: MagneticLassoSettings;
+  quickSelect: QuickSelectSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -52,4 +55,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   path: DEFAULT_PATH_SETTINGS,
   stamp: DEFAULT_STAMP_SETTINGS,
   magneticLasso: DEFAULT_MAGNETIC_LASSO_SETTINGS,
+  quickSelect: DEFAULT_QUICK_SELECT_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { ShapeSettings } from '../tools/shape/shape-settings';
+import { DEFAULT_SHAPE_SETTINGS } from '../tools/shape/shape-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  shape: ShapeSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  shape: DEFAULT_SHAPE_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { GradientSettings } from '../tools/gradient/gradient-settings';
+import { DEFAULT_GRADIENT_SETTINGS } from '../tools/gradient/gradient-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  gradient: GradientSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  gradient: DEFAULT_GRADIENT_SETTINGS,
 };

--- a/src/app/tool-settings-slices.ts
+++ b/src/app/tool-settings-slices.ts
@@ -24,6 +24,8 @@ import type { SpraySettings } from '../tools/spray/spray-settings';
 import { DEFAULT_SPRAY_SETTINGS } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
 import { DEFAULT_HEALING_SETTINGS } from '../tools/healing/healing-settings';
+import type { BrushSpeedSettings } from '../tools/brush/brush-speed-settings';
+import { DEFAULT_BRUSH_SPEED_SETTINGS } from '../tools/brush/brush-speed-settings';
 
 /**
  * Per-tool settings slices owned by the global ToolSettings store.
@@ -48,6 +50,7 @@ export interface ToolSettingsSlices {
   text: TextSettings;
   spray: SpraySettings;
   healing: HealingSettings;
+  brushSpeed: BrushSpeedSettings;
 }
 
 export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
@@ -64,4 +67,5 @@ export const DEFAULT_TOOL_SETTINGS_SLICES: ToolSettingsSlices = {
   text: DEFAULT_TEXT_SETTINGS,
   spray: DEFAULT_SPRAY_SETTINGS,
   healing: DEFAULT_HEALING_SETTINGS,
+  brushSpeed: DEFAULT_BRUSH_SPEED_SETTINGS,
 };

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,82 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: brushJitter (#453)', () => {
+  it('exposes brush-jitter settings under settings.brushJitter with the legacy defaults', () => {
+    // Reset to defaults — earlier tests in this file may have mutated
+    // the slice through setBrushJitterSetting.
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('hardness', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('angle', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('opacity', 0);
+    const { brushJitter } = useToolSettingsStore.getState().settings;
+    expect(brushJitter).toEqual({ size: 0, hardness: 0, angle: 0, opacity: 0 });
+  });
+
+  it('setBrushJitterSetting updates one field without disturbing the others', () => {
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('hardness', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('angle', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('opacity', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 40);
+    const after = useToolSettingsStore.getState().settings.brushJitter;
+    expect(after).toEqual({ size: 40, hardness: 0, angle: 0, opacity: 0 });
+  });
+
+  it('setBrushJitterSetting clamps every field into [0, 100]', () => {
+    for (const key of ['size', 'hardness', 'angle', 'opacity'] as const) {
+      useToolSettingsStore.getState().setBrushJitterSetting(key, -10);
+      expect(useToolSettingsStore.getState().settings.brushJitter[key]).toBe(0);
+      useToolSettingsStore.getState().setBrushJitterSetting(key, 9999);
+      expect(useToolSettingsStore.getState().settings.brushJitter[key]).toBe(100);
+    }
+  });
+
+  it('setBrushJitterSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setBrushJitterSetting('angle', 25);
+    expect(useToolSettingsStore.getState().settings.brushJitter.angle).toBe(25);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+
+  it('saveCurrentAsPreset captures the current brushJitter values', () => {
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 17);
+    useToolSettingsStore.getState().setBrushJitterSetting('hardness', 23);
+    useToolSettingsStore.getState().setBrushJitterSetting('angle', 31);
+    useToolSettingsStore.getState().setBrushJitterSetting('opacity', 43);
+    useToolSettingsStore.getState().saveCurrentAsPreset('jitter-roundtrip');
+    const saved = useToolSettingsStore
+      .getState()
+      .presets.find((p) => p.name === 'jitter-roundtrip');
+    expect(saved).toBeDefined();
+    expect(saved?.sizeJitter).toBe(17);
+    expect(saved?.hardnessJitter).toBe(23);
+    expect(saved?.angleJitter).toBe(31);
+    expect(saved?.opacityJitter).toBe(43);
+  });
+
+  it('setActivePreset restores brushJitter from the preset', () => {
+    // Save under known-jitter, then drift the slice, then setActivePreset
+    // and assert the slice came back. Exercises both the save path
+    // (legacy flat preset fields) and the restore path (writes into the
+    // new settings.brushJitter slice).
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 11);
+    useToolSettingsStore.getState().setBrushJitterSetting('hardness', 22);
+    useToolSettingsStore.getState().setBrushJitterSetting('angle', 33);
+    useToolSettingsStore.getState().setBrushJitterSetting('opacity', 44);
+    useToolSettingsStore.getState().saveCurrentAsPreset('jitter-restore');
+    const presetId = useToolSettingsStore
+      .getState()
+      .presets.find((p) => p.name === 'jitter-restore')!.id;
+    useToolSettingsStore.getState().setBrushJitterSetting('size', 0);
+    useToolSettingsStore.getState().setBrushJitterSetting('opacity', 0);
+    useToolSettingsStore.getState().setActivePreset(presetId);
+    const restored = useToolSettingsStore.getState().settings.brushJitter;
+    expect(restored).toEqual({ size: 11, hardness: 22, angle: 33, opacity: 44 });
+  });
+});

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -2,34 +2,36 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useToolSettingsStore } from './tool-settings-store';
 
-describe('setShapeMode — issue #236 (invalid modes render incorrectly)', () => {
+describe('setShapeSetting mode — issue #236 (invalid modes render incorrectly)', () => {
   it('accepts ellipse', () => {
-    useToolSettingsStore.getState().setShapeMode('ellipse');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+    useToolSettingsStore.getState().setShapeSetting('mode', 'ellipse');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 
   it('accepts polygon', () => {
-    useToolSettingsStore.getState().setShapeMode('polygon');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+    useToolSettingsStore.getState().setShapeSetting('mode', 'polygon');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('polygon');
   });
 
-  it('ignores invalid values like "rectangle" instead of silently storing them', () => {
-    useToolSettingsStore.getState().setShapeMode('ellipse');
+  it('collapses invalid values like "rectangle" to ellipse instead of silently storing them', () => {
+    useToolSettingsStore.getState().setShapeSetting('mode', 'polygon');
     // The setter is typed as ShapeMode but JS callers (and TS @ts-ignore
-    // bypasses) can pass anything. The store must reject invalid values
-    // so the GPU dispatch doesn't render a polygon with stale `sides`
-    // when a caller asked for "rectangle".
-    (useToolSettingsStore.getState().setShapeMode as (m: string) => void)('rectangle');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('ellipse');
+    // bypasses) can pass anything. The slice must collapse invalid values
+    // to the documented default ('ellipse') so the GPU dispatch doesn't
+    // render a polygon with stale `sides` when a caller asked for
+    // "rectangle" — same guard as the quick-select slice.
+    (useToolSettingsStore.getState().setShapeSetting as (k: 'mode', m: string) => void)('mode', 'rectangle');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 
-  it('ignores other invalid values (line, arrow, star)', () => {
-    useToolSettingsStore.getState().setShapeMode('polygon');
-    const setter = useToolSettingsStore.getState().setShapeMode as (m: string) => void;
-    setter('line');
-    setter('arrow');
-    setter('star');
-    expect(useToolSettingsStore.getState().shapeMode).toBe('polygon');
+  it('collapses other invalid values (line, arrow, star) to ellipse', () => {
+    const setter = useToolSettingsStore.getState().setShapeSetting as (k: 'mode', m: string) => void;
+    setter('mode', 'line');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
+    setter('mode', 'arrow');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
+    setter('mode', 'star');
+    expect(useToolSettingsStore.getState().settings.shape.mode).toBe('ellipse');
   });
 });
 
@@ -860,6 +862,123 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
     expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
     expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: shape (#453)', () => {
+  // Reset to the legacy defaults at the top of each test — prior tests
+  // in this file (including the #236 mode guard suite at the top) and
+  // sibling cases inside this block may have mutated the slice.
+  beforeEach(() => {
+    const set = useToolSettingsStore.getState().setShapeSetting;
+    set('mode', 'ellipse');
+    set('output', 'pixels');
+    set('fillColor', { r: 255, g: 255, b: 255, a: 1 });
+    set('strokeColor', null);
+    set('strokeWidth', 2);
+    set('polygonSides', 6);
+    set('cornerRadius', 0);
+  });
+
+  it('exposes shape settings under settings.shape with the legacy defaults', () => {
+    const { shape } = useToolSettingsStore.getState().settings;
+    expect(shape).toEqual({
+      mode: 'ellipse',
+      output: 'pixels',
+      fillColor: { r: 255, g: 255, b: 255, a: 1 },
+      strokeColor: null,
+      strokeWidth: 2,
+      polygonSides: 6,
+      cornerRadius: 0,
+    });
+  });
+
+  it('setShapeSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.shape;
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 7);
+    const after = useToolSettingsStore.getState().settings.shape;
+    expect(after.strokeWidth).toBe(7);
+    expect(after.mode).toBe(before.mode);
+    expect(after.output).toBe(before.output);
+    expect(after.fillColor).toBe(before.fillColor);
+    expect(after.strokeColor).toBe(before.strokeColor);
+    expect(after.polygonSides).toBe(before.polygonSides);
+    expect(after.cornerRadius).toBe(before.cornerRadius);
+  });
+
+  it('setShapeSetting clamps strokeWidth into [1, 50]', () => {
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 0);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(1);
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(50);
+  });
+
+  it('setShapeSetting rounds and clamps polygonSides into [3, 64]', () => {
+    // Sides must be an integer — fractional sides render as the floor
+    // count with weird seams. Legacy setShapePolygonSides rounded.
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 2);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(3);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(64);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 6.4);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(6);
+    useToolSettingsStore.getState().setShapeSetting('polygonSides', 6.6);
+    expect(useToolSettingsStore.getState().settings.shape.polygonSides).toBe(7);
+  });
+
+  it('setShapeSetting clamps cornerRadius into [0, 200]', () => {
+    useToolSettingsStore.getState().setShapeSetting('cornerRadius', -10);
+    expect(useToolSettingsStore.getState().settings.shape.cornerRadius).toBe(0);
+    useToolSettingsStore.getState().setShapeSetting('cornerRadius', 9999);
+    expect(useToolSettingsStore.getState().settings.shape.cornerRadius).toBe(200);
+  });
+
+  it('setShapeSetting passes nullable colors through, including null', () => {
+    useToolSettingsStore.getState().setShapeSetting('fillColor', null);
+    expect(useToolSettingsStore.getState().settings.shape.fillColor).toBeNull();
+    const red = { r: 200, g: 30, b: 40, a: 0.5 };
+    useToolSettingsStore.getState().setShapeSetting('strokeColor', red);
+    expect(useToolSettingsStore.getState().settings.shape.strokeColor).toEqual(red);
+  });
+
+  it('setShapeSetting collapses invalid output to "pixels" (mirrors mode guard)', () => {
+    useToolSettingsStore.getState().setShapeSetting('output', 'path');
+    expect(useToolSettingsStore.getState().settings.shape.output).toBe('path');
+    (useToolSettingsStore.getState().setShapeSetting as (k: 'output', v: string) => void)('output', 'vector');
+    expect(useToolSettingsStore.getState().settings.shape.output).toBe('pixels');
+  });
+
+  it('setShapeSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setShapeSetting('strokeWidth', 42);
+    expect(useToolSettingsStore.getState().settings.shape.strokeWidth).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,70 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: crop (#453)', () => {
+  it('exposes crop settings under settings.crop with the legacy default', () => {
+    // Reset to the legacy default — prior tests in this file may have
+    // mutated the slice through setCropSetting.
+    useToolSettingsStore.getState().setCropSetting('mode', 'normal');
+    const { crop } = useToolSettingsStore.getState().settings;
+    expect(crop).toEqual({ mode: 'normal' });
+  });
+
+  it('setCropSetting toggles mode between normal and perspective', () => {
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('perspective');
+    useToolSettingsStore.getState().setCropSetting('mode', 'normal');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+  });
+
+  it('setCropSetting rejects unknown mode values and falls back to "normal"', () => {
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    // The setter is typed as CropSettings['mode'] but JS callers (and
+    // any `as` cast in TS) can pass anything. The store must reject
+    // unknown values so the crop dispatcher doesn't read a state that
+    // neither the rect nor the perspective handler will service —
+    // mirrors the setShapeMode reject-and-reset behaviour from #236.
+    const setter = useToolSettingsStore.getState().setCropSetting as (
+      key: 'mode',
+      value: string,
+    ) => void;
+    setter('mode', 'rect');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+    setter('mode', 'free');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('normal');
+  });
+
+  it('setCropSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setCropSetting('mode', 'perspective');
+    expect(useToolSettingsStore.getState().settings.crop.mode).toBe('perspective');
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,136 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: gradient (#453)', () => {
+  beforeEach(() => {
+    // Reset to the legacy defaults — prior tests in this file (and the
+    // module-state persisted across tests) may have mutated the slice.
+    useToolSettingsStore.getState().setGradientSetting('type', 'linear');
+    useToolSettingsStore.getState().setGradientSetting('reverse', false);
+    useToolSettingsStore.getState().setGradientSetting('stops', [
+      { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+      { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+    ]);
+  });
+
+  it('exposes gradient settings under settings.gradient with the legacy defaults', () => {
+    const { gradient } = useToolSettingsStore.getState().settings;
+    expect(gradient.type).toBe('linear');
+    expect(gradient.reverse).toBe(false);
+    expect(gradient.stops.length).toBe(2);
+    expect(gradient.stops[0]).toEqual({ position: 0, color: { r: 0, g: 0, b: 0, a: 1 } });
+    expect(gradient.stops[1]).toEqual({ position: 1, color: { r: 255, g: 255, b: 255, a: 1 } });
+  });
+
+  it('setGradientSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.gradient;
+    useToolSettingsStore.getState().setGradientSetting('reverse', true);
+    const after = useToolSettingsStore.getState().settings.gradient;
+    expect(after.reverse).toBe(true);
+    expect(after.type).toBe(before.type);
+    expect(after.stops).toBe(before.stops);
+  });
+
+  it('setGradientSetting collapses unknown type strings to linear', () => {
+    // The legacy setGradientType accepted anything typed as the union;
+    // the slice tightens that to the documented default so a typed-string
+    // @ts-ignore bypass can't leave the GPU dispatch staring at a stale
+    // enum. Same shape as the shape slice (#623).
+    useToolSettingsStore.getState().setGradientSetting('type', 'radial');
+    expect(useToolSettingsStore.getState().settings.gradient.type).toBe('radial');
+    (useToolSettingsStore.getState().setGradientSetting as (k: string, v: unknown) => void)('type', 'conic');
+    expect(useToolSettingsStore.getState().settings.gradient.type).toBe('linear');
+  });
+
+  it('setGradientSetting clamps stops list above the max (the GPU dispatch uniform cap)', () => {
+    const tooMany = Array.from({ length: 25 }, (_, i) => ({
+      position: i / 24,
+      color: { r: i * 10, g: 0, b: 0, a: 1 },
+    }));
+    useToolSettingsStore.getState().setGradientSetting('stops', tooMany);
+    expect(useToolSettingsStore.getState().settings.gradient.stops.length).toBe(16);
+  });
+
+  it('setGradientSetting pads stops list below the min so the gradient shaders always have ≥2 stops', () => {
+    useToolSettingsStore.getState().setGradientSetting('stops', [
+      { position: 0.5, color: { r: 128, g: 128, b: 128, a: 1 } },
+    ]);
+    expect(useToolSettingsStore.getState().settings.gradient.stops.length).toBe(2);
+  });
+
+  it('setGradientSetting clamps per-stop position into [0, 1] and sorts', () => {
+    useToolSettingsStore.getState().setGradientSetting('stops', [
+      { position: 1.5, color: { r: 255, g: 0, b: 0, a: 1 } },
+      { position: -0.5, color: { r: 0, g: 0, b: 255, a: 1 } },
+    ]);
+    const sorted = useToolSettingsStore.getState().settings.gradient.stops;
+    expect(sorted.map((s) => s.position)).toEqual([0, 1]);
+  });
+
+  it('addGradientStop inserts and re-sorts via settings.gradient.stops', () => {
+    useToolSettingsStore.getState().addGradientStop(0.5, { r: 128, g: 128, b: 128, a: 1 });
+    const stops = useToolSettingsStore.getState().settings.gradient.stops;
+    expect(stops.length).toBe(3);
+    expect(stops.map((s) => s.position)).toEqual([0, 0.5, 1]);
+  });
+
+  it('addGradientStop is rejected at the max', () => {
+    const max = Array.from({ length: 16 }, (_, i) => ({
+      position: i / 15,
+      color: { r: i, g: 0, b: 0, a: 1 },
+    }));
+    useToolSettingsStore.getState().setGradientSetting('stops', max);
+    useToolSettingsStore.getState().addGradientStop(0.5, { r: 0, g: 255, b: 0, a: 1 });
+    expect(useToolSettingsStore.getState().settings.gradient.stops.length).toBe(16);
+  });
+
+  it('removeGradientStop refuses to drop the list below the min', () => {
+    useToolSettingsStore.getState().removeGradientStop(0);
+    expect(useToolSettingsStore.getState().settings.gradient.stops.length).toBe(2);
+  });
+
+  it('updateGradientStop patches a single stop and re-sorts the list', () => {
+    useToolSettingsStore.getState().setGradientSetting('stops', [
+      { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+      { position: 0.5, color: { r: 128, g: 128, b: 128, a: 1 } },
+      { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+    ]);
+    useToolSettingsStore.getState().updateGradientStop(1, { position: 0.9 });
+    const stops = useToolSettingsStore.getState().settings.gradient.stops;
+    expect(stops.map((s) => s.position)).toEqual([0, 0.9, 1]);
+  });
+
+  it('setGradientSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setGradientSetting('reverse', true);
+    expect(useToolSettingsStore.getState().settings.gradient.reverse).toBe(true);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -863,3 +863,102 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: brushSpeed (#453)', () => {
+  // First sub-slice carved out of the flat `brushSpeed*` brush fields.
+  // Same shape as the per-tool slices above: read via
+  // `settings.brushSpeed.<field>`, write via `setBrushSpeedSetting`.
+  // The remaining brush sub-slices (jitter, texture, tip/presets/
+  // sub-brushes) still live flat on the store and land in follow-up
+  // PRs.
+  it('exposes brushSpeed settings under settings.brushSpeed with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setBrushSpeedSetting or setActivePreset.
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 0);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sizeInvert', false);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'med');
+    const { brushSpeed } = useToolSettingsStore.getState().settings;
+    expect(brushSpeed).toEqual({ size: 0, sizeInvert: false, sensitivity: 'med' });
+  });
+
+  it('setBrushSpeedSetting updates one field without disturbing the others', () => {
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 50);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sizeInvert', true);
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    const before = useToolSettingsStore.getState().settings.brushSpeed;
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 120);
+    const after = useToolSettingsStore.getState().settings.brushSpeed;
+    expect(after.size).toBe(120);
+    expect(after.sizeInvert).toBe(before.sizeInvert);
+    expect(after.sensitivity).toBe(before.sensitivity);
+  });
+
+  it('setBrushSpeedSetting clamps size into [0, 300]', () => {
+    // The UI surfaces 0–100 with sizeInvert=false and 0–300 with
+    // sizeInvert=true. The store-level clamp is the looser bound so
+    // flipping the invert toggle never truncates the slider value.
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', -10);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(0);
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 9999);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(300);
+  });
+
+  it('setBrushSpeedSetting accepts the three documented sensitivity values', () => {
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'low');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('low');
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'med');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('high');
+  });
+
+  it('setBrushSpeedSetting collapses unknown sensitivity strings to "med"', () => {
+    // brush-stroke.ts maps sensitivity to a moving-average window
+    // (low → 6, med → 3, high → 2). An unrecognised enum would leave
+    // the ternary on the `med` branch silently, so the slice collapses
+    // unknown strings to 'med' explicitly — same enum-guard policy as
+    // shape/quickSelect/gradient.
+    useToolSettingsStore.getState().setBrushSpeedSetting('sensitivity', 'high');
+    const setter = useToolSettingsStore.getState().setBrushSpeedSetting as (
+      key: 'sensitivity',
+      value: string,
+    ) => void;
+    setter('sensitivity', 'medium');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+    setter('sensitivity', 'turbo');
+    expect(useToolSettingsStore.getState().settings.brushSpeed.sensitivity).toBe('med');
+  });
+
+  it('setBrushSpeedSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setBrushSpeedSetting('size', 42);
+    expect(useToolSettingsStore.getState().settings.brushSpeed.size).toBe(42);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -593,3 +593,101 @@ describe('per-tool slice: eraser (#453)', () => {
     expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
   });
 });
+
+describe('per-tool slice: quickSelect (#453)', () => {
+  it('exposes quickSelect settings under settings.quickSelect with the legacy defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setQuickSelectSetting.
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 20);
+    useToolSettingsStore.getState().setQuickSelectSetting('tolerance', 32);
+    useToolSettingsStore.getState().setQuickSelectSetting('edgeStrength', 50);
+    useToolSettingsStore.getState().setQuickSelectSetting('mode', 'add');
+    const { quickSelect } = useToolSettingsStore.getState().settings;
+    expect(quickSelect).toEqual({ size: 20, tolerance: 32, edgeStrength: 50, mode: 'add' });
+  });
+
+  it('setQuickSelectSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.quickSelect;
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 40);
+    const after = useToolSettingsStore.getState().settings.quickSelect;
+    expect(after.size).toBe(40);
+    expect(after.tolerance).toBe(before.tolerance);
+    expect(after.edgeStrength).toBe(before.edgeStrength);
+    expect(after.mode).toBe(before.mode);
+  });
+
+  it('setQuickSelectSetting clamps size into [1, 100] and rounds', () => {
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.quickSelect.size).toBe(1);
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 999);
+    expect(useToolSettingsStore.getState().settings.quickSelect.size).toBe(100);
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 12.4);
+    expect(useToolSettingsStore.getState().settings.quickSelect.size).toBe(12);
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 12.6);
+    expect(useToolSettingsStore.getState().settings.quickSelect.size).toBe(13);
+  });
+
+  it('setQuickSelectSetting clamps tolerance into [0, 255] and rounds', () => {
+    // Tolerance lives in the same units as RGBA channels because the
+    // stroke compares pixel deltas against it directly — preserve the
+    // 0–255 byte range exactly, not a percent 0–100.
+    useToolSettingsStore.getState().setQuickSelectSetting('tolerance', -10);
+    expect(useToolSettingsStore.getState().settings.quickSelect.tolerance).toBe(0);
+    useToolSettingsStore.getState().setQuickSelectSetting('tolerance', 999);
+    expect(useToolSettingsStore.getState().settings.quickSelect.tolerance).toBe(255);
+    useToolSettingsStore.getState().setQuickSelectSetting('tolerance', 60.6);
+    expect(useToolSettingsStore.getState().settings.quickSelect.tolerance).toBe(61);
+  });
+
+  it('setQuickSelectSetting clamps edgeStrength into [0, 100] and rounds', () => {
+    useToolSettingsStore.getState().setQuickSelectSetting('edgeStrength', -10);
+    expect(useToolSettingsStore.getState().settings.quickSelect.edgeStrength).toBe(0);
+    useToolSettingsStore.getState().setQuickSelectSetting('edgeStrength', 999);
+    expect(useToolSettingsStore.getState().settings.quickSelect.edgeStrength).toBe(100);
+    useToolSettingsStore.getState().setQuickSelectSetting('edgeStrength', 42.3);
+    expect(useToolSettingsStore.getState().settings.quickSelect.edgeStrength).toBe(42);
+  });
+
+  it('setQuickSelectSetting normalises mode to a known tag', () => {
+    useToolSettingsStore.getState().setQuickSelectSetting('mode', 'subtract');
+    expect(useToolSettingsStore.getState().settings.quickSelect.mode).toBe('subtract');
+    useToolSettingsStore.getState().setQuickSelectSetting('mode', 'add');
+    expect(useToolSettingsStore.getState().settings.quickSelect.mode).toBe('add');
+    // Unknown strings collapse to 'add' rather than silently passing
+    // through — guards against a typed-string @ts-ignore bypass leaving
+    // the selection in an unhandled state.
+    (useToolSettingsStore.getState().setQuickSelectSetting as (k: 'mode', v: string) => void)('mode', 'replace');
+    expect(useToolSettingsStore.getState().settings.quickSelect.mode).toBe('add');
+  });
+
+  it('setQuickSelectSetting preserves sibling slices and unrelated fields', () => {
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    useToolSettingsStore.getState().setQuickSelectSetting('size', 55);
+    expect(useToolSettingsStore.getState().settings.quickSelect.size).toBe(55);
+    // Sibling slice references preserved — selectors subscribed to the
+    // other slices should not re-render when quickSelect changes. This
+    // is the invariant that justifies slicing instead of fattening the
+    // flat bag further.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+  });
+});

--- a/src/app/tool-settings-store.test.ts
+++ b/src/app/tool-settings-store.test.ts
@@ -49,46 +49,46 @@ describe('opacity setters — issue #250 (percent vs normalised footgun)', () =>
 
   it('clamps brush opacity to the documented 1–100 percent range', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setBrushOpacity(50);
-    expect(store.getState().brushOpacity).toBe(50);
-    store.getState().setBrushOpacity(200);
-    expect(store.getState().brushOpacity).toBe(100);
-    store.getState().setBrushOpacity(-5);
-    expect(store.getState().brushOpacity).toBe(1);
+    store.getState().setBrushSetting('opacity', 50);
+    expect(store.getState().settings.brush.opacity).toBe(50);
+    store.getState().setBrushSetting('opacity', 200);
+    expect(store.getState().settings.brush.opacity).toBe(100);
+    store.getState().setBrushSetting('opacity', -5);
+    expect(store.getState().settings.brush.opacity).toBe(1);
   });
 
-  it('warns when setBrushOpacity receives a fractional value (likely 0–1 normalised)', async () => {
+  it('warns when setBrushSetting(opacity) receives a fractional value (likely 0–1 normalised)', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setBrushOpacity(0.5);
+    store.getState().setBrushSetting('opacity', 0.5);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
-    expect(message).toContain('setBrushOpacity');
+    expect(message).toContain('setBrushSetting(opacity)');
     expect(message).toContain('percent');
     expect(message).toContain('50');
     // The value still gets clamped into the percent range (no silent
     // 1%-stroke), so callers don't get the original footgun.
-    expect(store.getState().brushOpacity).toBe(1);
+    expect(store.getState().settings.brush.opacity).toBe(1);
   });
 
   it('does not warn for the integer sentinel 0', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setBrushOpacity(0);
+    store.getState().setBrushSetting('opacity', 0);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('does not warn for legitimate percent values, including 1', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setBrushOpacity(1);
-    store.getState().setBrushOpacity(50);
-    store.getState().setBrushOpacity(100);
+    store.getState().setBrushSetting('opacity', 1);
+    store.getState().setBrushSetting('opacity', 50);
+    store.getState().setBrushSetting('opacity', 100);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('warns at most once per setter even with repeated bad calls', async () => {
     const { useToolSettingsStore: store } = await import('./tool-settings-store');
-    store.getState().setBrushOpacity(0.5);
-    store.getState().setBrushOpacity(0.2);
-    store.getState().setBrushOpacity(0.99);
+    store.getState().setBrushSetting('opacity', 0.5);
+    store.getState().setBrushSetting('opacity', 0.2);
+    store.getState().setBrushSetting('opacity', 0.99);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -146,10 +146,10 @@ describe('per-tool slice: wand (#453)', () => {
     // The settings.wand object must be replaced (so React/Zustand
     // selectors that subscribe to it re-render) but the surrounding
     // ToolSettings shape should not churn unrelated fields.
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setWandSetting('contiguous', false);
     expect(useToolSettingsStore.getState().settings.wand.contiguous).toBe(false);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -176,13 +176,13 @@ describe('per-tool slice: fill (#453)', () => {
 
   it('setFillSetting preserves sibling slices and unrelated fields', () => {
     const beforeWand = useToolSettingsStore.getState().settings.wand;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setFillSetting('contiguous', false);
     expect(useToolSettingsStore.getState().settings.fill.contiguous).toBe(false);
     // Sibling slice reference preserved — selectors subscribed to
     // settings.wand should not re-render when fill changes.
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -216,7 +216,7 @@ describe('per-tool slice: marquee (#453)', () => {
   it('setMarqueeSetting preserves sibling slices and unrelated fields', () => {
     const beforeWand = useToolSettingsStore.getState().settings.wand;
     const beforeFill = useToolSettingsStore.getState().settings.fill;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setMarqueeSetting('feather', 50);
     expect(useToolSettingsStore.getState().settings.marquee.feather).toBe(50);
     // Sibling slice references preserved — selectors subscribed to
@@ -224,7 +224,7 @@ describe('per-tool slice: marquee (#453)', () => {
     // changes. This is the invariant that justifies slicing.
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
     expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -264,7 +264,7 @@ describe('per-tool slice: smudge (#453)', () => {
     const beforeWand = useToolSettingsStore.getState().settings.wand;
     const beforeFill = useToolSettingsStore.getState().settings.fill;
     const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setSmudgeSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.smudge.size).toBe(42);
     // Sibling slice references preserved — selectors subscribed to the
@@ -274,7 +274,7 @@ describe('per-tool slice: smudge (#453)', () => {
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
     expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
     expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -301,7 +301,7 @@ describe('per-tool slice: pencil (#453)', () => {
     const beforeFill = useToolSettingsStore.getState().settings.fill;
     const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
     const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setPencilSetting('size', 7);
     expect(useToolSettingsStore.getState().settings.pencil.size).toBe(7);
     // Sibling slice references preserved — selectors subscribed to the
@@ -312,7 +312,7 @@ describe('per-tool slice: pencil (#453)', () => {
     expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
     expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -364,7 +364,7 @@ describe('per-tool slice: sponge (#453)', () => {
     const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
     const beforePencil = useToolSettingsStore.getState().settings.pencil;
     const beforeEraser = useToolSettingsStore.getState().settings.eraser;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setSpongeSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.sponge.size).toBe(42);
     // Sibling slice references preserved — selectors subscribed to the
@@ -377,7 +377,7 @@ describe('per-tool slice: sponge (#453)', () => {
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
     expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -406,7 +406,7 @@ describe('per-tool slice: path (#453)', () => {
     const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
     const beforePencil = useToolSettingsStore.getState().settings.pencil;
     const beforeSponge = useToolSettingsStore.getState().settings.sponge;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setPathSetting('strokeWidth', 7);
     expect(useToolSettingsStore.getState().settings.path.strokeWidth).toBe(7);
     // Sibling slice references preserved — selectors subscribed to the
@@ -419,7 +419,7 @@ describe('per-tool slice: path (#453)', () => {
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
     expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
     expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -450,7 +450,7 @@ describe('per-tool slice: stamp (#453)', () => {
     const beforeSponge = useToolSettingsStore.getState().settings.sponge;
     const beforePath = useToolSettingsStore.getState().settings.path;
     const beforeEraser = useToolSettingsStore.getState().settings.eraser;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setStampSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.stamp.size).toBe(42);
     // Sibling slice references preserved — selectors subscribed to the
@@ -465,7 +465,7 @@ describe('per-tool slice: stamp (#453)', () => {
     expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
     expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -531,7 +531,7 @@ describe('per-tool slice: magneticLasso (#453)', () => {
     const beforePath = useToolSettingsStore.getState().settings.path;
     const beforeStamp = useToolSettingsStore.getState().settings.stamp;
     const beforeEraser = useToolSettingsStore.getState().settings.eraser;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setMagneticLassoSetting('width', 25);
     expect(useToolSettingsStore.getState().settings.magneticLasso.width).toBe(25);
     // Sibling slice references preserved — selectors subscribed to the
@@ -547,7 +547,7 @@ describe('per-tool slice: magneticLasso (#453)', () => {
     expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
     expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -594,7 +594,7 @@ describe('per-tool slice: eraser (#453)', () => {
     const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
     const beforePencil = useToolSettingsStore.getState().settings.pencil;
     const beforeSponge = useToolSettingsStore.getState().settings.sponge;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setEraserSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.eraser.size).toBe(42);
     // Sibling slice references preserved — selectors subscribed to the
@@ -607,7 +607,7 @@ describe('per-tool slice: eraser (#453)', () => {
     expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
     expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
     expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -694,7 +694,7 @@ describe('per-tool slice: text (#453)', () => {
     const beforeStamp = useToolSettingsStore.getState().settings.stamp;
     const beforeEraser = useToolSettingsStore.getState().settings.eraser;
     const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setTextSetting('fontSize', 48);
     expect(useToolSettingsStore.getState().settings.text.fontSize).toBe(48);
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
@@ -707,7 +707,7 @@ describe('per-tool slice: text (#453)', () => {
     expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -779,7 +779,7 @@ describe('per-tool slice: spray (#453)', () => {
     const beforeStamp = useToolSettingsStore.getState().settings.stamp;
     const beforeEraser = useToolSettingsStore.getState().settings.eraser;
     const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setSpraySetting('size', 42);
     expect(useToolSettingsStore.getState().settings.spray.size).toBe(42);
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
@@ -792,7 +792,7 @@ describe('per-tool slice: spray (#453)', () => {
     expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
     expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
   });
 });
 
@@ -845,7 +845,7 @@ describe('per-tool slice: healing (#453)', () => {
     const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
     const beforeText = useToolSettingsStore.getState().settings.text;
     const beforeSpray = useToolSettingsStore.getState().settings.spray;
-    const beforeBrushSize = useToolSettingsStore.getState().brushSize;
+    const beforeBrushSize = useToolSettingsStore.getState().settings.brush.size;
     useToolSettingsStore.getState().setHealingSetting('size', 42);
     expect(useToolSettingsStore.getState().settings.healing.size).toBe(42);
     expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
@@ -860,6 +860,162 @@ describe('per-tool slice: healing (#453)', () => {
     expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
     expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
     expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
-    expect(useToolSettingsStore.getState().brushSize).toBe(beforeBrushSize);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(beforeBrushSize);
+  });
+});
+
+describe('per-tool slice: brush (#453)', () => {
+  it('exposes brush settings under settings.brush with the legacy flat-bag defaults', () => {
+    // Reset to the legacy defaults — prior tests in this file may have
+    // mutated the slice through setBrushSetting.
+    useToolSettingsStore.getState().setBrushSetting('size', 10);
+    useToolSettingsStore.getState().setBrushSetting('opacity', 100);
+    useToolSettingsStore.getState().setBrushSetting('hardness', 80);
+    useToolSettingsStore.getState().setBrushSetting('spacing', 0);
+    useToolSettingsStore.getState().setBrushSetting('scatter', 0);
+    useToolSettingsStore.getState().setBrushSetting('angle', 0);
+    useToolSettingsStore.getState().setBrushSetting('fade', 0);
+    useToolSettingsStore.getState().setBrushSetting('taper', 0);
+    const { brush } = useToolSettingsStore.getState().settings;
+    expect(brush).toEqual({
+      size: 10,
+      opacity: 100,
+      hardness: 80,
+      spacing: 0,
+      scatter: 0,
+      angle: 0,
+      fade: 0,
+      taper: 0,
+    });
+  });
+
+  it('setBrushSetting updates one field without disturbing the others', () => {
+    const before = useToolSettingsStore.getState().settings.brush;
+    useToolSettingsStore.getState().setBrushSetting('size', 42);
+    const after = useToolSettingsStore.getState().settings.brush;
+    expect(after.size).toBe(42);
+    expect(after.opacity).toBe(before.opacity);
+    expect(after.hardness).toBe(before.hardness);
+    expect(after.spacing).toBe(before.spacing);
+    expect(after.scatter).toBe(before.scatter);
+    expect(after.angle).toBe(before.angle);
+    expect(after.fade).toBe(before.fade);
+    expect(after.taper).toBe(before.taper);
+  });
+
+  it('setBrushSetting clamps size into [1, 5000]', () => {
+    useToolSettingsStore.getState().setBrushSetting('size', 0);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(1);
+    useToolSettingsStore.getState().setBrushSetting('size', 99999);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(5000);
+  });
+
+  it('setBrushSetting clamps hardness into [0, 100]', () => {
+    useToolSettingsStore.getState().setBrushSetting('hardness', -10);
+    expect(useToolSettingsStore.getState().settings.brush.hardness).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('hardness', 250);
+    expect(useToolSettingsStore.getState().settings.brush.hardness).toBe(100);
+  });
+
+  it('setBrushSetting clamps spacing into [0, 200]', () => {
+    useToolSettingsStore.getState().setBrushSetting('spacing', -1);
+    expect(useToolSettingsStore.getState().settings.brush.spacing).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('spacing', 9999);
+    expect(useToolSettingsStore.getState().settings.brush.spacing).toBe(200);
+  });
+
+  it('setBrushSetting clamps scatter into [0, 100]', () => {
+    useToolSettingsStore.getState().setBrushSetting('scatter', -1);
+    expect(useToolSettingsStore.getState().settings.brush.scatter).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('scatter', 9999);
+    expect(useToolSettingsStore.getState().settings.brush.scatter).toBe(100);
+  });
+
+  it('setBrushSetting wraps angle into [0, 360) modulo', () => {
+    // Replicates the legacy `setBrushAngle` shape so the shader gets a
+    // clean modulo-wrapped degree value when callers pass a delta that
+    // went negative or past 360 (e.g. via a wheel turn).
+    useToolSettingsStore.getState().setBrushSetting('angle', 720);
+    expect(useToolSettingsStore.getState().settings.brush.angle).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('angle', -90);
+    expect(useToolSettingsStore.getState().settings.brush.angle).toBe(270);
+  });
+
+  it('setBrushSetting clamps fade into [0, 5000]', () => {
+    useToolSettingsStore.getState().setBrushSetting('fade', -1);
+    expect(useToolSettingsStore.getState().settings.brush.fade).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('fade', 99999);
+    expect(useToolSettingsStore.getState().settings.brush.fade).toBe(5000);
+  });
+
+  it('setBrushSetting clamps taper into [0, 5000]', () => {
+    useToolSettingsStore.getState().setBrushSetting('taper', -1);
+    expect(useToolSettingsStore.getState().settings.brush.taper).toBe(0);
+    useToolSettingsStore.getState().setBrushSetting('taper', 99999);
+    expect(useToolSettingsStore.getState().settings.brush.taper).toBe(5000);
+  });
+
+  it('setBrushSetting preserves sibling slices', () => {
+    // The settings.brush object must be replaced (so React/Zustand
+    // selectors that subscribe to it re-render) but the surrounding
+    // ToolSettings slices should not churn. Same invariant the prior
+    // slices lock down — if a future refactor accidentally rebuilds
+    // sibling slices, this test catches it.
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforeFill = useToolSettingsStore.getState().settings.fill;
+    const beforeMarquee = useToolSettingsStore.getState().settings.marquee;
+    const beforeSmudge = useToolSettingsStore.getState().settings.smudge;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    const beforeSponge = useToolSettingsStore.getState().settings.sponge;
+    const beforePath = useToolSettingsStore.getState().settings.path;
+    const beforeStamp = useToolSettingsStore.getState().settings.stamp;
+    const beforeEraser = useToolSettingsStore.getState().settings.eraser;
+    const beforeMagneticLasso = useToolSettingsStore.getState().settings.magneticLasso;
+    const beforeText = useToolSettingsStore.getState().settings.text;
+    const beforeSpray = useToolSettingsStore.getState().settings.spray;
+    const beforeHealing = useToolSettingsStore.getState().settings.healing;
+    useToolSettingsStore.getState().setBrushSetting('scatter', 25);
+    expect(useToolSettingsStore.getState().settings.brush.scatter).toBe(25);
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.fill).toBe(beforeFill);
+    expect(useToolSettingsStore.getState().settings.marquee).toBe(beforeMarquee);
+    expect(useToolSettingsStore.getState().settings.smudge).toBe(beforeSmudge);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
+    expect(useToolSettingsStore.getState().settings.sponge).toBe(beforeSponge);
+    expect(useToolSettingsStore.getState().settings.path).toBe(beforePath);
+    expect(useToolSettingsStore.getState().settings.stamp).toBe(beforeStamp);
+    expect(useToolSettingsStore.getState().settings.eraser).toBe(beforeEraser);
+    expect(useToolSettingsStore.getState().settings.magneticLasso).toBe(beforeMagneticLasso);
+    expect(useToolSettingsStore.getState().settings.text).toBe(beforeText);
+    expect(useToolSettingsStore.getState().settings.spray).toBe(beforeSpray);
+    expect(useToolSettingsStore.getState().settings.healing).toBe(beforeHealing);
+  });
+
+  it('setActivePreset writes brush dab dynamics through the slice', () => {
+    // The preset-apply path was the largest cluster of brush flat-field
+    // writes pre-slice — eight dab fields written through a single `set()`.
+    // After the slice it routes through `settings.brush` so the slice
+    // object identity changes (selectors fire) but sibling slices stay
+    // referentially identical.
+    const beforeWand = useToolSettingsStore.getState().settings.wand;
+    const beforePencil = useToolSettingsStore.getState().settings.pencil;
+    // Save a preset capturing the current brush state, then mutate the
+    // slice, then re-apply the preset — the slice should snap back to
+    // the captured values.
+    useToolSettingsStore.getState().setBrushSetting('size', 22);
+    useToolSettingsStore.getState().setBrushSetting('hardness', 55);
+    useToolSettingsStore.getState().setBrushSetting('spacing', 18);
+    useToolSettingsStore.getState().saveCurrentAsPreset('slice-test-preset');
+    const presets = useToolSettingsStore.getState().presets;
+    const savedPreset = presets[presets.length - 1]!;
+    useToolSettingsStore.getState().setBrushSetting('size', 999);
+    useToolSettingsStore.getState().setBrushSetting('hardness', 5);
+    useToolSettingsStore.getState().setActivePreset(savedPreset.id);
+    expect(useToolSettingsStore.getState().settings.brush.size).toBe(22);
+    expect(useToolSettingsStore.getState().settings.brush.hardness).toBe(55);
+    expect(useToolSettingsStore.getState().settings.brush.spacing).toBe(18);
+    // Sibling slices untouched by the preset-apply path.
+    expect(useToolSettingsStore.getState().settings.wand).toBe(beforeWand);
+    expect(useToolSettingsStore.getState().settings.pencil).toBe(beforePencil);
   });
 });

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampShapeSetting } from '../tools/shape/shape-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -45,13 +46,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushSize: 10,
   brushOpacity: 100,
   brushHardness: 80,
-  shapeMode: 'ellipse',
-  shapeOutput: 'pixels' as const,
-  shapeFillColor: { r: 255, g: 255, b: 255, a: 1 },
-  shapeStrokeColor: null,
-  shapeStrokeWidth: 2,
-  shapePolygonSides: 6,
-  shapeCornerRadius: 0,
   aspectRatioW: 1,
   aspectRatioH: 1,
   aspectRatioLocked: false,
@@ -182,20 +176,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       fill: { ...s.settings.fill, [key]: clampFillSetting(key, value) },
     },
   })),
-  setShapeMode: (mode) => {
-    // Guard against invalid values (e.g. 'rectangle', 'line') sneaking in
-    // via store bypass. The shader treats anything-not-ellipse as polygon
-    // and would render a polygon with whatever sides setting is current,
-    // which doesn't match what a caller passing 'rectangle' expects.
-    if (mode !== 'ellipse' && mode !== 'polygon') return;
-    set({ shapeMode: mode });
-  },
-  setShapeOutput: (output) => set({ shapeOutput: output }),
-  setShapeFillColor: (color) => set({ shapeFillColor: color }),
-  setShapeStrokeColor: (color) => set({ shapeStrokeColor: color }),
-  setShapeStrokeWidth: (width) => set({ shapeStrokeWidth: Math.max(1, Math.min(50, width)) }),
-  setShapePolygonSides: (sides) => set({ shapePolygonSides: Math.max(3, Math.min(64, Math.round(sides))) }),
-  setShapeCornerRadius: (radius) => set({ shapeCornerRadius: Math.max(0, Math.min(200, radius)) }),
+  setShapeSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      shape: { ...s.settings.shape, [key]: clampShapeSetting(key, value) },
+    },
+  })),
   setAspectRatioW: (w) => set({ aspectRatioW: Math.max(0.01, w) }),
   setAspectRatioH: (h) => set({ aspectRatioH: Math.max(0.01, h) }),
   setAspectRatioLocked: (locked) => set({ aspectRatioLocked: locked }),

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampCropSetting } from '../tools/crop/crop-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -55,7 +56,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   aspectRatioW: 1,
   aspectRatioH: 1,
   aspectRatioLocked: false,
-  cropMode: 'normal' as const,
   gradientType: 'linear',
   gradientStops: [
     { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
@@ -199,7 +199,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setAspectRatioW: (w) => set({ aspectRatioW: Math.max(0.01, w) }),
   setAspectRatioH: (h) => set({ aspectRatioH: Math.max(0.01, h) }),
   setAspectRatioLocked: (locked) => set({ aspectRatioLocked: locked }),
-  setCropMode: (mode) => set({ cropMode: mode }),
+  setCropSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      crop: { ...s.settings.crop, [key]: clampCropSetting(key, value) },
+    },
+  })),
   setGradientType: (type) => set({ gradientType: type }),
   setGradientStops: (stops) => {
     const clamped = stops.length < 2

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampBrushSetting } from '../tools/brush/brush-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -42,9 +43,6 @@ function warnIfNormalisedOpacity(setter: string, value: number): void {
 
 export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   settings: DEFAULT_TOOL_SETTINGS_SLICES,
-  brushSize: 10,
-  brushOpacity: 100,
-  brushHardness: 80,
   shapeMode: 'ellipse',
   shapeOutput: 'pixels' as const,
   shapeFillColor: { r: 255, g: 255, b: 255, a: 1 },
@@ -68,11 +66,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   quickSelectTolerance: 32,
   quickSelectEdgeStrength: 50,
   quickSelectMode: 'add' as const,
-  brushSpacing: 0,
-  brushScatter: 0,
-  brushAngle: 0,
-  brushFade: 0,
-  brushTaper: 0,
   activeBrushTip: null,
   symmetryHorizontal: false,
   symmetryVertical: false,
@@ -149,18 +142,16 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       },
     }));
   },
-  setBrushSize: (size) => set({ brushSize: Math.max(1, Math.min(5000, size)) }),
-  setBrushFade: (fade) => set({ brushFade: Math.max(0, Math.min(5000, fade)) }),
-  setBrushTaper: (taper) => set({ brushTaper: Math.max(0, Math.min(5000, taper)) }),
-  setBrushSpacing: (spacing) => set({ brushSpacing: Math.max(0, Math.min(200, spacing)) }),
-  setBrushScatter: (scatter) => set({ brushScatter: Math.max(0, Math.min(100, scatter)) }),
-  setBrushAngle: (angle) => set({ brushAngle: ((angle % 360) + 360) % 360 }),
-  setActiveBrushTip: (tip) => set({ activeBrushTip: tip }),
-  setBrushOpacity: (opacity) => {
-    warnIfNormalisedOpacity('setBrushOpacity', opacity);
-    set({ brushOpacity: Math.max(1, Math.min(100, opacity)) });
+  setBrushSetting: (key, value) => {
+    if (key === 'opacity') warnIfNormalisedOpacity('setBrushSetting(opacity)', value as number);
+    set((s) => ({
+      settings: {
+        ...s.settings,
+        brush: { ...s.settings.brush, [key]: clampBrushSetting(key, value) },
+      },
+    }));
   },
-  setBrushHardness: (hardness) => set({ brushHardness: Math.max(0, Math.min(100, hardness)) }),
+  setActiveBrushTip: (tip) => set({ activeBrushTip: tip }),
   setPencilSetting: (key, value) => set((s) => ({
     settings: {
       ...s.settings,
@@ -328,16 +319,17 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   addPresets: (presets) => set((s) => ({ presets: [...s.presets, ...presets] })),
   saveCurrentAsPreset: (name) => {
     const s = get();
+    const b = s.settings.brush;
     const preset: BrushPreset = {
       id: createPresetId(),
       name,
       tip: s.activeBrushTip,
-      size: s.brushSize,
-      hardness: s.brushHardness,
-      spacing: s.brushSpacing,
-      scatter: s.brushScatter,
-      angle: s.brushAngle,
-      opacity: s.brushOpacity,
+      size: b.size,
+      hardness: b.hardness,
+      spacing: b.spacing,
+      scatter: b.scatter,
+      angle: b.angle,
+      opacity: b.opacity,
       flow: 100,
       isCustom: true,
       sizeJitter: s.brushSizeJitter,
@@ -347,8 +339,8 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       speedSize: s.brushSpeedSize,
       speedSizeInvert: s.brushSpeedSizeInvert,
       speedSensitivity: s.brushSpeedSensitivity,
-      fade: s.brushFade,
-      taper: s.brushTaper,
+      fade: b.fade,
+      taper: b.taper,
       subBrushes: s.activeSubBrushes.length > 0 ? s.activeSubBrushes : undefined,
     };
     set((state) => ({ presets: [...state.presets, preset], activePresetId: preset.id }));
@@ -366,14 +358,21 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     const state = get();
     const preset = state.presets.find((p) => p.id === id);
     if (!preset) return;
-    set({
+    set((s) => ({
       activePresetId: id,
-      brushSize: preset.size,
-      brushHardness: preset.hardness,
-      brushOpacity: preset.opacity,
-      brushSpacing: preset.spacing,
-      brushScatter: preset.scatter,
-      brushAngle: preset.angle,
+      settings: {
+        ...s.settings,
+        brush: {
+          size: preset.size,
+          opacity: preset.opacity,
+          hardness: preset.hardness,
+          spacing: preset.spacing,
+          scatter: preset.scatter,
+          angle: preset.angle,
+          fade: preset.fade ?? 0,
+          taper: preset.taper ?? 0,
+        },
+      },
       activeBrushTip: preset.tip,
       brushSizeJitter: preset.sizeJitter ?? 0,
       brushHardnessJitter: preset.hardnessJitter ?? 0,
@@ -382,13 +381,11 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushSpeedSize: preset.speedSize ?? 0,
       brushSpeedSizeInvert: preset.speedSizeInvert ?? false,
       brushSpeedSensitivity: preset.speedSensitivity ?? 'med',
-      brushFade: preset.fade ?? 0,
-      brushTaper: preset.taper ?? 0,
       brushTextureData: null,
       brushTextureBlendMode: 'multiply',
       brushTextureScale: 100,
       activeSubBrushes: preset.subBrushes ?? [],
-    });
+    }));
   },
   setTipFromPreset: (id) => {
     const state = get();

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -14,6 +14,7 @@ import { clampEraserSetting } from '../tools/eraser/eraser-settings';
 import { clampPathSetting } from '../tools/path/path-settings';
 import { clampStampSetting } from '../tools/stamp/stamp-settings';
 import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import { clampQuickSelectSetting } from '../tools/quick-select/quick-select-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -63,10 +64,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   healingOpacity: 100,
   dodgeExposure: 50,
   dodgeMode: 'dodge',
-  quickSelectSize: 20,
-  quickSelectTolerance: 32,
-  quickSelectEdgeStrength: 50,
-  quickSelectMode: 'add' as const,
   textContent: 'Text',
   textFontSize: 24,
   textFontFamily: 'Inter, sans-serif',
@@ -286,14 +283,16 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       wand: { ...s.settings.wand, [key]: clampWandSetting(key, value) },
     },
   })),
-  setQuickSelectSize: (size) => set({ quickSelectSize: Math.max(1, Math.min(100, Math.round(size))) }),
-  setQuickSelectTolerance: (tolerance) => set({ quickSelectTolerance: Math.max(0, Math.min(255, Math.round(tolerance))) }),
-  setQuickSelectEdgeStrength: (strength) => set({ quickSelectEdgeStrength: Math.max(0, Math.min(100, Math.round(strength))) }),
-  setQuickSelectMode: (mode) => set({ quickSelectMode: mode }),
   setMagneticLassoSetting: (key, value) => set((s) => ({
     settings: {
       ...s.settings,
       magneticLasso: { ...s.settings.magneticLasso, [key]: clampMagneticLassoSetting(key, value) },
+    },
+  })),
+  setQuickSelectSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      quickSelect: { ...s.settings.quickSelect, [key]: clampQuickSelectSetting(key, value) },
     },
   })),
   setTextContent: (content) => set({ textContent: content }),

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampBrushSpeedSetting } from '../tools/brush/brush-speed-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -114,9 +115,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   brushAngleJitter: 0,
   brushOpacityJitter: 0,
   brushHardnessJitter: 0,
-  brushSpeedSize: 0,
-  brushSpeedSizeInvert: false,
-  brushSpeedSensitivity: 'med',
   brushTextureData: null,
   brushTextureBlendMode: 'multiply',
   brushTextureScale: 100,
@@ -129,9 +127,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setBrushAngleJitter: (jitter) => set({ brushAngleJitter: Math.max(0, Math.min(100, jitter)) }),
   setBrushOpacityJitter: (jitter) => set({ brushOpacityJitter: Math.max(0, Math.min(100, jitter)) }),
   setBrushHardnessJitter: (jitter) => set({ brushHardnessJitter: Math.max(0, Math.min(100, jitter)) }),
-  setBrushSpeedSize: (value) => set({ brushSpeedSize: Math.max(0, Math.min(300, value)) }),
-  setBrushSpeedSizeInvert: (invert) => set({ brushSpeedSizeInvert: invert }),
-  setBrushSpeedSensitivity: (sensitivity) => set({ brushSpeedSensitivity: sensitivity }),
+  setBrushSpeedSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      brushSpeed: { ...s.settings.brushSpeed, [key]: clampBrushSpeedSetting(key, value) },
+    },
+  })),
   setBrushTextureData: (texture) => set({ brushTextureData: texture }),
   setBrushTextureBlendMode: (mode) => set({ brushTextureBlendMode: mode }),
   setBrushTextureScale: (scale) => set({ brushTextureScale: Math.max(10, Math.min(300, scale)) }),
@@ -344,9 +345,9 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       hardnessJitter: s.brushHardnessJitter,
       angleJitter: s.brushAngleJitter,
       opacityJitter: s.brushOpacityJitter,
-      speedSize: s.brushSpeedSize,
-      speedSizeInvert: s.brushSpeedSizeInvert,
-      speedSensitivity: s.brushSpeedSensitivity,
+      speedSize: s.settings.brushSpeed.size,
+      speedSizeInvert: s.settings.brushSpeed.sizeInvert,
+      speedSensitivity: s.settings.brushSpeed.sensitivity,
       fade: s.brushFade,
       taper: s.brushTaper,
       subBrushes: s.activeSubBrushes.length > 0 ? s.activeSubBrushes : undefined,
@@ -366,7 +367,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     const state = get();
     const preset = state.presets.find((p) => p.id === id);
     if (!preset) return;
-    set({
+    set((s) => ({
       activePresetId: id,
       brushSize: preset.size,
       brushHardness: preset.hardness,
@@ -379,16 +380,21 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushHardnessJitter: preset.hardnessJitter ?? 0,
       brushAngleJitter: preset.angleJitter ?? 0,
       brushOpacityJitter: preset.opacityJitter ?? 0,
-      brushSpeedSize: preset.speedSize ?? 0,
-      brushSpeedSizeInvert: preset.speedSizeInvert ?? false,
-      brushSpeedSensitivity: preset.speedSensitivity ?? 'med',
       brushFade: preset.fade ?? 0,
       brushTaper: preset.taper ?? 0,
       brushTextureData: null,
       brushTextureBlendMode: 'multiply',
       brushTextureScale: 100,
       activeSubBrushes: preset.subBrushes ?? [],
-    });
+      settings: {
+        ...s.settings,
+        brushSpeed: {
+          size: clampBrushSpeedSetting('size', preset.speedSize ?? 0),
+          sizeInvert: preset.speedSizeInvert ?? false,
+          sensitivity: clampBrushSpeedSetting('sensitivity', preset.speedSensitivity ?? 'med'),
+        },
+      },
+    }));
   },
   setTipFromPreset: (id) => {
     const state = get();

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,12 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import {
+  appendGradientStop,
+  clampGradientSetting,
+  removeGradientStopAt,
+  updateGradientStopAt,
+} from '../tools/gradient/gradient-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -56,12 +62,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   aspectRatioH: 1,
   aspectRatioLocked: false,
   cropMode: 'normal' as const,
-  gradientType: 'linear',
-  gradientStops: [
-    { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
-    { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
-  ],
-  gradientReverse: false,
   dodgeExposure: 50,
   dodgeMode: 'dodge',
   quickSelectSize: 20,
@@ -200,36 +200,39 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   setAspectRatioH: (h) => set({ aspectRatioH: Math.max(0.01, h) }),
   setAspectRatioLocked: (locked) => set({ aspectRatioLocked: locked }),
   setCropMode: (mode) => set({ cropMode: mode }),
-  setGradientType: (type) => set({ gradientType: type }),
-  setGradientStops: (stops) => {
-    const clamped = stops.length < 2
-      ? [...stops, ...Array.from({ length: 2 - stops.length }, (_, i) => ({ position: i, color: { r: 0, g: 0, b: 0, a: 1 } }))]
-      : stops.slice(0, 16);
-    const sorted = [...clamped].sort((a, b) => a.position - b.position);
-    set({ gradientStops: sorted });
-  },
-  setGradientReverse: (reverse) => set({ gradientReverse: reverse }),
-  addGradientStop: (position, color) => set((state) => {
-    if (state.gradientStops.length >= 16) return state;
-    const newStops = [...state.gradientStops, { position: Math.max(0, Math.min(1, position)), color }];
-    newStops.sort((a, b) => a.position - b.position);
-    return { gradientStops: newStops };
-  }),
-  removeGradientStop: (index) => set((state) => {
-    if (state.gradientStops.length <= 2) return state;
-    const newStops = state.gradientStops.filter((_, i) => i !== index);
-    return { gradientStops: newStops };
-  }),
-  updateGradientStop: (index, partial) => set((state) => {
-    const newStops = state.gradientStops.map((stop, i) => {
-      if (i !== index) return stop;
-      return {
-        position: partial.position !== undefined ? Math.max(0, Math.min(1, partial.position)) : stop.position,
-        color: partial.color ?? stop.color,
-      };
-    });
-    return { gradientStops: [...newStops].sort((a, b) => a.position - b.position) };
-  }),
+  setGradientSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      gradient: { ...s.settings.gradient, [key]: clampGradientSetting(key, value) },
+    },
+  })),
+  addGradientStop: (position, color) => set((s) => ({
+    settings: {
+      ...s.settings,
+      gradient: {
+        ...s.settings.gradient,
+        stops: appendGradientStop(s.settings.gradient.stops, position, color),
+      },
+    },
+  })),
+  removeGradientStop: (index) => set((s) => ({
+    settings: {
+      ...s.settings,
+      gradient: {
+        ...s.settings.gradient,
+        stops: removeGradientStopAt(s.settings.gradient.stops, index),
+      },
+    },
+  })),
+  updateGradientStop: (index, partial) => set((s) => ({
+    settings: {
+      ...s.settings,
+      gradient: {
+        ...s.settings.gradient,
+        stops: updateGradientStopAt(s.settings.gradient.stops, index, partial),
+      },
+    },
+  })),
   setSymmetryHorizontal: (enabled) => set({ symmetryHorizontal: enabled }),
   setSymmetryVertical: (enabled) => set({ symmetryVertical: enabled }),
   setSymmetryRadialSegments: (segments) => set({ symmetryRadialSegments: Math.max(0, Math.min(32, Math.round(segments))) }),

--- a/src/app/tool-settings-store.ts
+++ b/src/app/tool-settings-store.ts
@@ -17,6 +17,7 @@ import { clampMagneticLassoSetting } from '../tools/magnetic-lasso/magnetic-lass
 import { clampTextSetting } from '../tools/text/text-settings';
 import { clampSpraySetting } from '../tools/spray/spray-settings';
 import { clampHealingSetting } from '../tools/healing/healing-settings';
+import { clampBrushJitterSetting } from '../tools/brush/brush-jitter-settings';
 
 export type { ToolSettings } from './tool-settings-types';
 
@@ -110,10 +111,6 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     { r: 255, g: 130, b: 0,   a: 1 },
     { r: 0,   g: 200, b: 200, a: 1 },
   ],
-  brushSizeJitter: 0,
-  brushAngleJitter: 0,
-  brushOpacityJitter: 0,
-  brushHardnessJitter: 0,
   brushSpeedSize: 0,
   brushSpeedSizeInvert: false,
   brushSpeedSensitivity: 'med',
@@ -125,10 +122,12 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
   activePresetId: 'builtin-hard-round',
   activeSubBrushes: [],
 
-  setBrushSizeJitter: (jitter) => set({ brushSizeJitter: Math.max(0, Math.min(100, jitter)) }),
-  setBrushAngleJitter: (jitter) => set({ brushAngleJitter: Math.max(0, Math.min(100, jitter)) }),
-  setBrushOpacityJitter: (jitter) => set({ brushOpacityJitter: Math.max(0, Math.min(100, jitter)) }),
-  setBrushHardnessJitter: (jitter) => set({ brushHardnessJitter: Math.max(0, Math.min(100, jitter)) }),
+  setBrushJitterSetting: (key, value) => set((s) => ({
+    settings: {
+      ...s.settings,
+      brushJitter: { ...s.settings.brushJitter, [key]: clampBrushJitterSetting(key, value) },
+    },
+  })),
   setBrushSpeedSize: (value) => set({ brushSpeedSize: Math.max(0, Math.min(300, value)) }),
   setBrushSpeedSizeInvert: (invert) => set({ brushSpeedSizeInvert: invert }),
   setBrushSpeedSensitivity: (sensitivity) => set({ brushSpeedSensitivity: sensitivity }),
@@ -340,10 +339,10 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       opacity: s.brushOpacity,
       flow: 100,
       isCustom: true,
-      sizeJitter: s.brushSizeJitter,
-      hardnessJitter: s.brushHardnessJitter,
-      angleJitter: s.brushAngleJitter,
-      opacityJitter: s.brushOpacityJitter,
+      sizeJitter: s.settings.brushJitter.size,
+      hardnessJitter: s.settings.brushJitter.hardness,
+      angleJitter: s.settings.brushJitter.angle,
+      opacityJitter: s.settings.brushJitter.opacity,
       speedSize: s.brushSpeedSize,
       speedSizeInvert: s.brushSpeedSizeInvert,
       speedSensitivity: s.brushSpeedSensitivity,
@@ -366,7 +365,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
     const state = get();
     const preset = state.presets.find((p) => p.id === id);
     if (!preset) return;
-    set({
+    set((s) => ({
       activePresetId: id,
       brushSize: preset.size,
       brushHardness: preset.hardness,
@@ -375,10 +374,15 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushScatter: preset.scatter,
       brushAngle: preset.angle,
       activeBrushTip: preset.tip,
-      brushSizeJitter: preset.sizeJitter ?? 0,
-      brushHardnessJitter: preset.hardnessJitter ?? 0,
-      brushAngleJitter: preset.angleJitter ?? 0,
-      brushOpacityJitter: preset.opacityJitter ?? 0,
+      settings: {
+        ...s.settings,
+        brushJitter: {
+          size: preset.sizeJitter ?? 0,
+          hardness: preset.hardnessJitter ?? 0,
+          angle: preset.angleJitter ?? 0,
+          opacity: preset.opacityJitter ?? 0,
+        },
+      },
       brushSpeedSize: preset.speedSize ?? 0,
       brushSpeedSizeInvert: preset.speedSizeInvert ?? false,
       brushSpeedSensitivity: preset.speedSensitivity ?? 'med',
@@ -388,7 +392,7 @@ export const useToolSettingsStore = create<ToolSettings>((set, get) => ({
       brushTextureBlendMode: 'multiply',
       brushTextureScale: 100,
       activeSubBrushes: preset.subBrushes ?? [],
-    });
+    }));
   },
   setTipFromPreset: (id) => {
     const state = get();

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -3,6 +3,7 @@ import type { GradientStop, GradientType } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
+import type { BrushSettings } from '../tools/brush/brush-settings';
 import type { WandSettings } from '../tools/wand/wand-settings';
 import type { FillSettings } from '../tools/fill/fill-settings';
 import type { MarqueeSettings } from '../tools/marquee/marquee-settings';
@@ -29,9 +30,6 @@ export interface ToolSettings {
    * on this interface.
    */
   settings: ToolSettingsSlices;
-  brushSize: number;
-  brushOpacity: number;
-  brushHardness: number;
   shapeMode: ShapeMode;
   shapeOutput: ShapeOutput;
   shapeFillColor: Color | null;
@@ -52,11 +50,6 @@ export interface ToolSettings {
   quickSelectTolerance: number;
   quickSelectEdgeStrength: number;
   quickSelectMode: 'add' | 'subtract';
-  brushSpacing: number;
-  brushScatter: number;
-  brushAngle: number;
-  brushFade: number;
-  brushTaper: number;
   activeBrushTip: BrushTipData | null;
   symmetryHorizontal: boolean;
   symmetryVertical: boolean;
@@ -93,12 +86,7 @@ export interface ToolSettings {
   addBrushTexture: (texture: BrushTextureData) => void;
   removeBrushTexture: (id: string) => void;
   setSpraySetting: <K extends keyof SpraySettings>(key: K, value: SpraySettings[K]) => void;
-  setBrushSize: (size: number) => void;
-  setBrushFade: (fade: number) => void;
-  setBrushTaper: (taper: number) => void;
-  setBrushSpacing: (spacing: number) => void;
-  setBrushScatter: (scatter: number) => void;
-  setBrushAngle: (angle: number) => void;
+  setBrushSetting: <K extends keyof BrushSettings>(key: K, value: BrushSettings[K]) => void;
   setActiveBrushTip: (tip: BrushTipData | null) => void;
   setStampSetting: <K extends keyof StampSettings>(key: K, value: StampSettings[K]) => void;
   setHealingSetting: <K extends keyof HealingSettings>(key: K, value: HealingSettings[K]) => void;
@@ -114,8 +102,6 @@ export interface ToolSettings {
   setQuickSelectMode: (mode: 'add' | 'subtract') => void;
   setMagneticLassoSetting: <K extends keyof MagneticLassoSettings>(key: K, value: MagneticLassoSettings[K]) => void;
   setTextSetting: <K extends keyof TextSettings>(key: K, value: TextSettings[K]) => void;
-  setBrushOpacity: (opacity: number) => void;
-  setBrushHardness: (hardness: number) => void;
   setPencilSetting: <K extends keyof PencilSettings>(key: K, value: PencilSettings[K]) => void;
   setEraserSetting: <K extends keyof EraserSettings>(key: K, value: EraserSettings[K]) => void;
   setPathSetting: <K extends keyof PathSettings>(key: K, value: PathSettings[K]) => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { BrushJitterSettings } from '../tools/brush/brush-jitter-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -65,10 +66,6 @@ export interface ToolSettings {
   foregroundColor: Color;
   backgroundColor: Color;
   recentColors: readonly Color[];
-  brushSizeJitter: number;
-  brushAngleJitter: number;
-  brushOpacityJitter: number;
-  brushHardnessJitter: number;
   brushSpeedSize: number;
   brushSpeedSizeInvert: boolean;
   brushSpeedSensitivity: 'low' | 'med' | 'high';
@@ -80,10 +77,7 @@ export interface ToolSettings {
   activePresetId: string | null;
   activeSubBrushes: SubBrush[];
 
-  setBrushSizeJitter: (jitter: number) => void;
-  setBrushAngleJitter: (jitter: number) => void;
-  setBrushOpacityJitter: (jitter: number) => void;
-  setBrushHardnessJitter: (jitter: number) => void;
+  setBrushJitterSetting: <K extends keyof BrushJitterSettings>(key: K, value: BrushJitterSettings[K]) => void;
   setBrushSpeedSize: (value: number) => void;
   setBrushSpeedSizeInvert: (invert: boolean) => void;
   setBrushSpeedSensitivity: (sensitivity: 'low' | 'med' | 'high') => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,6 +1,5 @@
 import type { Color } from '../types';
 import type { GradientStop, GradientType } from '../tools/gradient/gradient';
-import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
 import type { WandSettings } from '../tools/wand/wand-settings';
@@ -16,6 +15,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { ShapeSettings } from '../tools/shape/shape-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -32,13 +32,6 @@ export interface ToolSettings {
   brushSize: number;
   brushOpacity: number;
   brushHardness: number;
-  shapeMode: ShapeMode;
-  shapeOutput: ShapeOutput;
-  shapeFillColor: Color | null;
-  shapeStrokeColor: Color | null;
-  shapeStrokeWidth: number;
-  shapePolygonSides: number;
-  shapeCornerRadius: number;
   aspectRatioW: number;
   aspectRatioH: number;
   aspectRatioLocked: boolean;
@@ -120,13 +113,7 @@ export interface ToolSettings {
   setEraserSetting: <K extends keyof EraserSettings>(key: K, value: EraserSettings[K]) => void;
   setPathSetting: <K extends keyof PathSettings>(key: K, value: PathSettings[K]) => void;
   setFillSetting: <K extends keyof FillSettings>(key: K, value: FillSettings[K]) => void;
-  setShapeMode: (mode: ShapeMode) => void;
-  setShapeOutput: (output: ShapeOutput) => void;
-  setShapeFillColor: (color: Color | null) => void;
-  setShapeStrokeColor: (color: Color | null) => void;
-  setShapeStrokeWidth: (width: number) => void;
-  setShapePolygonSides: (sides: number) => void;
-  setShapeCornerRadius: (radius: number) => void;
+  setShapeSetting: <K extends keyof ShapeSettings>(key: K, value: ShapeSettings[K]) => void;
   setAspectRatioW: (w: number) => void;
   setAspectRatioH: (h: number) => void;
   setAspectRatioLocked: (locked: boolean) => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -13,6 +13,7 @@ import type { EraserSettings } from '../tools/eraser/eraser-settings';
 import type { PathSettings } from '../tools/path/path-settings';
 import type { StampSettings } from '../tools/stamp/stamp-settings';
 import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-lasso-settings';
+import type { QuickSelectSettings } from '../tools/quick-select/quick-select-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -47,10 +48,6 @@ export interface ToolSettings {
   healingOpacity: number;
   dodgeExposure: number;
   dodgeMode: DodgeMode;
-  quickSelectSize: number;
-  quickSelectTolerance: number;
-  quickSelectEdgeStrength: number;
-  quickSelectMode: 'add' | 'subtract';
   textContent: string;
   textFontSize: number;
   textFontFamily: string;
@@ -123,11 +120,8 @@ export interface ToolSettings {
   setSmudgeSetting: <K extends keyof SmudgeSettings>(key: K, value: SmudgeSettings[K]) => void;
   setMarqueeSetting: <K extends keyof MarqueeSettings>(key: K, value: MarqueeSettings[K]) => void;
   setWandSetting: <K extends keyof WandSettings>(key: K, value: WandSettings[K]) => void;
-  setQuickSelectSize: (size: number) => void;
-  setQuickSelectTolerance: (tolerance: number) => void;
-  setQuickSelectEdgeStrength: (strength: number) => void;
-  setQuickSelectMode: (mode: 'add' | 'subtract') => void;
   setMagneticLassoSetting: <K extends keyof MagneticLassoSettings>(key: K, value: MagneticLassoSettings[K]) => void;
+  setQuickSelectSetting: <K extends keyof QuickSelectSettings>(key: K, value: QuickSelectSettings[K]) => void;
   setTextContent: (content: string) => void;
   setTextFontSize: (size: number) => void;
   setTextFontFamily: (family: string) => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -1,5 +1,5 @@
 import type { Color } from '../types';
-import type { GradientStop, GradientType } from '../tools/gradient/gradient';
+import type { GradientStop } from '../tools/gradient/gradient';
 import type { ShapeMode, ShapeOutput } from '../tools/shape/shape';
 import type { DodgeMode } from '../tools/dodge/dodge';
 import type { BrushPreset, BrushTipData, BrushTextureData, BrushTextureBlendMode, SubBrush } from '../types/brush';
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { GradientSettings } from '../tools/gradient/gradient-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -43,9 +44,6 @@ export interface ToolSettings {
   aspectRatioH: number;
   aspectRatioLocked: boolean;
   cropMode: 'normal' | 'perspective';
-  gradientType: GradientType;
-  gradientStops: readonly GradientStop[];
-  gradientReverse: boolean;
   dodgeExposure: number;
   dodgeMode: DodgeMode;
   quickSelectSize: number;
@@ -131,9 +129,7 @@ export interface ToolSettings {
   setAspectRatioH: (h: number) => void;
   setAspectRatioLocked: (locked: boolean) => void;
   setCropMode: (mode: 'normal' | 'perspective') => void;
-  setGradientType: (type: 'linear' | 'radial') => void;
-  setGradientStops: (stops: readonly GradientStop[]) => void;
-  setGradientReverse: (reverse: boolean) => void;
+  setGradientSetting: <K extends keyof GradientSettings>(key: K, value: GradientSettings[K]) => void;
   addGradientStop: (position: number, color: Color) => void;
   removeGradientStop: (index: number) => void;
   updateGradientStop: (index: number, stop: Partial<GradientStop>) => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { BrushSpeedSettings } from '../tools/brush/brush-speed-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -69,9 +70,6 @@ export interface ToolSettings {
   brushAngleJitter: number;
   brushOpacityJitter: number;
   brushHardnessJitter: number;
-  brushSpeedSize: number;
-  brushSpeedSizeInvert: boolean;
-  brushSpeedSensitivity: 'low' | 'med' | 'high';
   brushTextureData: BrushTextureData | null;
   brushTextureBlendMode: BrushTextureBlendMode;
   brushTextureScale: number;
@@ -84,9 +82,7 @@ export interface ToolSettings {
   setBrushAngleJitter: (jitter: number) => void;
   setBrushOpacityJitter: (jitter: number) => void;
   setBrushHardnessJitter: (jitter: number) => void;
-  setBrushSpeedSize: (value: number) => void;
-  setBrushSpeedSizeInvert: (invert: boolean) => void;
-  setBrushSpeedSensitivity: (sensitivity: 'low' | 'med' | 'high') => void;
+  setBrushSpeedSetting: <K extends keyof BrushSpeedSettings>(key: K, value: BrushSpeedSettings[K]) => void;
   setBrushTextureData: (texture: BrushTextureData | null) => void;
   setBrushTextureBlendMode: (mode: BrushTextureBlendMode) => void;
   setBrushTextureScale: (scale: number) => void;

--- a/src/app/tool-settings-types.ts
+++ b/src/app/tool-settings-types.ts
@@ -16,6 +16,7 @@ import type { MagneticLassoSettings } from '../tools/magnetic-lasso/magnetic-las
 import type { TextSettings } from '../tools/text/text-settings';
 import type { SpraySettings } from '../tools/spray/spray-settings';
 import type { HealingSettings } from '../tools/healing/healing-settings';
+import type { CropSettings } from '../tools/crop/crop-settings';
 import type { ToolSettingsSlices } from './tool-settings-slices';
 
 export interface ToolSettings {
@@ -42,7 +43,6 @@ export interface ToolSettings {
   aspectRatioW: number;
   aspectRatioH: number;
   aspectRatioLocked: boolean;
-  cropMode: 'normal' | 'perspective';
   gradientType: GradientType;
   gradientStops: readonly GradientStop[];
   gradientReverse: boolean;
@@ -130,7 +130,7 @@ export interface ToolSettings {
   setAspectRatioW: (w: number) => void;
   setAspectRatioH: (h: number) => void;
   setAspectRatioLocked: (locked: boolean) => void;
-  setCropMode: (mode: 'normal' | 'perspective') => void;
+  setCropSetting: <K extends keyof CropSettings>(key: K, value: CropSettings[K]) => void;
   setGradientType: (type: 'linear' | 'radial') => void;
   setGradientStops: (stops: readonly GradientStop[]) => void;
   setGradientReverse: (reverse: boolean) => void;

--- a/src/app/useCanvasCursor.ts
+++ b/src/app/useCanvasCursor.ts
@@ -35,7 +35,7 @@ function getToolSize(tool: BrushTool, settings: ReturnType<typeof useToolSetting
   switch (tool) {
     case 'brush':
     case 'dodge':
-      return settings.brushSize;
+      return settings.settings.brush.size;
     case 'sponge':
       return settings.settings.sponge.size;
     case 'pencil':
@@ -186,6 +186,6 @@ export function getBrushCursorInfo(tool: ToolId): BrushCursorInfo | null {
     size: getToolSize(tool, settings),
     shape: tool === 'pencil' ? 'square' : 'circle',
     tip: tool === 'brush' ? settings.activeBrushTip : null,
-    angle: tool === 'brush' ? (settings.brushAngle * Math.PI) / 180 : 0,
+    angle: tool === 'brush' ? (settings.settings.brush.angle * Math.PI) / 180 : 0,
   };
 }

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -365,14 +365,15 @@ export function useCanvasInteraction(
           if (!engine) return;
 
           const toolSettings = useToolSettingsStore.getState();
-          const size = toolSettings.brushSize;
-          const hardness = toolSettings.brushHardness / 100;
-          const opacity = toolSettings.brushOpacity / 100;
+          const brush = toolSettings.settings.brush;
+          const size = brush.size;
+          const hardness = brush.hardness / 100;
+          const opacity = brush.opacity / 100;
           const color = toolSettings.foregroundColor;
           const r = color.r / 255;
           const g = color.g / 255;
           const b = color.b / 255;
-          const spacing = Math.max(1, size * toolSettings.brushSpacing / 100);
+          const spacing = Math.max(1, size * brush.spacing / 100);
 
           const result = smoothStroke(strokePoints, spacing);
           if (result.sampledPoints.length < 2) return;

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -206,7 +206,7 @@ function renderFrameGpu(
   syncAdjustments(engine, adjustments, adjustmentsEnabled);
   syncGroupAdjustments(engine, layers);
   syncMaskEditMode(engine, uiState.maskMode === 'layerMask', doc.activeLayerId);
-  syncBrushTip(engine, toolState.activeBrushTip, -toolState.brushAngle * Math.PI / 180, toolState.brushHardness);
+  syncBrushTip(engine, toolState.activeBrushTip, -toolState.settings.brush.angle * Math.PI / 180, toolState.settings.brush.hardness);
   syncBrushTexture(engine, toolState.brushTextureData, toolState.brushTextureScale, toolState.brushTextureBlendMode);
 
   renderEngine(engine);

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -60,17 +60,18 @@ export function BrushModal() {
   const brushTaper = useToolSettingsStore((s) => s.brushTaper);
   const setBrushTaper = useToolSettingsStore((s) => s.setBrushTaper);
 
-  const sizeJitter = useToolSettingsStore((s) => s.brushSizeJitter);
-  const hardnessJitter = useToolSettingsStore((s) => s.brushHardnessJitter);
-  const angleJitter = useToolSettingsStore((s) => s.brushAngleJitter);
-  const opacityJitter = useToolSettingsStore((s) => s.brushOpacityJitter);
+  const sizeJitter = useToolSettingsStore((s) => s.settings.brushJitter.size);
+  const hardnessJitter = useToolSettingsStore((s) => s.settings.brushJitter.hardness);
+  const angleJitter = useToolSettingsStore((s) => s.settings.brushJitter.angle);
+  const opacityJitter = useToolSettingsStore((s) => s.settings.brushJitter.opacity);
   const speedSize = useToolSettingsStore((s) => s.brushSpeedSize);
   const speedSizeInvert = useToolSettingsStore((s) => s.brushSpeedSizeInvert);
   const speedSensitivity = useToolSettingsStore((s) => s.brushSpeedSensitivity);
-  const setSizeJitter = useToolSettingsStore((s) => s.setBrushSizeJitter);
-  const setHardnessJitter = useToolSettingsStore((s) => s.setBrushHardnessJitter);
-  const setAngleJitter = useToolSettingsStore((s) => s.setBrushAngleJitter);
-  const setOpacityJitter = useToolSettingsStore((s) => s.setBrushOpacityJitter);
+  const setBrushJitterSetting = useToolSettingsStore((s) => s.setBrushJitterSetting);
+  const setSizeJitter = (v: number) => setBrushJitterSetting('size', v);
+  const setHardnessJitter = (v: number) => setBrushJitterSetting('hardness', v);
+  const setAngleJitter = (v: number) => setBrushJitterSetting('angle', v);
+  const setOpacityJitter = (v: number) => setBrushJitterSetting('opacity', v);
   const setSpeedSize = useToolSettingsStore((s) => s.setBrushSpeedSize);
   const setSpeedSizeInvert = useToolSettingsStore((s) => s.setBrushSpeedSizeInvert);
   const setSpeedSensitivity = useToolSettingsStore((s) => s.setBrushSpeedSensitivity);

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -43,22 +43,23 @@ export function BrushModal() {
   const saveCurrentAsPreset = useToolSettingsStore((s) => s.saveCurrentAsPreset);
   const setShowBrushModal = useUIStore((s) => s.setShowBrushModal);
 
-  const brushSize = useToolSettingsStore((s) => s.brushSize);
-  const brushOpacity = useToolSettingsStore((s) => s.brushOpacity);
-  const brushHardness = useToolSettingsStore((s) => s.brushHardness);
-  const brushSpacing = useToolSettingsStore((s) => s.brushSpacing);
-  const brushScatter = useToolSettingsStore((s) => s.brushScatter);
-  const brushAngle = useToolSettingsStore((s) => s.brushAngle);
+  const brushSize = useToolSettingsStore((s) => s.settings.brush.size);
+  const brushOpacity = useToolSettingsStore((s) => s.settings.brush.opacity);
+  const brushHardness = useToolSettingsStore((s) => s.settings.brush.hardness);
+  const brushSpacing = useToolSettingsStore((s) => s.settings.brush.spacing);
+  const brushScatter = useToolSettingsStore((s) => s.settings.brush.scatter);
+  const brushAngle = useToolSettingsStore((s) => s.settings.brush.angle);
+  const brushTaper = useToolSettingsStore((s) => s.settings.brush.taper);
   const activeBrushTip = useToolSettingsStore((s) => s.activeBrushTip);
 
-  const setBrushSize = useToolSettingsStore((s) => s.setBrushSize);
-  const setBrushOpacity = useToolSettingsStore((s) => s.setBrushOpacity);
-  const setBrushHardness = useToolSettingsStore((s) => s.setBrushHardness);
-  const setBrushSpacing = useToolSettingsStore((s) => s.setBrushSpacing);
-  const setBrushScatter = useToolSettingsStore((s) => s.setBrushScatter);
-  const setBrushAngle = useToolSettingsStore((s) => s.setBrushAngle);
-  const brushTaper = useToolSettingsStore((s) => s.brushTaper);
-  const setBrushTaper = useToolSettingsStore((s) => s.setBrushTaper);
+  const setBrushSetting = useToolSettingsStore((s) => s.setBrushSetting);
+  const setBrushSize = useCallback((v: number) => setBrushSetting('size', v), [setBrushSetting]);
+  const setBrushOpacity = useCallback((v: number) => setBrushSetting('opacity', v), [setBrushSetting]);
+  const setBrushHardness = useCallback((v: number) => setBrushSetting('hardness', v), [setBrushSetting]);
+  const setBrushSpacing = useCallback((v: number) => setBrushSetting('spacing', v), [setBrushSetting]);
+  const setBrushScatter = useCallback((v: number) => setBrushSetting('scatter', v), [setBrushSetting]);
+  const setBrushAngle = useCallback((v: number) => setBrushSetting('angle', v), [setBrushSetting]);
+  const setBrushTaper = useCallback((v: number) => setBrushSetting('taper', v), [setBrushSetting]);
 
   const sizeJitter = useToolSettingsStore((s) => s.brushSizeJitter);
   const hardnessJitter = useToolSettingsStore((s) => s.brushHardnessJitter);

--- a/src/components/BrushModal/BrushModal.tsx
+++ b/src/components/BrushModal/BrushModal.tsx
@@ -64,16 +64,14 @@ export function BrushModal() {
   const hardnessJitter = useToolSettingsStore((s) => s.brushHardnessJitter);
   const angleJitter = useToolSettingsStore((s) => s.brushAngleJitter);
   const opacityJitter = useToolSettingsStore((s) => s.brushOpacityJitter);
-  const speedSize = useToolSettingsStore((s) => s.brushSpeedSize);
-  const speedSizeInvert = useToolSettingsStore((s) => s.brushSpeedSizeInvert);
-  const speedSensitivity = useToolSettingsStore((s) => s.brushSpeedSensitivity);
+  const speedSize = useToolSettingsStore((s) => s.settings.brushSpeed.size);
+  const speedSizeInvert = useToolSettingsStore((s) => s.settings.brushSpeed.sizeInvert);
+  const speedSensitivity = useToolSettingsStore((s) => s.settings.brushSpeed.sensitivity);
   const setSizeJitter = useToolSettingsStore((s) => s.setBrushSizeJitter);
   const setHardnessJitter = useToolSettingsStore((s) => s.setBrushHardnessJitter);
   const setAngleJitter = useToolSettingsStore((s) => s.setBrushAngleJitter);
   const setOpacityJitter = useToolSettingsStore((s) => s.setBrushOpacityJitter);
-  const setSpeedSize = useToolSettingsStore((s) => s.setBrushSpeedSize);
-  const setSpeedSizeInvert = useToolSettingsStore((s) => s.setBrushSpeedSizeInvert);
-  const setSpeedSensitivity = useToolSettingsStore((s) => s.setBrushSpeedSensitivity);
+  const setBrushSpeedSetting = useToolSettingsStore((s) => s.setBrushSpeedSetting);
 
   const textureData = useToolSettingsStore((s) => s.brushTextureData);
   const textureBlendMode = useToolSettingsStore((s) => s.brushTextureBlendMode);
@@ -295,19 +293,19 @@ export function BrushModal() {
             <Slider label="Hardness Jitter" value={hardnessJitter} min={0} max={100} onChange={setHardnessJitter} />
             <Slider label="Angle Jitter" value={angleJitter} min={0} max={100} onChange={setAngleJitter} />
             <Slider label="Opacity Jitter" value={opacityJitter} min={0} max={100} onChange={setOpacityJitter} />
-            <Slider label="Speed Size" value={speedSize} min={0} max={speedSizeInvert ? 300 : 100} onChange={setSpeedSize} />
+            <Slider label="Speed Size" value={speedSize} min={0} max={speedSizeInvert ? 300 : 100} onChange={(v) => setBrushSpeedSetting('size', v)} />
             <div className={styles.speedToggleRow}>
               <span className={styles.speedToggleLabel}>Faster is</span>
               <div className={styles.speedToggleGroup}>
                 <button
                   className={`${styles.speedToggle}${!speedSizeInvert ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => { setSpeedSizeInvert(false); if (speedSize > 100) setSpeedSize(100); }}
+                  onClick={() => { setBrushSpeedSetting('sizeInvert', false); if (speedSize > 100) setBrushSpeedSetting('size', 100); }}
                 >
                   Thinner
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSizeInvert ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSizeInvert(true)}
+                  onClick={() => setBrushSpeedSetting('sizeInvert', true)}
                 >
                   Wider
                 </button>
@@ -316,19 +314,19 @@ export function BrushModal() {
               <div className={styles.speedToggleGroup}>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'low' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('low')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'low')}
                 >
                   Low
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'med' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('med')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'med')}
                 >
                   Med
                 </button>
                 <button
                   className={`${styles.speedToggle}${speedSensitivity === 'high' ? ` ${styles.speedToggleActive}` : ''}`}
-                  onClick={() => setSpeedSensitivity('high')}
+                  onClick={() => setBrushSpeedSetting('sensitivity', 'high')}
                 >
                   High
                 </button>

--- a/src/components/GradientModal/GradientModal.tsx
+++ b/src/components/GradientModal/GradientModal.tsx
@@ -11,16 +11,16 @@ interface GradientModalProps {
 }
 
 export function GradientModal({ onClose }: GradientModalProps) {
-  const gradientStops = useToolSettingsStore((s) => s.gradientStops);
-  const setGradientStops = useToolSettingsStore((s) => s.setGradientStops);
+  const gradientStops = useToolSettingsStore((s) => s.settings.gradient.stops);
+  const setGradientSetting = useToolSettingsStore((s) => s.setGradientSetting);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const sorted = [...gradientStops].sort((a, b) => a.position - b.position);
   const selectedStop = sorted[selectedIndex];
 
   const handleStopsChange = useCallback((stops: readonly GradientStop[]) => {
-    setGradientStops(stops);
-  }, [setGradientStops]);
+    setGradientSetting('stops', stops);
+  }, [setGradientSetting]);
 
   const handleSelectStop = useCallback((index: number) => {
     setSelectedIndex(index);
@@ -30,15 +30,15 @@ export function GradientModal({ onClose }: GradientModalProps) {
     const newStops = sorted.map((stop, i) =>
       i === selectedIndex ? { ...stop, color } : stop,
     );
-    setGradientStops(newStops);
-  }, [sorted, selectedIndex, setGradientStops]);
+    setGradientSetting('stops', newStops);
+  }, [sorted, selectedIndex, setGradientSetting]);
 
   const handleDelete = useCallback(() => {
     if (gradientStops.length <= 2) return;
     const newStops = sorted.filter((_, i) => i !== selectedIndex);
-    setGradientStops(newStops);
+    setGradientSetting('stops', newStops);
     setSelectedIndex(Math.min(selectedIndex, newStops.length - 1));
-  }, [gradientStops.length, sorted, selectedIndex, setGradientStops]);
+  }, [gradientStops.length, sorted, selectedIndex, setGradientSetting]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {

--- a/src/tools/brush/brush-jitter-settings.test.ts
+++ b/src/tools/brush/brush-jitter-settings.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_BRUSH_JITTER_SETTINGS,
+  clampBrushJitterSetting,
+  type BrushJitterSettings,
+} from './brush-jitter-settings';
+
+describe('brush-jitter-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_BRUSH_JITTER_SETTINGS).toEqual({
+      size: 0,
+      hardness: 0,
+      angle: 0,
+      opacity: 0,
+    } satisfies BrushJitterSettings);
+  });
+
+  it('clamps every field into [0, 100]', () => {
+    for (const key of ['size', 'hardness', 'angle', 'opacity'] as const) {
+      expect(clampBrushJitterSetting(key, -10)).toBe(0);
+      expect(clampBrushJitterSetting(key, 0)).toBe(0);
+      expect(clampBrushJitterSetting(key, 50)).toBe(50);
+      expect(clampBrushJitterSetting(key, 100)).toBe(100);
+      expect(clampBrushJitterSetting(key, 999)).toBe(100);
+    }
+  });
+
+  it('preserves sub-percent fractional values inside the range', () => {
+    // Slider input is integer, but the paint handlers divide by 100
+    // and operate on the resulting normalised value, so the slice
+    // must round-trip fractional inputs without quantising them.
+    expect(clampBrushJitterSetting('size', 12.5)).toBe(12.5);
+    expect(clampBrushJitterSetting('hardness', 33.3)).toBe(33.3);
+    expect(clampBrushJitterSetting('angle', 0.5)).toBe(0.5);
+    expect(clampBrushJitterSetting('opacity', 99.9)).toBe(99.9);
+  });
+});

--- a/src/tools/brush/brush-jitter-settings.ts
+++ b/src/tools/brush/brush-jitter-settings.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-tool settings slice for the Brush's jitter sub-namespace.
+ *
+ * Authoritative settings type for the brush's randomisation jitter —
+ * a follow-up slice to the `brush` dab-dynamics slice. Same pattern as
+ * `wand-settings.ts` / `fill-settings.ts` / `marquee-settings.ts` /
+ * `smudge-settings.ts` / `pencil-settings.ts` / `sponge-settings.ts` /
+ * `eraser-settings.ts` / `path-settings.ts` / `stamp-settings.ts` /
+ * `magnetic-lasso-settings.ts` / `text-settings.ts` /
+ * `spray-settings.ts` / `healing-settings.ts` / `brush-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`.
+ *
+ * The `brush` dab-dynamics slice intentionally excludes jitter — see
+ * the JSDoc on `brush-settings.ts`: jitter, speed and tip move in
+ * their own follow-up slices because they're a distinct namespace
+ * with their own option-bar panel (the Brush modal's Dynamics tab)
+ * and their own clamp range (0–100, percent-of-base).
+ *
+ * Every field is a percent-of-base 0–100 value that the paint
+ * handlers divide by 100 before feeding the brush kernel.
+ */
+export interface BrushJitterSettings {
+  size: number;
+  hardness: number;
+  angle: number;
+  opacity: number;
+}
+
+export const DEFAULT_BRUSH_JITTER_SETTINGS: BrushJitterSettings = {
+  size: 0,
+  hardness: 0,
+  angle: 0,
+  opacity: 0,
+};
+
+export function clampBrushJitterSetting<K extends keyof BrushJitterSettings>(
+  key: K,
+  value: BrushJitterSettings[K],
+): BrushJitterSettings[K] {
+  // Every jitter field is the same percent-of-base 0–100 range, so
+  // the switch is degenerate today. Keeping the per-key shape (vs. a
+  // single `Math.max(0, Math.min(100, n))`) so future fields with a
+  // different range can land without restructuring callers.
+  if (key === 'size' || key === 'hardness' || key === 'angle' || key === 'opacity') {
+    const n = value as number;
+    return Math.max(0, Math.min(100, n)) as BrushJitterSettings[K];
+  }
+  return value;
+}

--- a/src/tools/brush/brush-settings.test.ts
+++ b/src/tools/brush/brush-settings.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_BRUSH_SETTINGS, clampBrushSetting } from './brush-settings';
+
+describe('brush-settings (#453)', () => {
+  it('exposes legacy flat-bag defaults', () => {
+    expect(DEFAULT_BRUSH_SETTINGS).toEqual({
+      size: 10,
+      opacity: 100,
+      hardness: 80,
+      spacing: 0,
+      scatter: 0,
+      angle: 0,
+      fade: 0,
+      taper: 0,
+    });
+  });
+
+  it('clamps size into [1, 5000]', () => {
+    expect(clampBrushSetting('size', -10)).toBe(1);
+    expect(clampBrushSetting('size', 0)).toBe(1);
+    expect(clampBrushSetting('size', 250)).toBe(250);
+    expect(clampBrushSetting('size', 99999)).toBe(5000);
+  });
+
+  it('clamps opacity into [1, 100] to avoid a silent no-op stroke', () => {
+    // The eraser / healing / spray / brush opacity setters all clamp
+    // to 1 not 0 — the warn-once dedupe in the store catches the 0–1
+    // normalised footgun, and the clamp keeps a stroke visible even
+    // after the dedupe has fired once.
+    expect(clampBrushSetting('opacity', -5)).toBe(1);
+    expect(clampBrushSetting('opacity', 0)).toBe(1);
+    expect(clampBrushSetting('opacity', 50)).toBe(50);
+    expect(clampBrushSetting('opacity', 200)).toBe(100);
+  });
+
+  it('clamps hardness into [0, 100]', () => {
+    expect(clampBrushSetting('hardness', -10)).toBe(0);
+    expect(clampBrushSetting('hardness', 0)).toBe(0);
+    expect(clampBrushSetting('hardness', 50)).toBe(50);
+    expect(clampBrushSetting('hardness', 999)).toBe(100);
+  });
+
+  it('clamps spacing into [0, 200]', () => {
+    expect(clampBrushSetting('spacing', -1)).toBe(0);
+    expect(clampBrushSetting('spacing', 50)).toBe(50);
+    expect(clampBrushSetting('spacing', 9999)).toBe(200);
+  });
+
+  it('clamps scatter into [0, 100]', () => {
+    expect(clampBrushSetting('scatter', -1)).toBe(0);
+    expect(clampBrushSetting('scatter', 25)).toBe(25);
+    expect(clampBrushSetting('scatter', 9999)).toBe(100);
+  });
+
+  it('wraps angle into [0, 360) modulo', () => {
+    // Replicates the legacy `setBrushAngle` shape — callers can pass
+    // a delta that goes negative or above 360 (e.g. via a wheel) and
+    // the shader gets a clean modulo-wrapped degree value.
+    expect(clampBrushSetting('angle', 0)).toBe(0);
+    expect(clampBrushSetting('angle', 45)).toBe(45);
+    expect(clampBrushSetting('angle', 360)).toBe(0);
+    expect(clampBrushSetting('angle', 720)).toBe(0);
+    expect(clampBrushSetting('angle', -90)).toBe(270);
+    expect(clampBrushSetting('angle', -450)).toBe(270);
+  });
+
+  it('clamps fade into [0, 5000]', () => {
+    expect(clampBrushSetting('fade', -1)).toBe(0);
+    expect(clampBrushSetting('fade', 250)).toBe(250);
+    expect(clampBrushSetting('fade', 99999)).toBe(5000);
+  });
+
+  it('clamps taper into [0, 5000]', () => {
+    expect(clampBrushSetting('taper', -1)).toBe(0);
+    expect(clampBrushSetting('taper', 250)).toBe(250);
+    expect(clampBrushSetting('taper', 99999)).toBe(5000);
+  });
+
+  it('preserves sub-pixel values within range', () => {
+    // Several read sites take the value through floating-point math
+    // (e.g. `brushHardness / 100` in paint-handlers) so the slice
+    // must round-trip fractional values within the clamp range.
+    expect(clampBrushSetting('size', 12.5)).toBe(12.5);
+    expect(clampBrushSetting('hardness', 33.3)).toBe(33.3);
+    expect(clampBrushSetting('spacing', 17.7)).toBe(17.7);
+  });
+});

--- a/src/tools/brush/brush-settings.ts
+++ b/src/tools/brush/brush-settings.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-tool settings slice for the Brush tool.
+ *
+ * Authoritative settings type for the brush's per-stroke dab dynamics.
+ * The slice lives under `settings.brush` on the global ToolSettings
+ * store (see #453). Same pattern as `wand-settings.ts` /
+ * `fill-settings.ts` / `marquee-settings.ts` / `smudge-settings.ts` /
+ * `pencil-settings.ts` / `sponge-settings.ts` / `eraser-settings.ts` /
+ * `path-settings.ts` / `stamp-settings.ts` /
+ * `magnetic-lasso-settings.ts` / `text-settings.ts` /
+ * `spray-settings.ts` / `healing-settings.ts`: `<Tool>Settings`
+ * interface + `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting`
+ * helper, then registered in `tool-settings-slices.ts`.
+ *
+ * Scope is the eight core dab-dynamics fields shared across every
+ * brush stroke (size, opacity, hardness, spacing, scatter, angle,
+ * fade, taper). The brush's jitter / speed / texture / tip /
+ * presets / sub-brushes still live as flat fields on the store —
+ * presets and texture lists are cross-tool infrastructure and
+ * stay at the root by design (per the issue body's "cross-tool
+ * state stays at root" note), while jitter / speed / tip move in
+ * follow-up slices.
+ *
+ * `opacity` clamps to `[1, 100]` (not `[0, 100]`) so callers can't
+ * silently get a no-op stroke — same shape as eraser / healing /
+ * spray, gated by the percent-vs-normalised warn-once dedupe in the
+ * store.
+ */
+export interface BrushSettings {
+  size: number;
+  opacity: number;
+  hardness: number;
+  spacing: number;
+  scatter: number;
+  angle: number;
+  fade: number;
+  taper: number;
+}
+
+export const DEFAULT_BRUSH_SETTINGS: BrushSettings = {
+  size: 10,
+  opacity: 100,
+  hardness: 80,
+  spacing: 0,
+  scatter: 0,
+  angle: 0,
+  fade: 0,
+  taper: 0,
+};
+
+export function clampBrushSetting<K extends keyof BrushSettings>(
+  key: K,
+  value: BrushSettings[K],
+): BrushSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(5000, n)) as BrushSettings[K];
+  }
+  if (key === 'opacity') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, n)) as BrushSettings[K];
+  }
+  if (key === 'hardness') {
+    const n = value as number;
+    return Math.max(0, Math.min(100, n)) as BrushSettings[K];
+  }
+  if (key === 'spacing') {
+    const n = value as number;
+    return Math.max(0, Math.min(200, n)) as BrushSettings[K];
+  }
+  if (key === 'scatter') {
+    const n = value as number;
+    return Math.max(0, Math.min(100, n)) as BrushSettings[K];
+  }
+  if (key === 'angle') {
+    const n = value as number;
+    return (((n % 360) + 360) % 360) as BrushSettings[K];
+  }
+  if (key === 'fade') {
+    const n = value as number;
+    return Math.max(0, Math.min(5000, n)) as BrushSettings[K];
+  }
+  if (key === 'taper') {
+    const n = value as number;
+    return Math.max(0, Math.min(5000, n)) as BrushSettings[K];
+  }
+  return value;
+}

--- a/src/tools/brush/brush-speed-settings.test.ts
+++ b/src/tools/brush/brush-speed-settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampBrushSpeedSetting,
+  DEFAULT_BRUSH_SPEED_SETTINGS,
+} from './brush-speed-settings';
+
+describe('brush-speed-settings', () => {
+  it('defaults match the legacy flat-store brush-speed defaults', () => {
+    expect(DEFAULT_BRUSH_SPEED_SETTINGS).toEqual({
+      size: 0,
+      sizeInvert: false,
+      sensitivity: 'med',
+    });
+  });
+
+  it('clamps size into [0, 300]', () => {
+    // Range matches the legacy setBrushSpeedSize: [0, 300]. The UI
+    // surfaces [0, 100] when `sizeInvert` is false and [0, 300] when
+    // it's true, but the store-level clamp is the looser bound so the
+    // UI can flip the toggle without truncating the value.
+    expect(clampBrushSpeedSetting('size', -10)).toBe(0);
+    expect(clampBrushSpeedSetting('size', 0)).toBe(0);
+    expect(clampBrushSpeedSetting('size', 100)).toBe(100);
+    expect(clampBrushSpeedSetting('size', 300)).toBe(300);
+    expect(clampBrushSpeedSetting('size', 9999)).toBe(300);
+  });
+
+  it('coerces sizeInvert to a boolean', () => {
+    expect(clampBrushSpeedSetting('sizeInvert', true)).toBe(true);
+    expect(clampBrushSpeedSetting('sizeInvert', false)).toBe(false);
+  });
+
+  it('accepts low / med / high for sensitivity and falls back to med for unknown strings', () => {
+    // brush-stroke.ts maps sensitivity to a moving-average window
+    // (low → 6, med → 3, high → 2). An unrecognised enum would leave
+    // that ternary on the `med` branch silently, so the clamp
+    // collapses unknown strings to 'med' explicitly.
+    expect(clampBrushSpeedSetting('sensitivity', 'low')).toBe('low');
+    expect(clampBrushSpeedSetting('sensitivity', 'med')).toBe('med');
+    expect(clampBrushSpeedSetting('sensitivity', 'high')).toBe('high');
+    expect(
+      clampBrushSpeedSetting(
+        'sensitivity',
+        'medium' as unknown as 'low' | 'med' | 'high',
+      ),
+    ).toBe('med');
+  });
+});

--- a/src/tools/brush/brush-speed-settings.ts
+++ b/src/tools/brush/brush-speed-settings.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-tool settings slice for the Brush "speed dynamics" sub-tool.
+ *
+ * Carved out of the flat `brushSpeed*` fields on the ToolSettings store
+ * as the brush's first sub-slice (see #453). The remaining brush
+ * sub-slices — jitter, texture, tip / presets / sub-brushes — land in
+ * follow-up PRs. The slice lives under `settings.brushSpeed` on the
+ * global store; reads go through `s.settings.brushSpeed.<field>` and
+ * writes through the typed `setBrushSpeedSetting(key, value)` setter.
+ *
+ * `sensitivity` is an enum, not a number: the brush-stroke hot path
+ * maps it to a moving-average window (low → 6, med → 3, high → 2)
+ * inside `brush-stroke.ts`. Unknown enum strings collapse to the
+ * documented default ('med') here rather than no-op silently, so a
+ * `@ts-ignore` bypass can't leave the stroke loop staring at a stale
+ * enum.
+ */
+export type BrushSpeedSensitivity = 'low' | 'med' | 'high';
+
+export interface BrushSpeedSettings {
+  size: number;
+  sizeInvert: boolean;
+  sensitivity: BrushSpeedSensitivity;
+}
+
+export const DEFAULT_BRUSH_SPEED_SETTINGS: BrushSpeedSettings = {
+  size: 0,
+  sizeInvert: false,
+  sensitivity: 'med',
+};
+
+const SENSITIVITIES: readonly BrushSpeedSensitivity[] = ['low', 'med', 'high'];
+
+export function clampBrushSpeedSetting<K extends keyof BrushSpeedSettings>(
+  key: K,
+  value: BrushSpeedSettings[K],
+): BrushSpeedSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(0, Math.min(300, n)) as BrushSpeedSettings[K];
+  }
+  if (key === 'sizeInvert') {
+    return Boolean(value) as BrushSpeedSettings[K];
+  }
+  if (key === 'sensitivity') {
+    const s = value as BrushSpeedSensitivity;
+    return (SENSITIVITIES.includes(s) ? s : 'med') as BrushSpeedSettings[K];
+  }
+  return value;
+}

--- a/src/tools/brush/brush-stroke.ts
+++ b/src/tools/brush/brush-stroke.ts
@@ -33,10 +33,10 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
   const opacity = toolSettings.brushOpacity / 100;
   const brushScatter = toolSettings.brushScatter;
   const brushFade = toolSettings.brushFade;
-  const sizeJitter = toolSettings.brushSizeJitter / 100;
-  const hardnessJitter = toolSettings.brushHardnessJitter / 100;
-  const aJ = toolSettings.brushAngleJitter / 100;
-  const oJ = toolSettings.brushOpacityJitter / 100;
+  const sizeJitter = toolSettings.settings.brushJitter.size / 100;
+  const hardnessJitter = toolSettings.settings.brushJitter.hardness / 100;
+  const aJ = toolSettings.settings.brushJitter.angle / 100;
+  const oJ = toolSettings.settings.brushJitter.opacity / 100;
   const speedSize = toolSettings.brushSpeedSize / 100;
   const color = state.strokeColor ?? useToolSettingsStore.getState().foregroundColor;
   const r = color.r / 255;

--- a/src/tools/brush/brush-stroke.ts
+++ b/src/tools/brush/brush-stroke.ts
@@ -28,11 +28,12 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
   if (!state.lastPoint || !state.layerId) return;
 
   const toolSettings = useToolSettingsStore.getState();
-  const baseSize = toolSettings.brushSize;
-  const baseHardness = toolSettings.brushHardness / 100;
-  const opacity = toolSettings.brushOpacity / 100;
-  const brushScatter = toolSettings.brushScatter;
-  const brushFade = toolSettings.brushFade;
+  const brush = toolSettings.settings.brush;
+  const baseSize = brush.size;
+  const baseHardness = brush.hardness / 100;
+  const opacity = brush.opacity / 100;
+  const brushScatter = brush.scatter;
+  const brushFade = brush.fade;
   const sizeJitter = toolSettings.brushSizeJitter / 100;
   const hardnessJitter = toolSettings.brushHardnessJitter / 100;
   const aJ = toolSettings.brushAngleJitter / 100;
@@ -82,7 +83,7 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
   size = jittered.size;
   const hardness = jittered.hardness;
 
-  const brushTaper = toolSettings.brushTaper;
+  const brushTaper = brush.taper;
   if (brushTaper > 0) {
     const taperFactor = Math.max(0, 1 - (state.strokeDistance ?? 0) / brushTaper);
     size = size * taperFactor;
@@ -92,7 +93,7 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
     }
   }
 
-  const spacing = Math.max(1, size * toolSettings.brushSpacing / 100);
+  const spacing = Math.max(1, size * brush.spacing / 100);
 
   if (brushFade > 0 && (state.strokeDistance ?? 0) >= brushFade) {
     state.lastPoint = layerLocalPos;

--- a/src/tools/brush/brush-stroke.ts
+++ b/src/tools/brush/brush-stroke.ts
@@ -37,7 +37,7 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
   const hardnessJitter = toolSettings.brushHardnessJitter / 100;
   const aJ = toolSettings.brushAngleJitter / 100;
   const oJ = toolSettings.brushOpacityJitter / 100;
-  const speedSize = toolSettings.brushSpeedSize / 100;
+  const speedSize = toolSettings.settings.brushSpeed.size / 100;
   const color = state.strokeColor ?? useToolSettingsStore.getState().foregroundColor;
   const r = color.r / 255;
   const g = color.g / 255;
@@ -56,15 +56,16 @@ export function handleBrushStroke(deps: BrushStrokeDeps): void {
     const maxSpeed = 5;
     const normalizedSpeed = Math.min(rawSpeed / maxSpeed, 1);
 
-    const maWindow = toolSettings.brushSpeedSensitivity === 'high' ? 2
-      : toolSettings.brushSpeedSensitivity === 'low' ? 6 : 3;
+    const sensitivity = toolSettings.settings.brushSpeed.sensitivity;
+    const maWindow = sensitivity === 'high' ? 2
+      : sensitivity === 'low' ? 6 : 3;
     if (!state.speedHistory) state.speedHistory = [];
     state.speedHistory.push(normalizedSpeed);
     if (state.speedHistory.length > maWindow) state.speedHistory.shift();
 
     const avgSpeed = state.speedHistory.reduce((a, b) => a + b, 0) / state.speedHistory.length;
 
-    const invert = toolSettings.brushSpeedSizeInvert;
+    const invert = toolSettings.settings.brushSpeed.sizeInvert;
     const targetScale = invert
       ? 1 + speedSize * avgSpeed
       : 1 - speedSize * avgSpeed;

--- a/src/tools/crop/crop-interaction.test.ts
+++ b/src/tools/crop/crop-interaction.test.ts
@@ -45,7 +45,9 @@ vi.mock('../../app/editor-store', () => ({
 }));
 
 const ts = {
-  cropMode: 'rect' as 'rect' | 'perspective',
+  settings: {
+    crop: { mode: 'normal' as 'normal' | 'perspective' },
+  },
   aspectRatioLocked: false,
   aspectRatioW: 1,
   aspectRatioH: 1,
@@ -103,7 +105,7 @@ beforeEach(() => {
   uiState.setPerspectiveCropDragging.mockClear();
   editorState.cropCanvas.mockClear();
   editorState.notifyRender.mockClear();
-  ts.cropMode = 'rect';
+  ts.settings.crop.mode = 'normal';
   ts.aspectRatioLocked = false;
 });
 
@@ -121,7 +123,7 @@ describe('crop down', () => {
   });
 
   it('delegates to the perspective handler in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     const state = handleCropDown(makeCtx());
     // The perspective handler seeds the quad from the full document.
     expect(uiState.setPerspectiveCropQuad).toHaveBeenCalledWith({
@@ -180,7 +182,7 @@ describe('crop move', () => {
   });
 
   it('routes to the perspective handler in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     uiState.perspectiveCropQuad = {
       topLeft: { x: 0, y: 0 },
       topRight: { x: 200, y: 0 },
@@ -219,7 +221,7 @@ describe('crop up', () => {
   });
 
   it('releases the perspective drag in perspective mode', () => {
-    ts.cropMode = 'perspective';
+    ts.settings.crop.mode = 'perspective';
     uiState.cropRect = { x: 10, y: 10, width: 50, height: 40 };
     handleCropUp(makeState());
     expect(uiState.setPerspectiveCropDragging).toHaveBeenCalledWith(null);

--- a/src/tools/crop/crop-interaction.ts
+++ b/src/tools/crop/crop-interaction.ts
@@ -11,7 +11,7 @@ import {
 } from './perspective-crop-interaction';
 
 export function handleCropDown(ctx: InteractionContext): InteractionState {
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     return handlePerspectiveCropDown(ctx);
   }
 
@@ -30,7 +30,7 @@ export function handleCropDown(ctx: InteractionContext): InteractionState {
 }
 
 export function handleCropMove(state: InteractionState, canvasPos: Point): void {
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     handlePerspectiveCropMove(state, canvasPos);
     return;
   }
@@ -61,7 +61,7 @@ export function handleCropMove(state: InteractionState, canvasPos: Point): void 
 export function handleCropUp(state: InteractionState): void {
   if (state.tool !== 'crop') return;
 
-  if (useToolSettingsStore.getState().cropMode === 'perspective') {
+  if (useToolSettingsStore.getState().settings.crop.mode === 'perspective') {
     handlePerspectiveCropUp(state);
     return;
   }

--- a/src/tools/crop/crop-settings.test.ts
+++ b/src/tools/crop/crop-settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_CROP_SETTINGS,
+  clampCropSetting,
+  type CropSettings,
+} from './crop-settings';
+
+describe('crop-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_CROP_SETTINGS).toEqual({
+      mode: 'normal',
+    } satisfies CropSettings);
+  });
+
+  it('passes through valid modes unchanged', () => {
+    expect(clampCropSetting('mode', 'normal')).toBe('normal');
+    expect(clampCropSetting('mode', 'perspective')).toBe('perspective');
+  });
+
+  it('falls back to "normal" for unknown mode values', () => {
+    // The setter is typed as CropSettings['mode'] but JS callers (and
+    // any `as` cast in TS) can pass anything. The clamp must reject
+    // unknown values so the crop dispatcher doesn't read a state that
+    // neither the rect nor the perspective handler will service.
+    expect(clampCropSetting('mode', 'rect' as CropSettings['mode'])).toBe('normal');
+    expect(clampCropSetting('mode', '' as CropSettings['mode'])).toBe('normal');
+    expect(clampCropSetting('mode', 'free' as CropSettings['mode'])).toBe('normal');
+  });
+});

--- a/src/tools/crop/crop-settings.ts
+++ b/src/tools/crop/crop-settings.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-tool settings slice for the Crop tool.
+ *
+ * Authoritative settings type for crop. The slice lives under
+ * `settings.crop` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` +
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Single discriminated field — `mode`
+ * picks between the rectangular crop and the perspective-quad crop;
+ * aspect-ratio fields stay flat for now since they are shared with
+ * Shape / Marquee / Lasso and aren't crop-owned.
+ */
+export interface CropSettings {
+  mode: 'normal' | 'perspective';
+}
+
+export const DEFAULT_CROP_SETTINGS: CropSettings = {
+  mode: 'normal',
+};
+
+export function clampCropSetting<K extends keyof CropSettings>(
+  key: K,
+  value: CropSettings[K],
+): CropSettings[K] {
+  if (key === 'mode') {
+    const v = value as CropSettings['mode'];
+    if (v !== 'normal' && v !== 'perspective') {
+      return 'normal' as CropSettings[K];
+    }
+    return v as CropSettings[K];
+  }
+  return value;
+}

--- a/src/tools/dodge/dodge-interaction.test.ts
+++ b/src/tools/dodge/dodge-interaction.test.ts
@@ -33,7 +33,9 @@ vi.mock('../../app/editor-store', () => ({
 const ts = {
   dodgeMode: 'dodge' as 'dodge' | 'burn',
   dodgeExposure: 50,
-  brushSize: 20,
+  settings: {
+    brush: { size: 20 },
+  },
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },
@@ -90,7 +92,7 @@ beforeEach(() => {
   editorState.notifyRender.mockClear();
   ts.dodgeMode = 'dodge';
   ts.dodgeExposure = 50;
-  ts.brushSize = 20;
+  ts.settings.brush.size = 20;
 });
 
 describe('dodge down', () => {

--- a/src/tools/dodge/dodge-interaction.ts
+++ b/src/tools/dodge/dodge-interaction.ts
@@ -29,7 +29,7 @@ export function handleDodgeDown(ctx: InteractionContext): InteractionState {
   const dodgeMode = toolSettings.dodgeMode;
   editorState.pushHistory(dodgeMode === 'dodge' ? 'Dodge' : 'Burn');
   const exposure = toolSettings.dodgeExposure / 100;
-  const dodgeSize = toolSettings.brushSize;
+  const dodgeSize = toolSettings.settings.brush.size;
   const dodgeShiftLine = shiftKey
     && ctx.lastPaintPointRef.current
     && ctx.lastPaintPointRef.current.layerId === activeLayerId;
@@ -65,7 +65,7 @@ export function handleDodgeMove(state: InteractionState, layerLocalPos: Point): 
   if (!state.lastPoint) return;
   const toolSettings = useToolSettingsStore.getState();
   const exposure = toolSettings.dodgeExposure / 100;
-  const dodgeSize = toolSettings.brushSize;
+  const dodgeSize = toolSettings.settings.brush.size;
   const dodgeSpacing = Math.max(1, dodgeSize * 0.25);
 
   const engine = getEngine();

--- a/src/tools/gradient/gradient-interaction.test.ts
+++ b/src/tools/gradient/gradient-interaction.test.ts
@@ -64,12 +64,16 @@ vi.mock('../../app/ui-store', () => ({
 }));
 
 const ts = {
-  gradientType: 'linear' as 'linear' | 'radial',
-  gradientStops: [
-    { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
-    { position: 1, color: { r: 255, g: 255, b: 255, a: 0 } },
-  ],
-  gradientReverse: false,
+  settings: {
+    gradient: {
+      type: 'linear' as 'linear' | 'radial',
+      stops: [
+        { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+        { position: 1, color: { r: 255, g: 255, b: 255, a: 0 } },
+      ],
+      reverse: false,
+    },
+  },
   foregroundColor: { r: 0, g: 0, b: 0, a: 1 },
   backgroundColor: { r: 255, g: 255, b: 255, a: 0 },
   addRecentColor: vi.fn(),
@@ -121,7 +125,7 @@ describe('gradient drag lifecycle (issue #338)', () => {
     uiStateValues.gradientPreview = null;
     uiStateValues.isQuickMaskMode = false;
     uiStateValues.maskEditMode = false;
-    ts.gradientType = 'linear';
+    ts.settings.gradient.type = 'linear';
   });
 
   afterEach(() => {
@@ -212,7 +216,7 @@ describe('gradient on quick mask (issue #329)', () => {
     uiStateValues.gradientPreview = null;
     uiStateValues.isQuickMaskMode = false;
     uiStateValues.maskEditMode = false;
-    ts.gradientType = 'linear';
+    ts.settings.gradient.type = 'linear';
   });
 
   afterEach(() => {
@@ -233,7 +237,7 @@ describe('gradient on quick mask (issue #329)', () => {
 
   it('routes linear gradient to renderQuickMaskLinearGradient in quick-mask mode', () => {
     uiStateValues.isQuickMaskMode = true;
-    ts.gradientType = 'linear';
+    ts.settings.gradient.type = 'linear';
     const state = handleGradientDown(makeCtx());
     handleGradientMove(state, { x: 50, y: 80 });
     expect(renderQuickMaskLinearGradient).toHaveBeenCalledTimes(1);
@@ -243,7 +247,7 @@ describe('gradient on quick mask (issue #329)', () => {
 
   it('routes radial gradient to renderQuickMaskRadialGradient in quick-mask mode', () => {
     uiStateValues.isQuickMaskMode = true;
-    ts.gradientType = 'radial';
+    ts.settings.gradient.type = 'radial';
     const state = handleGradientDown(makeCtx());
     handleGradientMove(state, { x: 50, y: 80 });
     expect(renderQuickMaskRadialGradient).toHaveBeenCalledTimes(1);
@@ -273,12 +277,12 @@ describe('gradient on quick mask (issue #329)', () => {
 
   it('records a quick-mask history label on down', () => {
     uiStateValues.isQuickMaskMode = true;
-    ts.gradientType = 'linear';
+    ts.settings.gradient.type = 'linear';
     handleGradientDown(makeCtx());
     expect(editorState.pushHistory).toHaveBeenCalledWith('Quick Mask Linear Gradient');
 
     editorState.pushHistory.mockClear();
-    ts.gradientType = 'radial';
+    ts.settings.gradient.type = 'radial';
     handleGradientDown(makeCtx());
     expect(editorState.pushHistory).toHaveBeenCalledWith('Quick Mask Radial Gradient');
   });

--- a/src/tools/gradient/gradient-interaction.ts
+++ b/src/tools/gradient/gradient-interaction.ts
@@ -30,16 +30,17 @@ export function handleGradientDown(ctx: InteractionContext): InteractionState {
 
   const engine = getEngine();
 
+  const gradientType = ts.settings.gradient.type;
   if (isQuickMaskMode) {
-    editorState.pushHistory(ts.gradientType === 'radial' ? 'Quick Mask Radial Gradient' : 'Quick Mask Linear Gradient');
+    editorState.pushHistory(gradientType === 'radial' ? 'Quick Mask Radial Gradient' : 'Quick Mask Linear Gradient');
   } else if (maskEditMode && activeLayer.mask) {
-    editorState.pushHistory(ts.gradientType === 'radial' ? 'Mask Radial Gradient' : 'Mask Linear Gradient');
+    editorState.pushHistory(gradientType === 'radial' ? 'Mask Radial Gradient' : 'Mask Linear Gradient');
     if (engine) {
       const maskBytes = new Uint8Array(activeLayer.mask.data.buffer, activeLayer.mask.data.byteOffset, activeLayer.mask.data.byteLength);
       uploadLayerMask(engine, activeLayerId, maskBytes, activeLayer.mask.width, activeLayer.mask.height);
     }
   } else {
-    editorState.pushHistory(ts.gradientType === 'radial' ? 'Radial Gradient' : 'Linear Gradient');
+    editorState.pushHistory(gradientType === 'radial' ? 'Radial Gradient' : 'Linear Gradient');
   }
   ts.addRecentColor(ts.foregroundColor);
   ts.addRecentColor(ts.backgroundColor);
@@ -101,13 +102,13 @@ export function handleGradientMove(state: InteractionState, layerLocalPos: Point
   if (!state.startPoint || !state.layerId) return;
 
   const toolSettings = useToolSettingsStore.getState();
-  const gradType = toolSettings.gradientType;
-  const reverse = toolSettings.gradientReverse;
+  const gradType = toolSettings.settings.gradient.type;
+  const reverse = toolSettings.settings.gradient.reverse;
 
   const engine = getEngine();
   if (!engine) return;
 
-  const stops = toolSettings.gradientStops.map((s) => ({
+  const stops = toolSettings.settings.gradient.stops.map((s) => ({
     position: reverse ? 1 - s.position : s.position,
     r: s.color.r / 255,
     g: s.color.g / 255,

--- a/src/tools/gradient/gradient-settings.test.ts
+++ b/src/tools/gradient/gradient-settings.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_GRADIENT_SETTINGS,
+  MAX_GRADIENT_STOPS,
+  MIN_GRADIENT_STOPS,
+  appendGradientStop,
+  clampGradientSetting,
+  removeGradientStopAt,
+  updateGradientStopAt,
+  type GradientSettings,
+} from './gradient-settings';
+
+describe('gradient-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_GRADIENT_SETTINGS).toEqual({
+      type: 'linear',
+      stops: [
+        { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+        { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+      ],
+      reverse: false,
+    } satisfies GradientSettings);
+  });
+
+  describe('clampGradientSetting — type', () => {
+    it('passes the valid enum values through untouched', () => {
+      expect(clampGradientSetting('type', 'linear')).toBe('linear');
+      expect(clampGradientSetting('type', 'radial')).toBe('radial');
+    });
+
+    it('collapses unknown strings to linear (same shape as the shape slice #623)', () => {
+      // A typed-string @ts-ignore bypass — e.g. legacy code reaching for
+      // 'conic' or an empty string — must not leave the GPU dispatch
+      // staring at a stale enum. Collapse to the documented default.
+      expect(clampGradientSetting('type', 'conic' as 'linear' | 'radial')).toBe('linear');
+      expect(clampGradientSetting('type', '' as 'linear' | 'radial')).toBe('linear');
+    });
+  });
+
+  describe('clampGradientSetting — reverse', () => {
+    it('passes booleans through untouched', () => {
+      expect(clampGradientSetting('reverse', true)).toBe(true);
+      expect(clampGradientSetting('reverse', false)).toBe(false);
+    });
+  });
+
+  describe('clampGradientSetting — stops', () => {
+    it('passes a normal 2-stop list through untouched (already sorted, in range)', () => {
+      const stops = [
+        { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+        { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+      ];
+      expect(clampGradientSetting('stops', stops)).toEqual(stops);
+    });
+
+    it('pads a 0-stop list up to the minimum count', () => {
+      const clamped = clampGradientSetting('stops', []);
+      expect(clamped.length).toBe(MIN_GRADIENT_STOPS);
+    });
+
+    it('pads a 1-stop list up to the minimum count', () => {
+      const clamped = clampGradientSetting('stops', [
+        { position: 0.5, color: { r: 200, g: 100, b: 50, a: 1 } },
+      ]);
+      expect(clamped.length).toBe(MIN_GRADIENT_STOPS);
+      // The original stop is preserved.
+      expect(clamped.some((s) => s.color.r === 200)).toBe(true);
+    });
+
+    it('slices to the maximum count (the GPU dispatch uniform cap)', () => {
+      const tooMany = Array.from({ length: MAX_GRADIENT_STOPS + 5 }, (_, i) => ({
+        position: i / (MAX_GRADIENT_STOPS + 4),
+        color: { r: i, g: 0, b: 0, a: 1 },
+      }));
+      const clamped = clampGradientSetting('stops', tooMany);
+      expect(clamped.length).toBe(MAX_GRADIENT_STOPS);
+    });
+
+    it('clamps per-stop positions into [0, 1]', () => {
+      const clamped = clampGradientSetting('stops', [
+        { position: -0.5, color: { r: 0, g: 0, b: 0, a: 1 } },
+        { position: 1.5, color: { r: 255, g: 255, b: 255, a: 1 } },
+      ]);
+      expect(clamped[0]!.position).toBe(0);
+      expect(clamped[1]!.position).toBe(1);
+    });
+
+    it('sorts by position so consumers can interval-walk without re-sorting', () => {
+      const clamped = clampGradientSetting('stops', [
+        { position: 0.8, color: { r: 0, g: 0, b: 255, a: 1 } },
+        { position: 0.2, color: { r: 255, g: 0, b: 0, a: 1 } },
+        { position: 0.5, color: { r: 0, g: 255, b: 0, a: 1 } },
+      ]);
+      expect(clamped.map((s) => s.position)).toEqual([0.2, 0.5, 0.8]);
+    });
+  });
+});
+
+describe('gradient stop operations (#453)', () => {
+  const base = [
+    { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+    { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+  ];
+
+  describe('appendGradientStop', () => {
+    it('inserts a stop at the requested position and re-sorts', () => {
+      const next = appendGradientStop(base, 0.5, { r: 128, g: 128, b: 128, a: 1 });
+      expect(next.length).toBe(3);
+      expect(next.map((s) => s.position)).toEqual([0, 0.5, 1]);
+      expect(next[1]!.color.r).toBe(128);
+    });
+
+    it('clamps position into [0, 1]', () => {
+      const aboveOne = appendGradientStop(base, 5, { r: 0, g: 0, b: 0, a: 1 });
+      expect(aboveOne[aboveOne.length - 1]!.position).toBe(1);
+
+      const belowZero = appendGradientStop(base, -5, { r: 0, g: 0, b: 0, a: 1 });
+      expect(belowZero[0]!.position).toBe(0);
+    });
+
+    it('rejects when the list is already at the max', () => {
+      const full = Array.from({ length: MAX_GRADIENT_STOPS }, (_, i) => ({
+        position: i / (MAX_GRADIENT_STOPS - 1),
+        color: { r: 0, g: 0, b: 0, a: 1 },
+      }));
+      const next = appendGradientStop(full, 0.5, { r: 255, g: 255, b: 255, a: 1 });
+      expect(next).toBe(full);
+    });
+  });
+
+  describe('removeGradientStopAt', () => {
+    it('removes the stop at the requested index', () => {
+      const threeStop = [
+        ...base.slice(0, 1),
+        { position: 0.5, color: { r: 128, g: 128, b: 128, a: 1 } },
+        ...base.slice(1),
+      ];
+      const next = removeGradientStopAt(threeStop, 1);
+      expect(next.length).toBe(2);
+      expect(next.map((s) => s.position)).toEqual([0, 1]);
+    });
+
+    it('rejects when removing would drop the list below the minimum', () => {
+      const next = removeGradientStopAt(base, 0);
+      expect(next).toBe(base);
+    });
+  });
+
+  describe('updateGradientStopAt', () => {
+    it('patches position and color at the requested index', () => {
+      const next = updateGradientStopAt(base, 1, {
+        position: 0.75,
+        color: { r: 200, g: 200, b: 200, a: 1 },
+      });
+      expect(next[1]!.position).toBe(0.75);
+      expect(next[1]!.color.r).toBe(200);
+    });
+
+    it('preserves the existing field when partial omits it', () => {
+      const next = updateGradientStopAt(base, 0, { position: 0.1 });
+      expect(next[0]!.position).toBe(0.1);
+      expect(next[0]!.color.r).toBe(0);
+    });
+
+    it('clamps patched position into [0, 1]', () => {
+      const next = updateGradientStopAt(base, 1, { position: 2 });
+      expect(next[next.length - 1]!.position).toBe(1);
+    });
+
+    it('re-sorts so moving a stop past its neighbour reorders rather than producing a flat band', () => {
+      const threeStop = [
+        { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+        { position: 0.5, color: { r: 128, g: 128, b: 128, a: 1 } },
+        { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+      ];
+      // Move the middle stop past the right end — the result must
+      // still be monotonic. The clamp pulls 1.5 → 1, then the sort
+      // reorders so the gradient interpolates correctly rather than
+      // producing a flat band at the swap point.
+      const next = updateGradientStopAt(threeStop, 1, { position: 1.5 });
+      expect(next.map((s) => s.position)).toEqual([0, 1, 1]);
+    });
+  });
+});

--- a/src/tools/gradient/gradient-settings.ts
+++ b/src/tools/gradient/gradient-settings.ts
@@ -1,0 +1,145 @@
+import type { Color } from '../../types';
+import type { GradientStop, GradientType } from './gradient';
+
+/**
+ * Per-tool settings slice for the Gradient tool.
+ *
+ * Authoritative settings type for gradient. The slice lives under
+ * `settings.gradient` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Three fields: the `type` enum, the `stops`
+ * list (length and per-stop position both clamped), and a `reverse`
+ * boolean.
+ *
+ * `type` collapses unknown strings to `'linear'` rather than no-opping
+ * silently — same shape as the `shape` slice (#623) where the legacy
+ * setter early-returned on invalid input. A typed-string `@ts-ignore`
+ * bypass can't leave the GPU dispatch staring at a stale enum.
+ *
+ * `stops` clamps:
+ *   - Below 2 stops: pad with `{ position: i, color: opaque black }` —
+ *     the gradient shaders require at least two stops to interpolate.
+ *   - Above 16 stops: slice. 16 matches `MAX_GRADIENT_STOPS` in the
+ *     GPU dispatch — beyond that the uniform buffer overflows.
+ *   - Per-stop position into `[0, 1]`.
+ *   - Sorted by position so consumers can binary-search the interval
+ *     without re-sorting.
+ */
+export const MIN_GRADIENT_STOPS = 2;
+export const MAX_GRADIENT_STOPS = 16;
+
+export interface GradientSettings {
+  readonly type: GradientType;
+  readonly stops: readonly GradientStop[];
+  readonly reverse: boolean;
+}
+
+export const DEFAULT_GRADIENT_SETTINGS: GradientSettings = {
+  type: 'linear',
+  stops: [
+    { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
+    { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
+  ],
+  reverse: false,
+};
+
+function clampStops(stops: readonly GradientStop[]): readonly GradientStop[] {
+  const padded: GradientStop[] = stops.length < MIN_GRADIENT_STOPS
+    ? [
+        ...stops,
+        ...Array.from(
+          { length: MIN_GRADIENT_STOPS - stops.length },
+          (_, i): GradientStop => ({
+            position: stops.length + i,
+            color: { r: 0, g: 0, b: 0, a: 1 },
+          }),
+        ),
+      ]
+    : stops.slice(0, MAX_GRADIENT_STOPS);
+  const clamped: GradientStop[] = padded.map((s) => ({
+    position: Math.max(0, Math.min(1, s.position)),
+    color: s.color,
+  }));
+  clamped.sort((a, b) => a.position - b.position);
+  return clamped;
+}
+
+export function clampGradientSetting<K extends keyof GradientSettings>(
+  key: K,
+  value: GradientSettings[K],
+): GradientSettings[K] {
+  if (key === 'type') {
+    const t = value as GradientType;
+    if (t !== 'linear' && t !== 'radial') {
+      return 'linear' as GradientSettings[K];
+    }
+    return value;
+  }
+  if (key === 'stops') {
+    return clampStops(value as readonly GradientStop[]) as GradientSettings[K];
+  }
+  return value;
+}
+
+/**
+ * Append a stop to an existing stop list. Used by the gradient editor's
+ * "add stop" affordances. Rejects if the list is already at the max —
+ * the GPU dispatch has a fixed-size stop uniform — and clamps the new
+ * stop's position into `[0, 1]`. The result is re-sorted so consumers
+ * can binary-search the interval without re-sorting.
+ */
+export function appendGradientStop(
+  stops: readonly GradientStop[],
+  position: number,
+  color: Color,
+): readonly GradientStop[] {
+  if (stops.length >= MAX_GRADIENT_STOPS) return stops;
+  const newStop: GradientStop = {
+    position: Math.max(0, Math.min(1, position)),
+    color,
+  };
+  const next = [...stops, newStop];
+  next.sort((a, b) => a.position - b.position);
+  return next;
+}
+
+/**
+ * Remove the stop at `index`. Rejects if removing would drop the list
+ * below the minimum — the gradient shaders require at least two stops.
+ */
+export function removeGradientStopAt(
+  stops: readonly GradientStop[],
+  index: number,
+): readonly GradientStop[] {
+  if (stops.length <= MIN_GRADIENT_STOPS) return stops;
+  return stops.filter((_, i) => i !== index);
+}
+
+/**
+ * Patch the stop at `index` with a partial. Position is clamped into
+ * `[0, 1]`; color (if present) overwrites. Re-sorts so moving a stop
+ * past its neighbour reorders the list rather than producing a
+ * non-monotonic gradient (which would render with a flat band).
+ */
+export function updateGradientStopAt(
+  stops: readonly GradientStop[],
+  index: number,
+  partial: Partial<GradientStop>,
+): readonly GradientStop[] {
+  const next = stops.map((stop, i) => {
+    if (i !== index) return stop;
+    return {
+      position: partial.position !== undefined
+        ? Math.max(0, Math.min(1, partial.position))
+        : stop.position,
+      color: partial.color ?? stop.color,
+    };
+  });
+  return [...next].sort((a, b) => a.position - b.position);
+}

--- a/src/tools/gradient/gradient.test.ts
+++ b/src/tools/gradient/gradient.test.ts
@@ -3,16 +3,7 @@ import {
   interpolateGradient,
   computeLinearGradientT,
   computeRadialGradientT,
-  defaultGradientSettings,
 } from './gradient';
-
-describe('defaultGradientSettings', () => {
-  it('returns black to white linear gradient', () => {
-    const s = defaultGradientSettings();
-    expect(s.type).toBe('linear');
-    expect(s.stops.length).toBe(2);
-  });
-});
 
 describe('interpolateGradient', () => {
   const stops = [

--- a/src/tools/gradient/gradient.ts
+++ b/src/tools/gradient/gradient.ts
@@ -7,23 +7,6 @@ export interface GradientStop {
   readonly color: Color;
 }
 
-export interface GradientSettings {
-  readonly type: GradientType;
-  readonly stops: readonly GradientStop[];
-  readonly reverse: boolean;
-}
-
-export function defaultGradientSettings(): GradientSettings {
-  return {
-    type: 'linear',
-    stops: [
-      { position: 0, color: { r: 0, g: 0, b: 0, a: 1 } },
-      { position: 1, color: { r: 255, g: 255, b: 255, a: 1 } },
-    ],
-    reverse: false,
-  };
-}
-
 export function interpolateGradient(stops: readonly GradientStop[], t: number): Color {
   if (stops.length === 0) return { r: 0, g: 0, b: 0, a: 0 };
   if (stops.length === 1) return stops[0]!.color;

--- a/src/tools/quick-select/QuickSelectOptions.tsx
+++ b/src/tools/quick-select/QuickSelectOptions.tsx
@@ -3,26 +3,23 @@ import { Slider } from '../../components/Slider/Slider';
 import styles from '../../app/OptionsBar/OptionsBar.module.css';
 
 export function QuickSelectOptions() {
-  const size = useToolSettingsStore((s) => s.quickSelectSize);
-  const tolerance = useToolSettingsStore((s) => s.quickSelectTolerance);
-  const edgeStrength = useToolSettingsStore((s) => s.quickSelectEdgeStrength);
-  const mode = useToolSettingsStore((s) => s.quickSelectMode);
-  const setSize = useToolSettingsStore((s) => s.setQuickSelectSize);
-  const setTolerance = useToolSettingsStore((s) => s.setQuickSelectTolerance);
-  const setEdgeStrength = useToolSettingsStore((s) => s.setQuickSelectEdgeStrength);
-  const setMode = useToolSettingsStore((s) => s.setQuickSelectMode);
+  const size = useToolSettingsStore((s) => s.settings.quickSelect.size);
+  const tolerance = useToolSettingsStore((s) => s.settings.quickSelect.tolerance);
+  const edgeStrength = useToolSettingsStore((s) => s.settings.quickSelect.edgeStrength);
+  const mode = useToolSettingsStore((s) => s.settings.quickSelect.mode);
+  const setQuickSelectSetting = useToolSettingsStore((s) => s.setQuickSelectSetting);
 
   return (
     <>
-      <Slider label="Size" value={size} min={1} max={100} onChange={setSize} />
-      <Slider label="Tolerance" value={tolerance} min={0} max={255} onChange={setTolerance} />
-      <Slider label="Edge Strength" value={edgeStrength} min={0} max={100} onChange={setEdgeStrength} />
+      <Slider label="Size" value={size} min={1} max={100} onChange={(v) => setQuickSelectSetting('size', v)} />
+      <Slider label="Tolerance" value={tolerance} min={0} max={255} onChange={(v) => setQuickSelectSetting('tolerance', v)} />
+      <Slider label="Edge Strength" value={edgeStrength} min={0} max={100} onChange={(v) => setQuickSelectSetting('edgeStrength', v)} />
       <label className={styles.checkbox}>
         <input
           type="radio"
           name="quick-select-mode"
           checked={mode === 'add'}
-          onChange={() => setMode('add')}
+          onChange={() => setQuickSelectSetting('mode', 'add')}
         />
         Add
       </label>
@@ -31,7 +28,7 @@ export function QuickSelectOptions() {
           type="radio"
           name="quick-select-mode"
           checked={mode === 'subtract'}
-          onChange={() => setMode('subtract')}
+          onChange={() => setQuickSelectSetting('mode', 'subtract')}
         />
         Subtract
       </label>

--- a/src/tools/quick-select/quick-select-interaction.test.ts
+++ b/src/tools/quick-select/quick-select-interaction.test.ts
@@ -39,10 +39,14 @@ vi.mock('../../app/ui-store', () => ({
 }));
 
 const ts = {
-  quickSelectSize: 3,
-  quickSelectTolerance: 32,
-  quickSelectEdgeStrength: 0,
-  quickSelectMode: 'add' as 'add' | 'subtract',
+  settings: {
+    quickSelect: {
+      size: 3,
+      tolerance: 32,
+      edgeStrength: 0,
+      mode: 'add' as 'add' | 'subtract',
+    },
+  },
 };
 vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },
@@ -127,8 +131,8 @@ beforeEach(() => {
   editorState.clearSelection.mockClear();
   editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
   uiState.setTransform.mockClear();
-  ts.quickSelectMode = 'add';
-  ts.quickSelectTolerance = 32;
+  ts.settings.quickSelect.mode = 'add';
+  ts.settings.quickSelect.tolerance = 32;
   // Clear the module-level stroke session from any previous test.
   handleQuickSelectUp();
 });
@@ -184,7 +188,7 @@ describe('quick select down', () => {
   });
 
   it('subtract mode removes the clicked region from a prior selection', () => {
-    ts.quickSelectMode = 'subtract';
+    ts.settings.quickSelect.mode = 'subtract';
     const prior = new Uint8ClampedArray(DOC_W * DOC_H).fill(255);
     editorState.selection = {
       active: true,
@@ -204,7 +208,7 @@ describe('quick select down', () => {
   });
 
   it('clears the selection when subtracting leaves nothing', () => {
-    ts.quickSelectMode = 'subtract';
+    ts.settings.quickSelect.mode = 'subtract';
     const prior = new Uint8ClampedArray(DOC_W * DOC_H);
     for (let y = 0; y < 6; y++) {
       for (let x = 0; x < DOC_W; x++) prior[y * DOC_W + x] = 255;

--- a/src/tools/quick-select/quick-select-interaction.ts
+++ b/src/tools/quick-select/quick-select-interaction.ts
@@ -47,7 +47,7 @@ export function handleQuickSelectDown(ctx: InteractionContext): InteractionState
     return undefined;
   }
 
-  const settings = useToolSettingsStore.getState();
+  const { quickSelect } = useToolSettingsStore.getState().settings;
   const priorMask = editorState.selection.mask
     ? new Uint8ClampedArray(editorState.selection.mask)
     : null;
@@ -61,14 +61,14 @@ export function handleQuickSelectDown(ctx: InteractionContext): InteractionState
       pixels: new Uint8ClampedArray(rawPixels.buffer, rawPixels.byteOffset, rawPixels.byteLength),
       width: docW,
       height: docH,
-      radius: settings.quickSelectSize,
-      tolerance: settings.quickSelectTolerance,
-      edgeStrength: settings.quickSelectEdgeStrength,
+      radius: quickSelect.size,
+      tolerance: quickSelect.tolerance,
+      edgeStrength: quickSelect.edgeStrength,
     },
     {
       points: [canvasPos],
       existingMask: strokeMask,
-      mode: settings.quickSelectMode,
+      mode: quickSelect.mode,
     },
   );
 
@@ -107,7 +107,7 @@ export function handleQuickSelectMove(
 ): void {
   if (!session || !state.lastPoint) return;
 
-  const settings = useToolSettingsStore.getState();
+  const { quickSelect } = useToolSettingsStore.getState().settings;
   const editorState = useEditorStore.getState();
 
   const updatedMask = applyQuickSelectStroke(
@@ -115,14 +115,14 @@ export function handleQuickSelectMove(
       pixels: session.pixels,
       width: session.docWidth,
       height: session.docHeight,
-      radius: settings.quickSelectSize,
-      tolerance: settings.quickSelectTolerance,
-      edgeStrength: settings.quickSelectEdgeStrength,
+      radius: quickSelect.size,
+      tolerance: quickSelect.tolerance,
+      edgeStrength: quickSelect.edgeStrength,
     },
     {
       points: [canvasPos],
       existingMask: session.strokeMask,
-      mode: settings.quickSelectMode,
+      mode: quickSelect.mode,
     },
   );
 

--- a/src/tools/quick-select/quick-select-settings.test.ts
+++ b/src/tools/quick-select/quick-select-settings.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { clampQuickSelectSetting, DEFAULT_QUICK_SELECT_SETTINGS } from './quick-select-settings';
+
+describe('quick-select-settings', () => {
+  it('defaults match the legacy flat-store quick-select defaults', () => {
+    expect(DEFAULT_QUICK_SELECT_SETTINGS).toEqual({
+      size: 20,
+      tolerance: 32,
+      edgeStrength: 50,
+      mode: 'add',
+    });
+  });
+
+  it('clamps size into [1, 100] and rounds', () => {
+    expect(clampQuickSelectSetting('size', 0)).toBe(1);
+    expect(clampQuickSelectSetting('size', -100)).toBe(1);
+    expect(clampQuickSelectSetting('size', 1)).toBe(1);
+    expect(clampQuickSelectSetting('size', 50)).toBe(50);
+    expect(clampQuickSelectSetting('size', 100)).toBe(100);
+    expect(clampQuickSelectSetting('size', 999)).toBe(100);
+    expect(clampQuickSelectSetting('size', 12.4)).toBe(12);
+    expect(clampQuickSelectSetting('size', 12.6)).toBe(13);
+  });
+
+  it('clamps tolerance into the 0–255 byte range (not 0–100 percent) and rounds', () => {
+    // Tolerance lives in the same units as RGBA channels because the
+    // stroke compares pixel deltas against it directly.
+    expect(clampQuickSelectSetting('tolerance', -10)).toBe(0);
+    expect(clampQuickSelectSetting('tolerance', 0)).toBe(0);
+    expect(clampQuickSelectSetting('tolerance', 128)).toBe(128);
+    expect(clampQuickSelectSetting('tolerance', 255)).toBe(255);
+    expect(clampQuickSelectSetting('tolerance', 9999)).toBe(255);
+    expect(clampQuickSelectSetting('tolerance', 60.6)).toBe(61);
+  });
+
+  it('clamps edgeStrength into [0, 100] and rounds', () => {
+    expect(clampQuickSelectSetting('edgeStrength', -10)).toBe(0);
+    expect(clampQuickSelectSetting('edgeStrength', 0)).toBe(0);
+    expect(clampQuickSelectSetting('edgeStrength', 50)).toBe(50);
+    expect(clampQuickSelectSetting('edgeStrength', 100)).toBe(100);
+    expect(clampQuickSelectSetting('edgeStrength', 999)).toBe(100);
+    expect(clampQuickSelectSetting('edgeStrength', 42.3)).toBe(42);
+  });
+
+  it('normalises mode to a known tag, collapsing unknown values to add', () => {
+    expect(clampQuickSelectSetting('mode', 'add')).toBe('add');
+    expect(clampQuickSelectSetting('mode', 'subtract')).toBe('subtract');
+    // Unknown strings collapse to 'add' rather than silently passing
+    // through — guards against a typed-string @ts-ignore bypass leaving
+    // the selection in an unhandled state.
+    expect(
+      (clampQuickSelectSetting as (k: 'mode', v: string) => string)('mode', 'replace'),
+    ).toBe('add');
+  });
+});

--- a/src/tools/quick-select/quick-select-settings.ts
+++ b/src/tools/quick-select/quick-select-settings.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-tool settings slice for the Quick Selection tool.
+ *
+ * Authoritative settings type for quick-select. The slice lives under
+ * `settings.quickSelect` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts`: `<Tool>Settings`
+ * interface + `DEFAULT_<TOOL>_SETTINGS` + a `clamp<Tool>Setting` helper,
+ * then registered in `tool-settings-slices.ts`.
+ *
+ * Three rounded numeric fields with different clamp ranges plus one
+ * enum mode field — the first slice on the assistant-selection tool
+ * class to mix a tagged-union enum with numeric ranges, and the first
+ * slice carrying a 0–255 byte range (`tolerance` lives in the same
+ * units as RGBA channels because the stroke compares pixel deltas
+ * against it directly).
+ */
+export type QuickSelectMode = 'add' | 'subtract';
+
+export interface QuickSelectSettings {
+  size: number;
+  tolerance: number;
+  edgeStrength: number;
+  mode: QuickSelectMode;
+}
+
+export const DEFAULT_QUICK_SELECT_SETTINGS: QuickSelectSettings = {
+  size: 20,
+  tolerance: 32,
+  edgeStrength: 50,
+  mode: 'add',
+};
+
+export function clampQuickSelectSetting<K extends keyof QuickSelectSettings>(
+  key: K,
+  value: QuickSelectSettings[K],
+): QuickSelectSettings[K] {
+  if (key === 'size') {
+    const n = value as number;
+    return Math.max(1, Math.min(100, Math.round(n))) as QuickSelectSettings[K];
+  }
+  if (key === 'tolerance') {
+    const n = value as number;
+    return Math.max(0, Math.min(255, Math.round(n))) as QuickSelectSettings[K];
+  }
+  if (key === 'edgeStrength') {
+    const n = value as number;
+    return Math.max(0, Math.min(100, Math.round(n))) as QuickSelectSettings[K];
+  }
+  if (key === 'mode') {
+    const m = value as QuickSelectMode;
+    return (m === 'subtract' ? 'subtract' : 'add') as QuickSelectSettings[K];
+  }
+  return value;
+}

--- a/src/tools/shape/shape-interaction.test.ts
+++ b/src/tools/shape/shape-interaction.test.ts
@@ -75,13 +75,17 @@ vi.mock('../../app/ui-store', () => ({
 import type { Color } from '../../types';
 
 const ts = {
-  shapeMode: 'ellipse' as 'ellipse' | 'polygon',
-  shapeOutput: 'pixels' as 'pixels' | 'path',
-  shapeFillColor: { r: 255, g: 0, b: 0, a: 1 } as Color | null,
-  shapeStrokeColor: { r: 0, g: 0, b: 255, a: 0.5 } as Color | null,
-  shapeStrokeWidth: 2,
-  shapePolygonSides: 5,
-  shapeCornerRadius: 0,
+  settings: {
+    shape: {
+      mode: 'ellipse' as 'ellipse' | 'polygon',
+      output: 'pixels' as 'pixels' | 'path',
+      fillColor: { r: 255, g: 0, b: 0, a: 1 } as Color | null,
+      strokeColor: { r: 0, g: 0, b: 255, a: 0.5 } as Color | null,
+      strokeWidth: 2,
+      polygonSides: 5,
+      cornerRadius: 0,
+    },
+  },
   aspectRatioLocked: false,
   aspectRatioW: 1,
   aspectRatioH: 1,
@@ -160,13 +164,13 @@ beforeEach(() => {
   editorState.addPath.mockClear();
   setState.mockClear();
   uiState.setPendingShapeClick.mockClear();
-  ts.shapeMode = 'ellipse';
-  ts.shapeOutput = 'pixels';
-  ts.shapeFillColor = { r: 255, g: 0, b: 0, a: 1 };
-  ts.shapeStrokeColor = { r: 0, g: 0, b: 255, a: 0.5 };
-  ts.shapeStrokeWidth = 2;
-  ts.shapePolygonSides = 5;
-  ts.shapeCornerRadius = 0;
+  ts.settings.shape.mode = 'ellipse';
+  ts.settings.shape.output = 'pixels';
+  ts.settings.shape.fillColor = { r: 255, g: 0, b: 0, a: 1 };
+  ts.settings.shape.strokeColor = { r: 0, g: 0, b: 255, a: 0.5 };
+  ts.settings.shape.strokeWidth = 2;
+  ts.settings.shape.polygonSides = 5;
+  ts.settings.shape.cornerRadius = 0;
   ts.aspectRatioLocked = false;
   ts.addRecentColor.mockClear();
 });
@@ -189,8 +193,8 @@ describe('shape down', () => {
   });
 
   it('does not record recent colors when fill and stroke are disabled', () => {
-    ts.shapeFillColor = null;
-    ts.shapeStrokeColor = null;
+    ts.settings.shape.fillColor = null;
+    ts.settings.shape.strokeColor = null;
     handleShapeDown(makeCtx());
     expect(ts.addRecentColor).not.toHaveBeenCalled();
   });
@@ -239,7 +243,7 @@ describe('shape move', () => {
   });
 
   it('renders polygons with mode 1', () => {
-    ts.shapeMode = 'polygon';
+    ts.settings.shape.mode = 'polygon';
     handleShapeMove(makeState(), { x: 80, y: 70 });
     expect(renderShape.mock.calls[0]![2]).toBe(1);
   });
@@ -264,14 +268,14 @@ describe('shape move', () => {
   });
 
   it('caps the corner radius at half the smaller dimension', () => {
-    ts.shapeCornerRadius = 50;
+    ts.settings.shape.cornerRadius = 50;
     handleShapeMove(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 60 });
     // w 60, h 20 => cap is 10.
     expect(renderShape.mock.calls[0]![17]).toBe(10);
   });
 
   it('renders a transparent fill when the fill color is disabled', () => {
-    ts.shapeFillColor = null;
+    ts.settings.shape.fillColor = null;
     handleShapeMove(makeState(), { x: 80, y: 70 });
     const args = renderShape.mock.calls[0]!;
     expect(args[7]).toBe(0);
@@ -314,7 +318,7 @@ describe('shape up — click vs drag', () => {
   });
 
   it('a click in path-output mode undoes without opening the size modal', () => {
-    ts.shapeOutput = 'path';
+    ts.settings.shape.output = 'path';
     handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 51, y: 51 });
     expect(editorState.undo).toHaveBeenCalledTimes(1);
     expect(uiState.setPendingShapeClick).not.toHaveBeenCalled();
@@ -383,7 +387,7 @@ describe('shape up — committing pixels', () => {
 
 describe('shape up — path output', () => {
   beforeEach(() => {
-    ts.shapeOutput = 'path';
+    ts.settings.shape.output = 'path';
   });
 
   it('undoes the raster preview and adds a closed ellipse path', () => {
@@ -411,8 +415,8 @@ describe('shape up — path output', () => {
   });
 
   it('adds a polygon path with one anchor per side', () => {
-    ts.shapeMode = 'polygon';
-    ts.shapePolygonSides = 3;
+    ts.settings.shape.mode = 'polygon';
+    ts.settings.shape.polygonSides = 3;
     handleShapeUp(makeState({ startPoint: { x: 50, y: 50 } }), { x: 80, y: 70 });
     const [anchors] = editorState.addPath.mock.calls[0]! as [PathAnchor[]];
     expect(anchors).toHaveLength(3);
@@ -455,7 +459,7 @@ describe('confirmShapeSize', () => {
   });
 
   it('caps the corner radius at half the smaller dimension', () => {
-    ts.shapeCornerRadius = 100;
+    ts.settings.shape.cornerRadius = 100;
     confirmShapeSize(60, 40, click);
     expect(renderShapeExpanded.mock.calls[0]![17]).toBe(20);
   });

--- a/src/tools/shape/shape-interaction.ts
+++ b/src/tools/shape/shape-interaction.ts
@@ -81,8 +81,9 @@ export function handleShapeDown(ctx: InteractionContext): InteractionState {
   editorState.pushHistory('Shape');
 
   const ts = useToolSettingsStore.getState();
-  if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
-  if (ts.shapeStrokeColor) ts.addRecentColor(ts.shapeStrokeColor);
+  const shape = ts.settings.shape;
+  if (shape.fillColor) ts.addRecentColor(shape.fillColor);
+  if (shape.strokeColor) ts.addRecentColor(shape.strokeColor);
   const engine = getEngine();
   if (engine) gpuSaveShapePreview(engine, activeLayerId);
 
@@ -101,7 +102,7 @@ export function handleShapeDown(ctx: InteractionContext): InteractionState {
 export function handleShapeMove(state: InteractionState, layerLocalPos: Point, metaKey = false): void {
   if (!state.startPoint || !state.layerId) return;
 
-  const toolSettings = useToolSettingsStore.getState();
+  const shape = useToolSettingsStore.getState().settings.shape;
   const constrainedEdge = constrainToAspectRatio(state.startPoint, layerLocalPos, metaKey);
   const rx = Math.abs(constrainedEdge.x - state.startPoint.x);
   const ry = Math.abs(constrainedEdge.y - state.startPoint.y);
@@ -110,11 +111,11 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
   const engine = getEngine();
   if (!engine) return;
 
-  const fillColor = toolSettings.shapeFillColor;
-  const strokeColor = toolSettings.shapeStrokeColor;
+  const fillColor = shape.fillColor;
+  const strokeColor = shape.strokeColor;
   gpuRenderShape(
     engine, state.layerId,
-    shapeModeToU32(toolSettings.shapeMode),
+    shapeModeToU32(shape.mode),
     state.startPoint.x + state.layerStartX,
     state.startPoint.y + state.layerStartY,
     rx * 2, ry * 2,
@@ -122,8 +123,8 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
     fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
     strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
     strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-    toolSettings.shapeStrokeWidth, toolSettings.shapePolygonSides,
-    Math.min(toolSettings.shapeCornerRadius, Math.min(rx * 2, ry * 2) / 2),
+    shape.strokeWidth, shape.polygonSides,
+    Math.min(shape.cornerRadius, Math.min(rx * 2, ry * 2) / 2),
   );
   clearJsPixelData(state.layerId);
   useEditorStore.getState().notifyRender();
@@ -137,10 +138,11 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
 export function confirmShapeSize(width: number, height: number, click: ShapeSizeClick): void {
   const editorState = useEditorStore.getState();
   const ts = useToolSettingsStore.getState();
+  const shape = ts.settings.shape;
 
   editorState.pushHistory('Shape');
-  if (ts.shapeFillColor) ts.addRecentColor(ts.shapeFillColor);
-  if (ts.shapeStrokeColor) ts.addRecentColor(ts.shapeStrokeColor);
+  if (shape.fillColor) ts.addRecentColor(shape.fillColor);
+  if (shape.strokeColor) ts.addRecentColor(shape.strokeColor);
 
   const engine = getEngine();
   if (!engine) return;
@@ -148,18 +150,18 @@ export function confirmShapeSize(width: number, height: number, click: ShapeSize
   const cx = click.center.x + click.layerX;
   const cy = click.center.y + click.layerY;
 
-  const fillColor = ts.shapeFillColor;
-  const strokeColor = ts.shapeStrokeColor;
+  const fillColor = shape.fillColor;
+  const strokeColor = shape.strokeColor;
   gpuRenderShapeExpanded(
     engine, click.layerId,
-    shapeModeToU32(ts.shapeMode),
+    shapeModeToU32(shape.mode),
     cx, cy, width, height,
     fillColor ? fillColor.r / 255 : 0, fillColor ? fillColor.g / 255 : 0,
     fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
     strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
     strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-    ts.shapeStrokeWidth, ts.shapePolygonSides,
-    Math.min(ts.shapeCornerRadius, Math.min(width, height) / 2),
+    shape.strokeWidth, shape.polygonSides,
+    Math.min(shape.cornerRadius, Math.min(width, height) / 2),
   );
   syncLayerBoundsFromEngine(engine, click.layerId);
   clearJsPixelData(click.layerId);
@@ -174,11 +176,11 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
 
   const dx = layerLocalPos.x - state.startPoint.x;
   const dy = layerLocalPos.y - state.startPoint.y;
-  const toolSettings = useToolSettingsStore.getState();
+  const shape = useToolSettingsStore.getState().settings.shape;
 
   if (Math.sqrt(dx * dx + dy * dy) < CLICK_THRESHOLD) {
     useEditorStore.getState().undo();
-    if (toolSettings.shapeOutput === 'path') return;
+    if (shape.output === 'path') return;
     useUIStore.getState().setPendingShapeClick({
       center: state.startPoint,
       layerId: state.layerId!,
@@ -188,34 +190,34 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
     return;
   }
 
-  if (engine && state.layerId && toolSettings.shapeOutput !== 'path') {
+  if (engine && state.layerId && shape.output !== 'path') {
     const constrainedEdge = constrainToAspectRatio(state.startPoint, layerLocalPos, metaKey);
     const rx = Math.abs(constrainedEdge.x - state.startPoint.x);
     const ry = Math.abs(constrainedEdge.y - state.startPoint.y);
     const docCx = state.startPoint.x + state.layerStartX;
     const docCy = state.startPoint.y + state.layerStartY;
-    const sw = toolSettings.shapeStrokeWidth;
+    const sw = shape.strokeWidth;
     const { width: docW, height: docH } = useEditorStore.getState().document;
     if (docCx - rx - sw < 0 || docCy - ry - sw < 0
         || docCx + rx + sw > docW || docCy + ry + sw > docH) {
-      const fillColor = toolSettings.shapeFillColor;
-      const strokeColor = toolSettings.shapeStrokeColor;
+      const fillColor = shape.fillColor;
+      const strokeColor = shape.strokeColor;
       gpuRenderShapeExpanded(
         engine, state.layerId,
-        shapeModeToU32(toolSettings.shapeMode),
+        shapeModeToU32(shape.mode),
         docCx, docCy, rx * 2, ry * 2,
         fillColor ? fillColor.r / 255 : 0, fillColor ? fillColor.g / 255 : 0,
         fillColor ? fillColor.b / 255 : 0, fillColor ? fillColor.a : 0,
         strokeColor ? strokeColor.r / 255 : 0, strokeColor ? strokeColor.g / 255 : 0,
         strokeColor ? strokeColor.b / 255 : 0, strokeColor ? strokeColor.a : 0,
-        sw, toolSettings.shapePolygonSides,
-        Math.min(toolSettings.shapeCornerRadius, Math.min(rx * 2, ry * 2) / 2),
+        sw, shape.polygonSides,
+        Math.min(shape.cornerRadius, Math.min(rx * 2, ry * 2) / 2),
       );
     }
     syncLayerBoundsFromEngine(engine, state.layerId);
   }
 
-  if (toolSettings.shapeOutput === 'path') {
+  if (shape.output === 'path') {
     // Undo the raster preview that was rendered during drag.
     useEditorStore.getState().undo();
 
@@ -229,10 +231,10 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
 
     const editorState = useEditorStore.getState();
     let anchors: PathAnchor[];
-    if (toolSettings.shapeMode === 'ellipse') {
+    if (shape.mode === 'ellipse') {
       anchors = ellipseToPathAnchors(cx, cy, rx, ry);
     } else {
-      anchors = polygonToPathAnchors(cx, cy, rx, ry, toolSettings.shapePolygonSides);
+      anchors = polygonToPathAnchors(cx, cy, rx, ry, shape.polygonSides);
     }
     editorState.addPath(anchors, true);
     editorState.notifyRender();

--- a/src/tools/shape/shape-settings.test.ts
+++ b/src/tools/shape/shape-settings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SHAPE_SETTINGS,
+  clampShapeSetting,
+  type ShapeSettings,
+} from './shape-settings';
+
+describe('shape-settings clamps and defaults (#453)', () => {
+  it('defaults match the values the flat-bag store carried', () => {
+    expect(DEFAULT_SHAPE_SETTINGS).toEqual({
+      mode: 'ellipse',
+      output: 'pixels',
+      fillColor: { r: 255, g: 255, b: 255, a: 1 },
+      strokeColor: null,
+      strokeWidth: 2,
+      polygonSides: 6,
+      cornerRadius: 0,
+    } satisfies ShapeSettings);
+  });
+
+  it('mode collapses unknown strings to "ellipse" rather than letting a typed-string bypass leave a polygon-with-stale-sides render (#236)', () => {
+    expect(clampShapeSetting('mode', 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'polygon')).toBe('polygon');
+    // The shader treats anything-not-ellipse as polygon. A bypass passing
+    // 'rectangle' must not silently render a polygon with whatever sides
+    // value is current — fall back to the documented default instead.
+    expect(clampShapeSetting('mode', 'rectangle' as 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'line' as 'ellipse')).toBe('ellipse');
+    expect(clampShapeSetting('mode', 'arrow' as 'ellipse')).toBe('ellipse');
+  });
+
+  it('output collapses unknown strings to "pixels" for the same reason', () => {
+    expect(clampShapeSetting('output', 'pixels')).toBe('pixels');
+    expect(clampShapeSetting('output', 'path')).toBe('path');
+    expect(clampShapeSetting('output', 'vector' as 'pixels')).toBe('pixels');
+    expect(clampShapeSetting('output', '' as 'pixels')).toBe('pixels');
+  });
+
+  it('clamps strokeWidth into [1, 50]', () => {
+    expect(clampShapeSetting('strokeWidth', 0)).toBe(1);
+    expect(clampShapeSetting('strokeWidth', -5)).toBe(1);
+    expect(clampShapeSetting('strokeWidth', 999)).toBe(50);
+    expect(clampShapeSetting('strokeWidth', 2)).toBe(2);
+    expect(clampShapeSetting('strokeWidth', 50)).toBe(50);
+    expect(clampShapeSetting('strokeWidth', 1)).toBe(1);
+  });
+
+  it('clamps and rounds polygonSides into [3, 64]', () => {
+    // Sides must be an integer — fractional sides would render as the
+    // floor count with weird seams. The legacy setter rounded, preserve.
+    expect(clampShapeSetting('polygonSides', 2)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 0)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 99)).toBe(64);
+    expect(clampShapeSetting('polygonSides', 6.4)).toBe(6);
+    expect(clampShapeSetting('polygonSides', 6.6)).toBe(7);
+    expect(clampShapeSetting('polygonSides', 3)).toBe(3);
+    expect(clampShapeSetting('polygonSides', 64)).toBe(64);
+  });
+
+  it('clamps cornerRadius into [0, 200]', () => {
+    expect(clampShapeSetting('cornerRadius', -1)).toBe(0);
+    expect(clampShapeSetting('cornerRadius', 0)).toBe(0);
+    expect(clampShapeSetting('cornerRadius', 99999)).toBe(200);
+    expect(clampShapeSetting('cornerRadius', 100)).toBe(100);
+    expect(clampShapeSetting('cornerRadius', 200)).toBe(200);
+  });
+
+  it('does not round numeric fields outside polygonSides', () => {
+    // Sub-pixel stroke widths and corner radii are meaningful for HDPI
+    // rendering and animations, so the clamps guard the bounds without
+    // forcing integers (polygonSides is the lone exception — see above).
+    expect(clampShapeSetting('strokeWidth', 2.5)).toBe(2.5);
+    expect(clampShapeSetting('cornerRadius', 12.75)).toBe(12.75);
+  });
+
+  it('passes fillColor and strokeColor through unchanged, including null', () => {
+    const red = { r: 255, g: 0, b: 0, a: 1 };
+    expect(clampShapeSetting('fillColor', red)).toBe(red);
+    expect(clampShapeSetting('fillColor', null)).toBe(null);
+    expect(clampShapeSetting('strokeColor', null)).toBe(null);
+    expect(clampShapeSetting('strokeColor', red)).toBe(red);
+  });
+});

--- a/src/tools/shape/shape-settings.ts
+++ b/src/tools/shape/shape-settings.ts
@@ -1,0 +1,77 @@
+import type { Color } from '../../types';
+import type { ShapeMode, ShapeOutput } from './shape';
+
+/**
+ * Per-tool settings slice for the Shape tool.
+ *
+ * Authoritative settings type for shape. The slice lives under
+ * `settings.shape` on the global ToolSettings store (see #453).
+ * Same pattern as `wand-settings.ts` / `fill-settings.ts` /
+ * `marquee-settings.ts` / `smudge-settings.ts` / `pencil-settings.ts` /
+ * `sponge-settings.ts` / `eraser-settings.ts` / `path-settings.ts` /
+ * `stamp-settings.ts` / `magnetic-lasso-settings.ts` /
+ * `text-settings.ts` / `spray-settings.ts` / `healing-settings.ts`:
+ * `<Tool>Settings` interface + `DEFAULT_<TOOL>_SETTINGS` + a
+ * `clamp<Tool>Setting` helper, then registered in
+ * `tool-settings-slices.ts`. Seven fields covering geometry (mode,
+ * output, polygonSides, cornerRadius) and appearance (fillColor,
+ * strokeColor, strokeWidth) — the largest slice by field count so
+ * far, and the first slice to mix three rectangular numeric clamps
+ * with two nullable-color fields and two tagged-union enums in one
+ * shape.
+ *
+ * The `mode` field rejects invalid strings (`'rectangle'`, `'line'`,
+ * etc.) by falling back to `'ellipse'` rather than letting a
+ * `@ts-ignore` bypass leave the GPU shader rendering a polygon with
+ * stale `sides` — the same guard the legacy `setShapeMode` carried
+ * (issue #236). `output` collapses unknown values to `'pixels'` for
+ * the same reason.
+ */
+export interface ShapeSettings {
+  mode: ShapeMode;
+  output: ShapeOutput;
+  fillColor: Color | null;
+  strokeColor: Color | null;
+  strokeWidth: number;
+  polygonSides: number;
+  cornerRadius: number;
+}
+
+export const DEFAULT_SHAPE_SETTINGS: ShapeSettings = {
+  mode: 'ellipse',
+  output: 'pixels',
+  fillColor: { r: 255, g: 255, b: 255, a: 1 },
+  strokeColor: null,
+  strokeWidth: 2,
+  polygonSides: 6,
+  cornerRadius: 0,
+};
+
+export function clampShapeSetting<K extends keyof ShapeSettings>(
+  key: K,
+  value: ShapeSettings[K],
+): ShapeSettings[K] {
+  if (key === 'mode') {
+    const m = value as string;
+    if (m !== 'ellipse' && m !== 'polygon') return 'ellipse' as ShapeSettings[K];
+    return value;
+  }
+  if (key === 'output') {
+    const o = value as string;
+    if (o !== 'pixels' && o !== 'path') return 'pixels' as ShapeSettings[K];
+    return value;
+  }
+  if (key === 'strokeWidth') {
+    const n = value as number;
+    return Math.max(1, Math.min(50, n)) as ShapeSettings[K];
+  }
+  if (key === 'polygonSides') {
+    const n = value as number;
+    return Math.max(3, Math.min(64, Math.round(n))) as ShapeSettings[K];
+  }
+  if (key === 'cornerRadius') {
+    const n = value as number;
+    return Math.max(0, Math.min(200, n)) as ShapeSettings[K];
+  }
+  return value;
+}

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -292,7 +292,7 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
       if (shapeFillSeededFromForeground) return;
       shapeFillSeededFromForeground = true;
       const ts = useToolSettingsStore.getState();
-      ts.setShapeFillColor(ts.foregroundColor);
+      ts.setShapeSetting('fillColor', ts.foregroundColor);
     },
   },
   text: {


### PR DESCRIPTION
## Summary

Combines the seven remaining open per-tool settings slice PRs into one branch, with all conflicts against `main` resolved, so they can land together instead of fighting over the same shared files (`tool-settings-slices.ts`, `tool-settings-store.ts`, `tool-settings-types.ts`, `tool-settings-store.test.ts`) on every individual merge.

This **closes out #453** — every per-tool settings sub-tree is now an authoritative slice, and `tool-settings-store.ts` is down to **399 lines** (under the ≤400 acceptance target).

## Slices combined

| PR | Slice | Fields migrated |
|----|-------|-----------------|
| #608 | `quickSelect` | size, tolerance, edgeStrength, mode |
| #623 | `shape` | mode, output, fillColor, strokeColor, strokeWidth, polygonSides, cornerRadius |
| #626 | `gradient` | type, stops, reverse (+ stop list ops) |
| #627 | `crop` | mode |
| #628 | `brush` | size, opacity, hardness, spacing, scatter, angle, fade, taper |
| #631 | `brushSpeed` | size, sizeInvert, sensitivity |
| #630 | `brushJitter` | size, hardness, angle, opacity |

Together with the slices already on `main` (wand, fill, marquee, smudge, pencil, sponge, eraser, path, stamp, magneticLasso, text, spray, healing, brushTexture, dodge) this brings the registry to **22 slices**.

## Conflict resolution approach

Each branch was cut before several other slices landed on `main`, so the shared files conflicted. Conflicts were resolved as the **union of slice migrations**: keep every slice already on `main`, add the new one, and drop a flat field/setter whenever *either* side had migrated it. Notable cross-cutting resolutions:

- **dodge** (already a slice on `main`) shares the brush size field — its read sites now use `settings.brush.size` after #628.
- **`setActivePreset`** writes the `brush`, `brushTexture`, `brushSpeed`, and `brushJitter` slices through a single `settings` spread (avoiding duplicate-key clobbering) and `saveCurrentAsPreset` reads them back from the slices.
- The `setShapeMode` issue #236 test block is retargeted to `setShapeSetting`; sibling-slice referential-identity tests read `settings.brush.size` instead of the removed flat field.

## Not migrated (by design)

Per #453's design note ("cross-tool state stays at root"), the remaining root-level fields are intentionally left flat — they are not per-tool settings: aspect ratio, symmetry, foreground/background/recent colors, and brush infrastructure (active tip, textures, presets, sub-brushes). Liquify keeps its settings in `ui-store.ts` (outside this store's scope); eyedropper/lasso/move/transform have no persistent tool settings.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only); pixel-debt check OK
- [x] `npm run test` — 1350 unit tests pass (the only failing test *files* are the pre-existing `engine-wasm/pkg` import errors from WASM not being built in this environment; CI builds WASM server-side)

Closes #453. Supersedes #608, #623, #626, #627, #628, #630, #631.

Note: the duplicate stale PRs #629 (spray), #606 (dodge), and #596 (healing) were **not** included — those exact slices already landed on `main`, so they can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMNUmaQNMgUiHeAmYvNHM8)_