### PR TITLE
fix(paste): preserve content dimensions on pasted layers

### DIFF
--- a/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
+++ b/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
@@ -33,7 +33,21 @@ pub fn remove_layer(engine: &mut EngineInner, layer_id: &str) {
 
 pub fn update_layer(engine: &mut EngineInner, desc: LayerDesc) {
     if let Some(existing) = engine.layer_stack.iter_mut().find(|l| l.id == desc.id) {
-        *existing = desc;
+        // When a float is active on this layer, the engine has expanded
+        // the texture to doc size and updated x/y/width/height to match.
+        // Preserve these so that syncLayers (pushing content dimensions
+        // from the JS model) doesn't corrupt the expanded texture state.
+        let is_float_layer = engine.float_layer_id.as_deref() == Some(desc.id.as_str());
+        if is_float_layer {
+            let (px, py, pw, ph) = (existing.x, existing.y, existing.width, existing.height);
+            *existing = desc;
+            existing.x = px;
+            existing.y = py;
+            existing.width = pw;
+            existing.height = ph;
+        } else {
+            *existing = desc;
+        }
     }
     engine.needs_recomposite = true;
 }

--- a/src/app/interactions/prefloat.ts
+++ b/src/app/interactions/prefloat.ts
@@ -63,33 +63,12 @@ function executePrefloat(layerId: string, mask: Uint8ClampedArray, bounds: Rect)
   const result = floatSelection(engine, layerId);
   compositeFloat(engine, 0, 0);
 
-  if (result.length >= 4) {
+  if (result.length >= 2) {
     const newX = result[0]!;
     const newY = result[1]!;
-    const newW = result[2]!;
-    const newH = result[3]!;
     const curLayer = useEditorStore.getState().document.layers.find(l => l.id === layerId);
-    if (curLayer) {
-      const posChanged = curLayer.x !== newX || curLayer.y !== newY;
-      const sizeChanged = curLayer.type === 'raster'
-        && (curLayer.width !== newW || curLayer.height !== newH);
-      if (posChanged || sizeChanged) {
-        useEditorStore.setState((s) => ({
-          document: {
-            ...s.document,
-            layers: s.document.layers.map((l) =>
-              l.id === layerId
-                ? {
-                  ...l,
-                  x: newX,
-                  y: newY,
-                  ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
-                }
-                : l
-            ),
-          },
-        }));
-      }
+    if (curLayer && (curLayer.x !== newX || curLayer.y !== newY)) {
+      useEditorStore.getState().updateLayerPosition(layerId, newX, newY);
     }
   }
 

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -129,35 +129,15 @@ export function handleTransformDown(ctx: InteractionContext): InteractionState |
       const floatBounds = floatSelection(engine, activeLayerId);
       compositeFloat(engine, 0, 0);
 
-      // Sync expanded position AND dimensions to Zustand so engine-sync
-      // doesn't push stale width/height back to the engine.
-      if (floatBounds.length >= 4) {
+      // Sync expanded position to Zustand so engine-sync doesn't
+      // override it. Width/height are protected engine-side (update_layer
+      // preserves them while a float is active).
+      if (floatBounds.length >= 2) {
         const newX = floatBounds[0]!;
         const newY = floatBounds[1]!;
-        const newW = floatBounds[2]!;
-        const newH = floatBounds[3]!;
         const currentLayer = useEditorStore.getState().document.layers.find(l => l.id === activeLayerId);
-        if (currentLayer) {
-          const posChanged = currentLayer.x !== newX || currentLayer.y !== newY;
-          const sizeChanged = currentLayer.type === 'raster'
-            && (currentLayer.width !== newW || currentLayer.height !== newH);
-          if (posChanged || sizeChanged) {
-            useEditorStore.setState((s) => ({
-              document: {
-                ...s.document,
-                layers: s.document.layers.map((l) =>
-                  l.id === activeLayerId
-                    ? {
-                      ...l,
-                      x: newX,
-                      y: newY,
-                      ...(l.type === 'raster' ? { width: newW, height: newH } : {}),
-                    }
-                    : l
-                ),
-              },
-            }));
-          }
+        if (currentLayer && (currentLayer.x !== newX || currentLayer.y !== newY)) {
+          useEditorStore.getState().updateLayerPosition(activeLayerId, newX, newY);
         }
       }
 


### PR DESCRIPTION
## Summary

- Pasted layers were reporting document dimensions (e.g. 400×300) instead of their actual content dimensions (e.g. 100×80) after the auto-select feature (#347) triggered a prefloat that expanded the GPU texture
- Root cause: commit 72c049f3 (#638) correctly synced expanded GPU dimensions back to the JS layer model to fix smudge on rotated layers, but this also affected paste where the expansion is only an internal GPU optimization
- Fix: make the Rust `update_layer` function preserve x/y/width/height when the target layer has an active float, so `syncLayers` can't overwrite the engine's expanded texture state with stale JS content dimensions — reverting the JS-side dimension syncs to position-only

## Test plan

- [x] `e2e/external-paste-drop.spec.ts` — all 18 tests pass (previously 3 failed + 1 flaky)
- [x] `e2e/smudge.spec.ts` + `e2e/smudge-bounds-bug.spec.ts` — pass (original #638 fix preserved)
- [x] `e2e/transform*.spec.ts` — all 30+ transform/stray-pixel tests pass
- [x] `e2e/move-layer.spec.ts` + `e2e/cut-paste-position.spec.ts` — pass
- [x] Full e2e suite (162 files) — all pass, exit code 0
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)