### PR TITLE
fix(smudge): fix tools broken on pasted+rotated layers, remove move stall

### DIFF
--- a/src/app/OptionsBar/tool-options/TransformControls.tsx
+++ b/src/app/OptionsBar/tool-options/TransformControls.tsx
@@ -37,13 +37,33 @@ export function applyGpuTransform(invMatrix: Float32Array): void {
   // Float if needed
   if (!hasFloat(engine)) {
     const floatBounds = floatSelection(engine, activeLayerId);
-    // Sync expanded position to Zustand (text layers expand to diagonal size).
     if (floatBounds.length >= 4) {
       const newX = floatBounds[0]!;
       const newY = floatBounds[1]!;
+      const newW = floatBounds[2]!;
+      const newH = floatBounds[3]!;
       const curLayer = editorState.document.layers.find(l => l.id === activeLayerId);
-      if (curLayer && (curLayer.x !== newX || curLayer.y !== newY)) {
-        editorState.updateLayerPosition(activeLayerId, newX, newY);
+      if (curLayer) {
+        const posChanged = curLayer.x !== newX || curLayer.y !== newY;
+        const sizeChanged = curLayer.type === 'raster'
+          && (curLayer.width !== newW || curLayer.height !== newH);
+        if (posChanged || sizeChanged) {
+          useEditorStore.setState((s) => ({
+            document: {
+              ...s.document,
+              layers: s.document.layers.map((l) =>
+                l.id === activeLayerId
+                  ? {
+                    ...l,
+                    x: newX,
+                    y: newY,
+                    ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
+                  }
+                  : l
+              ),
+            },
+          }));
+        }
       }
     }
   }

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -150,9 +150,30 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
       if (floatBoundsMove.length >= 4) {
         const newX = floatBoundsMove[0]!;
         const newY = floatBoundsMove[1]!;
+        const newW = floatBoundsMove[2]!;
+        const newH = floatBoundsMove[3]!;
         const curLayer = useEditorStore.getState().document.layers.find(l => l.id === activeLayerId);
-        if (curLayer && (curLayer.x !== newX || curLayer.y !== newY)) {
-          useEditorStore.getState().updateLayerPosition(activeLayerId, newX, newY);
+        if (curLayer) {
+          const posChanged = curLayer.x !== newX || curLayer.y !== newY;
+          const sizeChanged = curLayer.type === 'raster'
+            && (curLayer.width !== newW || curLayer.height !== newH);
+          if (posChanged || sizeChanged) {
+            useEditorStore.setState((s) => ({
+              document: {
+                ...s.document,
+                layers: s.document.layers.map((l) =>
+                  l.id === activeLayerId
+                    ? {
+                      ...l,
+                      x: newX,
+                      y: newY,
+                      ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
+                    }
+                    : l
+                ),
+              },
+            }));
+          }
         }
       }
 
@@ -447,13 +468,34 @@ export function handleNudgeMove(
       const floatBoundsDup = floatSelection(engine, activeId);
       compositeFloat(engine, 0, 0);
 
-      // Sync expanded position to Zustand (text layers expand to diagonal size).
+      // Sync expanded position AND dimensions to Zustand.
       if (floatBoundsDup.length >= 4) {
         const newX = floatBoundsDup[0]!;
         const newY = floatBoundsDup[1]!;
+        const newW = floatBoundsDup[2]!;
+        const newH = floatBoundsDup[3]!;
         const curLayer = useEditorStore.getState().document.layers.find(l => l.id === activeId);
-        if (curLayer && (curLayer.x !== newX || curLayer.y !== newY)) {
-          useEditorStore.getState().updateLayerPosition(activeId, newX, newY);
+        if (curLayer) {
+          const posChanged = curLayer.x !== newX || curLayer.y !== newY;
+          const sizeChanged = curLayer.type === 'raster'
+            && (curLayer.width !== newW || curLayer.height !== newH);
+          if (posChanged || sizeChanged) {
+            useEditorStore.setState((s) => ({
+              document: {
+                ...s.document,
+                layers: s.document.layers.map((l) =>
+                  l.id === activeId
+                    ? {
+                      ...l,
+                      x: newX,
+                      y: newY,
+                      ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
+                    }
+                    : l
+                ),
+              },
+            }));
+          }
         }
       }
 

--- a/src/app/interactions/prefloat.ts
+++ b/src/app/interactions/prefloat.ts
@@ -66,9 +66,30 @@ function executePrefloat(layerId: string, mask: Uint8ClampedArray, bounds: Rect)
   if (result.length >= 4) {
     const newX = result[0]!;
     const newY = result[1]!;
+    const newW = result[2]!;
+    const newH = result[3]!;
     const curLayer = useEditorStore.getState().document.layers.find(l => l.id === layerId);
-    if (curLayer && (curLayer.x !== newX || curLayer.y !== newY)) {
-      useEditorStore.getState().updateLayerPosition(layerId, newX, newY);
+    if (curLayer) {
+      const posChanged = curLayer.x !== newX || curLayer.y !== newY;
+      const sizeChanged = curLayer.type === 'raster'
+        && (curLayer.width !== newW || curLayer.height !== newH);
+      if (posChanged || sizeChanged) {
+        useEditorStore.setState((s) => ({
+          document: {
+            ...s.document,
+            layers: s.document.layers.map((l) =>
+              l.id === layerId
+                ? {
+                  ...l,
+                  x: newX,
+                  y: newY,
+                  ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
+                }
+                : l
+            ),
+          },
+        }));
+      }
     }
   }
 

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -129,13 +129,35 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
       const floatBounds = floatSelection(engine, activeLayerId);
       compositeFloat(engine, 0, 0);
 
-      // Sync expanded position to Zustand so engine-sync doesn't override it.
+      // Sync expanded position AND dimensions to Zustand so engine-sync
+      // doesn't push stale width/height back to the engine.
       if (floatBounds.length >= 4) {
         const newX = floatBounds[0]!;
         const newY = floatBounds[1]!;
+        const newW = floatBounds[2]!;
+        const newH = floatBounds[3]!;
         const currentLayer = useEditorStore.getState().document.layers.find(l => l.id === activeLayerId);
-        if (currentLayer && (currentLayer.x !== newX || currentLayer.y !== newY)) {
-          useEditorStore.getState().updateLayerPosition(activeLayerId, newX, newY);
+        if (currentLayer) {
+          const posChanged = currentLayer.x !== newX || currentLayer.y !== newY;
+          const sizeChanged = currentLayer.type === 'raster'
+            && (currentLayer.width !== newW || currentLayer.height !== newH);
+          if (posChanged || sizeChanged) {
+            useEditorStore.setState((s) => ({
+              document: {
+                ...s.document,
+                layers: s.document.layers.map((l) =>
+                  l.id === activeLayerId
+                    ? {
+                      ...l,
+                      x: newX,
+                      y: newY,
+                      ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
+                    }
+                    : l
+                ),
+              },
+            }));
+          }
         }
       }
 

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -236,13 +236,15 @@ export function useCanvasInteraction(
         finalizePendingStroke(pendingStrokeRef);
 
         // Only expand the active layer's pixel data for tools that actually
-        // read/write it (move, smudge, fill). Tools like text, crop, path,
-        // eyedropper, and selection tools don't need pixel data and expanding
-        // would destructively change layer bounds before pushHistory captures
+        // read/write it via JS. Tools like text, crop, path, eyedropper,
+        // and selection tools don't need pixel data and expanding would
+        // destructively change layer bounds before pushHistory captures
         // them — causing undo to restore the wrong positions.
+        // Move is excluded: selection moves use the float system (GPU-only)
+        // and non-selection moves call expandLayerForEditing in the handler.
         // Quick Mask Mode paints on the quick mask buffer (not the layer), so
         // no pixel data expansion is needed — same as non-paint tools.
-        const needsPixelData = (isPaintTool && !isQuickMaskMode) || activeTool === 'move' || activeTool === 'fill';
+        const needsPixelData = (isPaintTool && !isQuickMaskMode) || activeTool === 'fill';
         if (needsPixelData) {
           const imageData = editorState.expandLayerForEditing(activeLayerId);
           expandedLayer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId)!;
@@ -274,6 +276,16 @@ export function useCanvasInteraction(
         persistentTransformRef.current = null;
         floatingSelectionRef.current = null;
         selectLayerAlpha(activeLayerId);
+
+        // After dropping the float, the engine may have resized/repositioned
+        // the layer texture. Sync JS bounds so that syncLayers doesn't push
+        // stale dimensions back to the engine.
+        const synced = syncLayerAfterFullSize(engine, activeLayerId);
+        if (synced) {
+          expandedLayer = synced;
+          layerPos = { x: canvasPos.x - expandedLayer.x, y: canvasPos.y - expandedLayer.y };
+        }
+
         const selAfter = useEditorStore.getState().selection;
         if (selAfter.active && selAfter.mask) {
           const maskBytes = new Uint8Array(selAfter.mask.buffer, selAfter.mask.byteOffset, selAfter.mask.byteLength);
@@ -281,8 +293,16 @@ export function useCanvasInteraction(
         }
       }
 
+      // Rebuild context if the float commit updated layer position/bounds.
+      const finalCtx = (expandedLayer !== ctx.activeLayer || layerPos !== ctx.layerPos)
+        ? buildContext(e, canvasPos, layerPos, activeLayerId, expandedLayer)
+        : ctx;
+      if (useGpu) {
+        finalCtx.isStrokeContinuation = true;
+      }
+
       const handler = toolHandlers[activeTool];
-      const newState = handler?.down?.(ctx);
+      const newState = handler?.down?.(finalCtx);
       if (newState) {
         stateRef.current = withToolGesture(newState, !!useGpuStroke);
       }

--- a/src/tools/smudge/smudge-interaction.test.ts
+++ b/src/tools/smudge/smudge-interaction.test.ts
@@ -13,9 +13,15 @@ vi.mock('../../engine-wasm/engine-state', () => ({
   getEngine: () => engine,
 }));
 
+const syncLayerAfterFullSize = vi.fn();
+vi.mock('../../app/sync-layer-after-full-size', () => ({
+  syncLayerAfterFullSize: (...args: unknown[]) => syncLayerAfterFullSize(...args),
+}));
+
 const editorState = {
   pushHistory: vi.fn(),
   notifyRender: vi.fn(),
+  document: { layers: [{ id: 'layer-1', type: 'raster', x: 0, y: 0, width: 100, height: 100 }] },
 };
 vi.mock('../../app/editor-store', () => ({
   useEditorStore: { getState: () => editorState },

--- a/src/tools/smudge/smudge-interaction.ts
+++ b/src/tools/smudge/smudge-interaction.ts
@@ -8,23 +8,30 @@ import {
   applySmudgeDab as gpuSmudgeDab,
   applySmudgeDabBatch as gpuSmudgeDabBatch,
 } from '../../engine-wasm/wasm-bridge';
+import { syncLayerAfterFullSize } from '../../app/sync-layer-after-full-size';
 import { interpolateFlat } from '../common/dab-interpolation';
 
 export function handleSmudgeDown(ctx: InteractionContext): InteractionState {
-  const { layerPos, activeLayerId, activeLayer, shiftKey } = ctx;
+  const { activeLayerId, activeLayer, shiftKey } = ctx;
+  let { layerPos } = ctx;
   const editorState = useEditorStore.getState();
   editorState.pushHistory('Smudge');
   const { size, strength: strengthPercent } = useToolSettingsStore.getState().settings.smudge;
   const strength = strengthPercent / 100;
 
+  let startLayer = activeLayer;
   const engine = getEngine();
   if (engine) {
+    const synced = syncLayerAfterFullSize(engine, activeLayerId);
+    if (synced) {
+      startLayer = synced;
+      layerPos = { x: ctx.canvasPos.x - synced.x, y: ctx.canvasPos.y - synced.y };
+    }
+
     const shiftLine = shiftKey
       && ctx.lastPaintPointRef.current
       && ctx.lastPaintPointRef.current.layerId === activeLayerId;
     if (shiftLine) {
-      // Build a flat [prev, p1, p2, ...] array starting from the last stroke
-      // endpoint so the smudge pulls along the full shift-click line.
       const from = ctx.lastPaintPointRef.current!.point;
       const spacing = Math.max(1, size * 0.25);
       const interior = interpolateFlat(from, layerPos, spacing);
@@ -34,8 +41,6 @@ export function handleSmudgeDown(ctx: InteractionContext): InteractionState {
       pts.set(interior, 2);
       gpuSmudgeDabBatch(engine, activeLayerId, pts, size, strength);
     } else {
-      // First dab has no prior point — use the current position as its own
-      // prev, which is a no-op by construction (delta = 0).
       gpuSmudgeDab(engine, activeLayerId, layerPos.x, layerPos.y, layerPos.x, layerPos.y, size, strength);
     }
     editorState.notifyRender();
@@ -47,8 +52,8 @@ export function handleSmudgeDown(ctx: InteractionContext): InteractionState {
     layerId: activeLayerId,
     tool: 'smudge',
     startPoint: null,
-    layerStartX: activeLayer.x,
-    layerStartY: activeLayer.y,
+    layerStartX: startLayer.x,
+    layerStartY: startLayer.y,
     ...DEFAULT_TRANSFORM_FIELDS,
   };
 }

--- a/src/tools/tool-registry.test.ts
+++ b/src/tools/tool-registry.test.ts
@@ -31,7 +31,7 @@ describe('tool registry', () => {
 
   it('exposes the same GPU set the manual constant used to', () => {
     expect(new Set(GPU_TOOLS)).toEqual(new Set<ToolId>([
-      'brush', 'pencil', 'eraser', 'dodge', 'sponge', 'stamp', 'healing', 'gradient', 'shape', 'spray',
+      'brush', 'pencil', 'eraser', 'dodge', 'sponge', 'smudge', 'stamp', 'healing', 'gradient', 'shape', 'spray',
     ]))
   });
 

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -208,6 +208,7 @@ export const toolRegistry: Record<ToolId, ToolDescriptor> = {
     label: 'Smudge',
     shortcut: 'r',
     optionsComponent: SmudgeOptions,
+    isGpu: true,
     handler: {
       down: (ctx) => handleSmudgeDown(ctx),
       move: (ctx, state) => handleSmudgeMove(state, ctx.layerPos),


### PR DESCRIPTION
## Summary

- **Smudge (and other tools) did nothing on a pasted layer after rotating it.** After `floatSelection`, only layer x/y were synced to JS — width/height were dropped. The stale dimensions were pushed back to the WASM engine by `syncLayers`, corrupting layer state. Fixed by syncing width/height at all `floatSelection` call sites. Also marked smudge as `isGpu: true` and added `syncLayerAfterFullSize` before the first dab.
- **~1 second hesitation when starting a selection move on a large canvas.** The coordination code called `expandLayerForEditing` for the move tool, triggering a synchronous `glReadPixels` (64MB+ for a 4K canvas). This was unnecessary — selection moves use the GPU float system and non-selection moves handle their own expansion in the handler.

## Test plan

- [x] Unit tests pass (1459/1459)
- [x] Typecheck passes
- [ ] Open a large image, cut a small section, paste, move, rotate, switch to smudge → smudge works immediately
- [ ] Verify dodge/burn and sponge also work on the pasted+rotated layer
- [ ] Switching layers away and back still works correctly
- [ ] On a 4K+ canvas, make a selection and start moving — no hesitation
- [ ] Undo/redo after smudge on a rotated layer restores correctly
- [ ] Transform via options bar (flip/rotate buttons) syncs dimensions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)