### PR TITLE
perf: eliminate per-pointer-move GPU stalls and uploads (#641, #642, #643)

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -32,6 +32,7 @@ const ALLOWLIST = {
   // ──────────────────────────────────────────────────────────────────────
   'src/app/editor-store.test.ts': 5,
   'src/app/tool-settings-store.test.ts': 5,
+  'src/app/interactions/move-handlers.test.ts': 1,
   'src/app/interactions/quick-mask-move.test.ts': 2,
   'src/app/store/actions/align-layer.test.ts': 2,
   'src/app/store/actions/crop-canvas.test.ts': 1,

--- a/src/app/interactions/move-handlers.test.ts
+++ b/src/app/interactions/move-handlers.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import type { MutableRefObject } from 'react';
+import type { Rect } from '../../types';
+
+// Mock all WASM/engine bridges. Typed as Mock<AnyFn> so the mocks both
+// accept whatever the production code sends and keep the .mock and
+// .mockClear helpers.
+type AnyFn = (...args: unknown[]) => unknown;
+const uploadQuickMaskPixelsMock = vi.fn() as Mock<AnyFn>;
+const setSelectionMaskMock = vi.fn() as Mock<AnyFn>;
+const readQuickMaskPixelsMock = vi.fn() as Mock<AnyFn>;
+const floatSelectionMock = vi.fn() as Mock<AnyFn>;
+const restoreFloatBaseMock = vi.fn() as Mock<AnyFn>;
+const compositeFloatMock = vi.fn() as Mock<AnyFn>;
+const hasFloatMock = vi.fn(() => false);
+
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  uploadQuickMaskPixels: (...a: unknown[]) => uploadQuickMaskPixelsMock(...a),
+  setSelectionMask: (...a: unknown[]) => setSelectionMaskMock(...a),
+  readQuickMaskPixels: (...a: unknown[]) => readQuickMaskPixelsMock(...a),
+  floatSelection: (...a: unknown[]) => floatSelectionMock(...a),
+  restoreFloatBase: (...a: unknown[]) => restoreFloatBaseMock(...a),
+  compositeFloat: (...a: unknown[]) => compositeFloatMock(...a),
+  hasFloat: () => hasFloatMock(),
+}));
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => ({ __engine: 'mock' }),
+}));
+
+// UI store mock — maskMode is toggled per test via a mutable ref.
+const uiState = {
+  maskMode: 'quickMask' as 'quickMask' | 'edit' | null,
+  showGrid: false,
+  snapToGrid: false,
+  snapToLayers: false,
+  gridSize: 8,
+  clearSnapLines: vi.fn(),
+  setSnapLines: vi.fn(),
+  setTransform: vi.fn(),
+  setActiveTransformHandle: vi.fn(),
+};
+vi.mock('../ui-store', () => ({
+  useUIStore: {
+    getState: () => uiState,
+  },
+}));
+
+// Editor store mock.
+const setSelectionMock = vi.fn() as Mock<AnyFn>;
+const notifyRenderMock = vi.fn();
+const editorState = {
+  document: {
+    width: 4096,
+    height: 4096,
+    layers: [{ id: 'layer-1', x: 0, y: 0, type: 'raster', width: 4096, height: 4096, visible: true }],
+    activeLayerId: 'layer-1',
+  },
+  selection: {
+    active: true,
+    mask: null as Uint8ClampedArray | null,
+    bounds: null as Rect | null,
+    maskWidth: 4096,
+    maskHeight: 4096,
+  },
+  setSelection: (...a: unknown[]) => setSelectionMock(...a),
+  notifyRender: () => notifyRenderMock(),
+  updateLayerPosition: vi.fn(),
+  pushHistory: vi.fn(),
+  pushPrebuiltSnapshot: vi.fn(),
+  expandLayerForEditing: vi.fn(),
+  cropLayerToContent: vi.fn(),
+  duplicateLayer: vi.fn(),
+  setSelectionBounds: vi.fn(),
+};
+vi.mock('../editor-store', () => ({
+  useEditorStore: {
+    getState: () => editorState,
+    setState: vi.fn(),
+  },
+}));
+
+vi.mock('../store/clear-js-pixel-data', () => ({
+  clearJsPixelData: vi.fn(),
+}));
+
+vi.mock('../../panels/LayerPanel/layer-selection', () => ({
+  selectLayerAlpha: vi.fn(),
+}));
+
+vi.mock('./prefloat', () => ({
+  consumePrefloat: () => null,
+  cancelPrefloat: vi.fn(),
+}));
+
+const setMarqueePreviewMock = vi.fn() as Mock<AnyFn>;
+const getMarqueePreviewMock = vi.fn(() => null);
+vi.mock('../../tools/marquee/marquee-preview', () => ({
+  setMarqueePreview: (...a: unknown[]) => setMarqueePreviewMock(...a),
+  getMarqueePreview: () => getMarqueePreviewMock(),
+}));
+
+vi.mock('../../tools/move/move', () => ({
+  snapPositionToGrid: (x: number, y: number) => ({ x, y }),
+  snapPositionToLayers: (x: number, y: number) => ({ x, y, snapLinesX: [], snapLinesY: [] }),
+}));
+
+vi.mock('../../tools/transform/transform', () => ({
+  createTransformState: (bounds: Rect) => ({ originalBounds: bounds, translateX: 0, translateY: 0 }),
+}));
+
+import { handleMoveMove, handleMoveUp } from './move-handlers';
+import type { InteractionState, FloatingSelection, PersistentTransform } from './interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from './interaction-types';
+
+function makeState(overrides: Partial<InteractionState> = {}): InteractionState {
+  const docW = editorState.document.width;
+  const docH = editorState.document.height;
+  const mask = new Uint8ClampedArray(docW * docH);
+  // Small square selection in the center.
+  const startX = 100;
+  const startY = 100;
+  const w = 50;
+  const h = 50;
+  for (let y = startY; y < startY + h; y++) {
+    for (let x = startX; x < startX + w; x++) {
+      mask[y * docW + x] = 255;
+    }
+  }
+  return {
+    drawing: true,
+    lastPoint: { x: 125, y: 125 },
+    layerId: 'layer-1',
+    tool: 'move',
+    startPoint: { x: 125, y: 125 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    moveOriginalMask: mask,
+    moveOriginalBounds: { x: startX, y: startY, width: w, height: h },
+    quickMaskOriginalPixels: new Uint8Array(docW * docH),
+    quickMaskOriginalWidth: docW,
+    quickMaskOriginalHeight: docH,
+    ...overrides,
+  };
+}
+
+function makeFloatingSelectionRef(v: FloatingSelection | null = null): MutableRefObject<FloatingSelection | null> {
+  return { current: v };
+}
+
+describe('handleMoveMove — quick-mask + marquee (#642)', () => {
+  beforeEach(() => {
+    uploadQuickMaskPixelsMock.mockClear();
+    setSelectionMock.mockClear();
+    setMarqueePreviewMock.mockClear();
+    notifyRenderMock.mockClear();
+    uiState.setTransform.mockClear();
+    uiState.maskMode = 'quickMask';
+  });
+
+  it('does NOT upload the quick-mask pixels or full selection mask during a move event', () => {
+    const state = makeState();
+    handleMoveMove(state, { x: 175, y: 125 }, makeFloatingSelectionRef(null));
+
+    // The bug: docW*docH-byte GPU uploads on every move event. Fix asserts none.
+    expect(uploadQuickMaskPixelsMock).not.toHaveBeenCalled();
+    expect(setSelectionMock).not.toHaveBeenCalled();
+  });
+
+  it('emits an analytic marquee-move preview instead so the outline stays live', () => {
+    const state = makeState();
+    handleMoveMove(state, { x: 175, y: 140 }, makeFloatingSelectionRef(null));
+
+    expect(setMarqueePreviewMock).toHaveBeenCalledTimes(1);
+    expect(setMarqueePreviewMock).toHaveBeenCalledWith({ kind: 'move', dx: 50, dy: 15 });
+    expect(notifyRenderMock).toHaveBeenCalled();
+  });
+
+  it('rapid move events add no GPU uploads (30 moves ⇒ 0 uploads)', () => {
+    const state = makeState();
+    for (let i = 0; i < 30; i++) {
+      handleMoveMove(state, { x: 125 + i, y: 125 + i }, makeFloatingSelectionRef(null));
+    }
+    expect(uploadQuickMaskPixelsMock).not.toHaveBeenCalled();
+    expect(setSelectionMock).not.toHaveBeenCalled();
+    expect(setMarqueePreviewMock).toHaveBeenCalledTimes(30);
+  });
+});
+
+describe('handleMoveUp — quick-mask + marquee (#642)', () => {
+  beforeEach(() => {
+    uploadQuickMaskPixelsMock.mockClear();
+    setSelectionMock.mockClear();
+    setMarqueePreviewMock.mockClear();
+    notifyRenderMock.mockClear();
+    uiState.setTransform.mockClear();
+    uiState.maskMode = 'quickMask';
+  });
+
+  it('materializes the translated quick-mask pixels + selection mask exactly once on release', () => {
+    const state = makeState();
+    handleMoveUp(
+      state,
+      { x: 155, y: 145 },
+      makeFloatingSelectionRef(null),
+      { current: null } as MutableRefObject<PersistentTransform | null>,
+    );
+
+    // The whole point of the fix: exactly one upload + one setSelection at commit.
+    expect(uploadQuickMaskPixelsMock).toHaveBeenCalledTimes(1);
+    expect(setSelectionMock).toHaveBeenCalledTimes(1);
+    const setSelectionArgs = setSelectionMock.mock.calls[0]!;
+    const commitBounds = setSelectionArgs[0] as Rect;
+    // Original bounds were {100, 100, 50, 50}, drag was (30, 20).
+    expect(commitBounds).toEqual({ x: 130, y: 120, width: 50, height: 50 });
+    expect(setMarqueePreviewMock).toHaveBeenCalledWith(null);
+  });
+
+  it('is a no-op when the pointer did not move (no allocation, no upload)', () => {
+    const state = makeState();
+    handleMoveUp(
+      state,
+      { x: 125, y: 125 },
+      makeFloatingSelectionRef(null),
+      { current: null } as MutableRefObject<PersistentTransform | null>,
+    );
+
+    expect(uploadQuickMaskPixelsMock).not.toHaveBeenCalled();
+    expect(setSelectionMock).not.toHaveBeenCalled();
+    expect(setMarqueePreviewMock).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -25,6 +25,7 @@ import type {
 import { DEFAULT_TRANSFORM_FIELDS } from './interaction-types';
 import { translateSelectionMask, translateQuickMaskContent } from './quick-mask-move';
 import { consumePrefloat, cancelPrefloat } from './prefloat';
+import { setMarqueePreview } from '../../tools/marquee/marquee-preview';
 
 interface QuickMaskSnapshot {
   pixels: Uint8Array;
@@ -238,46 +239,20 @@ export function handleMoveMove(
   const dragDx = Math.round(canvasPos.x - state.startPoint.x);
   const dragDy = Math.round(canvasPos.y - state.startPoint.y);
 
-  // Quick-mask + marquee move: translate both the marquee outline AND the
-  // painted quick-mask content under it (issue #315). The layer texture is
-  // untouched — only the quick-mask texture moves.
+  // Quick-mask + marquee move: during the drag we ONLY translate the marquee
+  // outline via the analytic preview — the same pattern the regular move path
+  // uses (see the comment below at line 300). The quick-mask pixel translate
+  // + full-document GPU upload happens once, on pointer-up (#642). This
+  // avoids a docW*docH CPU loop + docW*docH-byte upload per move event
+  // (~16.7MB on a 4K canvas).
   if (
     useUIStore.getState().maskMode === 'quickMask'
     && !floatingSelectionRef.current
     && state.moveOriginalMask
     && state.moveOriginalBounds
   ) {
-    const edState = useEditorStore.getState();
-    const { width: docW, height: docH } = edState.document;
-    const { mask: newMask, bounds: newBounds } = translateSelectionMask(
-      state.moveOriginalMask,
-      state.moveOriginalBounds,
-      dragDx,
-      dragDy,
-      docW,
-      docH,
-    );
-    edState.setSelection(newBounds, newMask, docW, docH);
-    useUIStore.getState().setTransform(createTransformState(newBounds));
-
-    const engine = getEngine();
-    if (
-      engine
-      && state.quickMaskOriginalPixels
-      && state.quickMaskOriginalWidth === docW
-      && state.quickMaskOriginalHeight === docH
-    ) {
-      const newPixels = translateQuickMaskContent(
-        state.quickMaskOriginalPixels,
-        state.moveOriginalMask,
-        dragDx,
-        dragDy,
-        docW,
-        docH,
-      );
-      uploadQuickMaskPixels(engine, newPixels, docW, docH);
-    }
-    edState.notifyRender();
+    setMarqueePreview({ kind: 'move', dx: dragDx, dy: dragDy });
+    useEditorStore.getState().notifyRender();
     return;
   }
 
@@ -363,6 +338,57 @@ export function handleMoveUp(
   _persistentTransformRef: MutableRefObject<PersistentTransform | null>,
 ): void {
   useUIStore.getState().clearSnapLines();
+
+  // Quick-mask + marquee move: the drag-time path only updated the marquee
+  // outline preview to avoid per-move CPU translates and GPU uploads.
+  // Materialize the translated quick-mask pixels + selection mask now, once.
+  if (
+    useUIStore.getState().maskMode === 'quickMask'
+    && !floatingSelectionRef.current
+    && state.moveOriginalMask
+    && state.moveOriginalBounds
+    && state.startPoint
+  ) {
+    const dragDx = Math.round(canvasPos.x - state.startPoint.x);
+    const dragDy = Math.round(canvasPos.y - state.startPoint.y);
+    const edState = useEditorStore.getState();
+    const { width: docW, height: docH } = edState.document;
+
+    if (dragDx !== 0 || dragDy !== 0) {
+      const { mask: newMask, bounds: newBounds } = translateSelectionMask(
+        state.moveOriginalMask,
+        state.moveOriginalBounds,
+        dragDx,
+        dragDy,
+        docW,
+        docH,
+      );
+      edState.setSelection(newBounds, newMask, docW, docH);
+      useUIStore.getState().setTransform(createTransformState(newBounds));
+
+      const engine = getEngine();
+      if (
+        engine
+        && state.quickMaskOriginalPixels
+        && state.quickMaskOriginalWidth === docW
+        && state.quickMaskOriginalHeight === docH
+      ) {
+        const newPixels = translateQuickMaskContent(
+          state.quickMaskOriginalPixels,
+          state.moveOriginalMask,
+          dragDx,
+          dragDy,
+          docW,
+          docH,
+        );
+        uploadQuickMaskPixels(engine, newPixels, docW, docH);
+      }
+    }
+    setMarqueePreview(null);
+    edState.notifyRender();
+    return;
+  }
+
   if (!floatingSelectionRef.current || !state.startPoint) return;
 
   const dragDx = Math.round(canvasPos.x - state.startPoint.x);

--- a/src/app/interactions/transform-handlers.test.ts
+++ b/src/app/interactions/transform-handlers.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Rect } from '../../types';
+
+// Bridges — we care that setSelection is NOT called per move, and IS called on up.
+const setSelectionMaskMock = vi.fn();
+vi.mock('../../engine-wasm/wasm-bridge', () => ({
+  floatSelection: vi.fn(),
+  hasFloat: vi.fn(() => false),
+  setSelectionMask: (...a: unknown[]) => setSelectionMaskMock(...a),
+  compositeFloat: vi.fn(),
+  compositeFloatAffine: vi.fn(),
+  compositeFloatPerspective: vi.fn(),
+  dropFloat: vi.fn(),
+}));
+
+vi.mock('../../engine-wasm/engine-state', () => ({
+  getEngine: () => ({ __engine: 'mock' }),
+}));
+
+const uiState = {
+  showGrid: false,
+  snapToGrid: false,
+  gridSize: 8,
+  activeTool: 'marquee-rect' as string,
+  transform: null as unknown,
+  setTransform: vi.fn((t: unknown) => { uiState.transform = t; }),
+  setActiveTransformHandle: vi.fn(),
+};
+vi.mock('../ui-store', () => ({
+  useUIStore: {
+    getState: () => uiState,
+  },
+}));
+
+const editorState = {
+  document: { width: 1024, height: 1024, layers: [], activeLayerId: 'layer-1' },
+  setSelection: vi.fn(),
+  notifyRender: vi.fn(),
+};
+vi.mock('../editor-store', () => ({
+  useEditorStore: {
+    getState: () => editorState,
+    setState: vi.fn(),
+  },
+}));
+
+vi.mock('../store/clear-js-pixel-data', () => ({
+  clearJsPixelData: vi.fn(),
+}));
+
+vi.mock('../../panels/LayerPanel/layer-selection', () => ({
+  selectLayerAlpha: vi.fn(),
+}));
+
+import { handleTransformMove, handleSelectionTransformUp } from './transform-handlers';
+import type { InteractionState } from './interaction-types';
+import { DEFAULT_TRANSFORM_FIELDS } from './interaction-types';
+
+function makeSelectionTransformState(): InteractionState {
+  const startBounds: Rect = { x: 100, y: 100, width: 100, height: 100 };
+  const startState = {
+    originalBounds: startBounds,
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+    translateX: 0,
+    translateY: 0,
+    skewX: 0,
+    skewY: 0,
+    mode: 'free' as const,
+    corners: [{ x: 0, y: 0 }, { x: 0, y: 0 }, { x: 0, y: 0 }, { x: 0, y: 0 }] as [
+      { x: number; y: number }, { x: number; y: number }, { x: number; y: number }, { x: number; y: number },
+    ],
+  };
+  return {
+    drawing: true,
+    lastPoint: null,
+    layerId: 'layer-1',
+    tool: 'marquee-rect',
+    startPoint: { x: 200, y: 200 },
+    layerStartX: 0,
+    layerStartY: 0,
+    ...DEFAULT_TRANSFORM_FIELDS,
+    // Overrides DEFAULT_TRANSFORM_FIELDS.gesture — spread order matters.
+    gesture: {
+      kind: 'transform',
+      handle: 'bottom-right',
+      startState,
+      startAngle: 0,
+      selectionOnly: true,
+    },
+  };
+}
+
+describe('handleTransformMove — selection-only resize (#643)', () => {
+  beforeEach(() => {
+    editorState.setSelection.mockClear();
+    editorState.notifyRender.mockClear();
+    setSelectionMaskMock.mockClear();
+    uiState.setTransform.mockClear();
+    uiState.transform = null;
+    uiState.activeTool = 'marquee-rect';
+  });
+
+  it('does NOT rebuild or upload the selection mask per pointer-move', () => {
+    const state = makeSelectionTransformState();
+
+    // Simulate 30 rapid move events (drag from 200,200 outward).
+    for (let i = 1; i <= 30; i++) {
+      handleTransformMove(state, { x: 200 + i * 2, y: 200 + i * 2 }, false);
+    }
+
+    // The bug: setSelection was called on every move, forcing engine-sync
+    // to re-upload a docW*docH selection mask each frame.
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('publishes an updated transform (with active scale/translate) each move so ants track live', () => {
+    const state = makeSelectionTransformState();
+    handleTransformMove(state, { x: 250, y: 250 }, false);
+
+    expect(uiState.setTransform).toHaveBeenCalledTimes(1);
+    const t = uiState.setTransform.mock.calls[0]![0] as {
+      originalBounds: Rect;
+      scaleX: number;
+      scaleY: number;
+      translateX: number;
+      translateY: number;
+    };
+    // originalBounds are preserved from startState (not reset to identity).
+    expect(t.originalBounds).toEqual({ x: 100, y: 100, width: 100, height: 100 });
+    // The mask is unchanged — the scale is expressed on the transform, which
+    // renderSelectionAnts applies to the mask contours.
+    expect(t.scaleX !== 1 || t.scaleY !== 1 || t.translateX !== 0 || t.translateY !== 0).toBe(true);
+  });
+});
+
+describe('handleSelectionTransformUp — materializes mask on commit (#643)', () => {
+  beforeEach(() => {
+    editorState.setSelection.mockClear();
+    editorState.notifyRender.mockClear();
+    uiState.setTransform.mockClear();
+    uiState.activeTool = 'marquee-rect';
+    uiState.transform = null;
+  });
+
+  it('rebuilds the selection mask + commits new bounds exactly once on release', () => {
+    const state = makeSelectionTransformState();
+    // Drive one move so the transform is set on the UI store.
+    handleTransformMove(state, { x: 300, y: 250 }, false);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+
+    handleSelectionTransformUp(state);
+
+    expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+    const [bounds, mask, w, h] = editorState.setSelection.mock.calls[0]!;
+    expect(w).toBe(1024);
+    expect(h).toBe(1024);
+    expect(mask).toBeInstanceOf(Uint8ClampedArray);
+    // The commit collapses the transform into fresh bounds + identity transform.
+    const finalT = uiState.setTransform.mock.calls[uiState.setTransform.mock.calls.length - 1]![0] as {
+      scaleX: number;
+      scaleY: number;
+      translateX: number;
+      translateY: number;
+    };
+    expect(finalT.scaleX).toBe(1);
+    expect(finalT.scaleY).toBe(1);
+    expect(finalT.translateX).toBe(0);
+    expect(finalT.translateY).toBe(0);
+    // Sanity: the bounds passed to setSelection should be non-empty.
+    const boundsRect = bounds as Rect;
+    expect(boundsRect.width).toBeGreaterThan(0);
+    expect(boundsRect.height).toBeGreaterThan(0);
+  });
+
+  it('is a no-op for non-selection-only transform gestures', () => {
+    const state = makeSelectionTransformState();
+    // Flip the flag to simulate a layer-transform gesture instead.
+    (state.gesture as { selectionOnly: boolean }).selectionOnly = false;
+    handleSelectionTransformUp(state);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the gesture is not a transform at all', () => {
+    const state: InteractionState = {
+      ...makeSelectionTransformState(),
+      gesture: { kind: 'idle' },
+    };
+    handleSelectionTransformUp(state);
+    expect(editorState.setSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/interactions/transform-handlers.ts
+++ b/src/app/interactions/transform-handlers.ts
@@ -383,6 +383,39 @@ function handleSelectionTransformMove(
   const newBounds = getTransformedBounds(newTransform);
   if (newBounds.width < 1 || newBounds.height < 1) return;
 
+  // During the drag we ONLY publish the new transform. The selection mask is
+  // NOT rebuilt or re-uploaded per move — `renderSelectionAnts` already
+  // applies the transform matrix to the existing mask contours, so the
+  // outline stays visually correct. The full docW×docH mask alloc + upload
+  // (~16.7MB per event on a 4K canvas) is deferred to pointer-up (#643).
+  useUIStore.getState().setTransform(newTransform);
+  useEditorStore.getState().notifyRender();
+}
+
+/**
+ * Commit a selection-only transform on pointer-up. Materializes the resized
+ * selection mask once from the final transform state — during the drag we
+ * only updated the transform preview to avoid a per-move full-document mask
+ * alloc + GPU upload (#643).
+ */
+export function handleSelectionTransformUp(state: InteractionState): void {
+  if (state.gesture.kind !== 'transform' || !state.gesture.selectionOnly) return;
+
+  const startState = state.gesture.startState;
+  const currentTransform = useUIStore.getState().transform;
+  if (!currentTransform) return;
+
+  const newTransform: TransformState = {
+    ...startState,
+    scaleX: currentTransform.scaleX,
+    scaleY: currentTransform.scaleY,
+    translateX: currentTransform.translateX,
+    translateY: currentTransform.translateY,
+  };
+
+  const newBounds = getTransformedBounds(newTransform);
+  if (newBounds.width < 1 || newBounds.height < 1) return;
+
   const editorState = useEditorStore.getState();
   const { width: docW, height: docH } = editorState.document;
   const activeTool = useUIStore.getState().activeTool;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -26,7 +26,7 @@ import type {
   PreToolDownGuard,
 } from './interactions/interaction-types';
 import { gestureUsedGpuStroke, INITIAL_INTERACTION_STATE, withToolGesture } from './interactions/interaction-types';
-import { handleTransformDown } from './interactions/transform-handlers';
+import { handleTransformDown, handleSelectionTransformUp } from './interactions/transform-handlers';
 import {
   handleMeshWarpDown,
   handleMeshWarpMove,
@@ -557,6 +557,11 @@ export function useCanvasInteraction(
     // grabs can re-transform from the original pixels without degradation.
     // The float is only dropped when the user commits (clearPersistentTransform).
     if (state.gesture.kind === 'transform') {
+      // Selection-only transforms defer mask materialization to pointer-up
+      // to avoid per-move full-document alloc + GPU upload (#643).
+      if (state.gesture.selectionOnly) {
+        handleSelectionTransformUp(state);
+      }
       useUIStore.getState().setActiveTransformHandle(null);
     }
 

--- a/src/tools/eyedropper/eyedropper-interaction.test.ts
+++ b/src/tools/eyedropper/eyedropper-interaction.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../app/tool-settings-store', () => ({
   useToolSettingsStore: { getState: () => ts },
 }));
 
-import { handleEyedropperDown, handleEyedropperMove } from './eyedropper-interaction';
+import { handleEyedropperDown, handleEyedropperMove, _flushEyedropperSampleForTest } from './eyedropper-interaction';
 import type { InteractionContext, InteractionState } from '../../app/interactions/interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS } from '../../app/interactions/interaction-types';
 
@@ -121,5 +121,54 @@ describe('eyedropper interaction', () => {
     expect(args[1]).toBe(-5);
     expect(args[2]).toBe(-8);
     expect(ts.setForegroundColor).not.toHaveBeenCalled();
+  });
+
+  describe('move throttling (fixes #641)', () => {
+    it('coalesces rapid move events to one readPixels call per animation frame', () => {
+      const raf = vi.fn((cb: () => void) => {
+        (raf as unknown as { pending?: () => void }).pending = cb;
+        return 1;
+      });
+      const cancelRaf = vi.fn();
+      (globalThis as Record<string, unknown>).requestAnimationFrame = raf;
+      (globalThis as Record<string, unknown>).cancelAnimationFrame = cancelRaf;
+
+      try {
+        sampleColor.mockReturnValue(new Uint8Array([1, 2, 3, 255]));
+
+        // 5 pointer moves within one frame => only one rAF scheduled.
+        for (let i = 0; i < 5; i++) {
+          handleEyedropperMove(makeState(), { x: i, y: i });
+        }
+        expect(raf).toHaveBeenCalledTimes(1);
+        expect(sampleColor).not.toHaveBeenCalled();
+
+        // Firing the rAF samples only the last coalesced position.
+        const pending = (raf as unknown as { pending?: () => void }).pending;
+        expect(pending).toBeDefined();
+        pending!();
+        expect(sampleColor).toHaveBeenCalledTimes(1);
+        const args = sampleColor.mock.calls[0]!;
+        expect(args[1]).toBe(4);
+        expect(args[2]).toBe(4);
+        expect(ts.setForegroundColor).toHaveBeenCalledTimes(1);
+        expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 1, g: 2, b: 3, a: 1 });
+      } finally {
+        delete (globalThis as Record<string, unknown>).requestAnimationFrame;
+        delete (globalThis as Record<string, unknown>).cancelAnimationFrame;
+        _flushEyedropperSampleForTest();
+      }
+    });
+
+    it('runs synchronously when requestAnimationFrame is unavailable', () => {
+      // Node test env has no rAF — verifies fallback so tests still work.
+      sampleColor.mockReturnValue(new Uint8Array([9, 8, 7, 255]));
+      handleEyedropperMove(makeState({ layerStartX: 100, layerStartY: 200 }), { x: 10, y: 15 });
+      expect(sampleColor).toHaveBeenCalledTimes(1);
+      const args = sampleColor.mock.calls[0]!;
+      expect(args[1]).toBe(110);
+      expect(args[2]).toBe(215);
+      expect(ts.setForegroundColor).toHaveBeenCalledWith({ r: 9, g: 8, b: 7, a: 1 });
+    });
   });
 });

--- a/src/tools/eyedropper/eyedropper-interaction.ts
+++ b/src/tools/eyedropper/eyedropper-interaction.ts
@@ -14,6 +14,47 @@ function gpuSampleColorAt(canvasX: number, canvasY: number): { r: number; g: num
   return { r: rgba[0]!, g: rgba[1]!, b: rgba[2]!, a: rgba[3]! / 255 };
 }
 
+// Coalesce eyedropper move sampling to at most one readback per animation
+// frame. `gl.readPixels` is a pipeline-synchronizing call: on a large
+// canvas with many layers it stalls the JS thread until the GPU flushes
+// pending composite work. Firing it at pointer-event rate turned every
+// eyedropper drag into a per-move sync (#641). We keep only the most
+// recent position and sample it on the next rAF, so at most one readback
+// per rendered frame instead of one per pointer event.
+let pendingSample: { x: number; y: number } | null = null;
+let sampleRafId: number | null = null;
+
+function flushPendingSample(): void {
+  sampleRafId = null;
+  const pending = pendingSample;
+  pendingSample = null;
+  if (!pending) return;
+  const gpuColor = gpuSampleColorAt(pending.x, pending.y);
+  if (gpuColor) {
+    useToolSettingsStore.getState().setForegroundColor(gpuColor);
+  }
+}
+
+function scheduleSample(canvasX: number, canvasY: number): void {
+  pendingSample = { x: canvasX, y: canvasY };
+  if (sampleRafId !== null) return;
+  if (typeof requestAnimationFrame === 'function') {
+    sampleRafId = requestAnimationFrame(flushPendingSample);
+    return;
+  }
+  // Test / non-browser environment: flush synchronously.
+  flushPendingSample();
+}
+
+/** Test-only hook to force any pending rAF sample to run now. */
+export function _flushEyedropperSampleForTest(): void {
+  if (sampleRafId !== null && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(sampleRafId);
+  }
+  sampleRafId = null;
+  flushPendingSample();
+}
+
 export function handleEyedropperDown(ctx: InteractionContext): InteractionState {
   const { canvasPos, activeLayerId, activeLayer } = ctx;
 
@@ -37,8 +78,5 @@ export function handleEyedropperDown(ctx: InteractionContext): InteractionState 
 export function handleEyedropperMove(state: InteractionState, layerLocalPos: Point): void {
   const canvasX = layerLocalPos.x + state.layerStartX;
   const canvasY = layerLocalPos.y + state.layerStartY;
-  const gpuColor = gpuSampleColorAt(canvasX, canvasY);
-  if (gpuColor) {
-    useToolSettingsStore.getState().setForegroundColor(gpuColor);
-  }
+  scheduleSample(canvasX, canvasY);
 }


### PR DESCRIPTION
## Summary

Fixes three pointer-move performance issues that all shared the same shape: full-document GPU work fired per pointer event, dominating drag latency on large (4K) canvases.

### #641 — eyedropper `readPixels` stall

`gl.readPixels` on the eyedropper move handler was a pipeline-synchronizing call, forcing the driver to flush queued composite work on every mousemove. Coalesce sampling to at most one readback per animation frame via `requestAnimationFrame` — the last position wins, the sampler runs once per rendered frame instead of once per pointer event.

- `src/tools/eyedropper/eyedropper-interaction.ts` — new rAF-coalesced sampler; move handler just schedules, doesn't sample synchronously.

### #642 — quick-mask marquee move full-document upload

The quick-mask + marquee move branch rebuilt a `docW × docH` quick-mask buffer on the CPU **and** uploaded it to the GPU on every pointer-move (~16.7 MB per event on a 4K canvas), plus replaced the selection mask reference (forcing `syncSelection` to re-upload the full mask on the next frame).

Match the regular move path's pattern: during the drag only update the analytic marquee outline preview; materialize the translated pixels + selection mask **once** on pointer-up.

- `src/app/interactions/move-handlers.ts` — quick-mask move branch now emits `setMarqueePreview({ kind: 'move', dx, dy })`; the pointer-up path picks up the deferred work.

### #643 — selection-only transform resize re-uploads mask each move

`handleSelectionTransformMove` allocated a fresh `docW × docH` mask via `createRectSelection` / `createEllipseSelection` on every move and called `setSelection(...)`, defeating the reference-based `syncSelection` diff and triggering a full-mask GPU upload per event.

`renderSelectionAnts` already applies the current transform matrix to the mask contours — the outline stays visually correct if we just publish the new transform. Rebuild the mask **once** in a new `handleSelectionTransformUp` on pointer-up.

- `src/app/interactions/transform-handlers.ts` — new `handleSelectionTransformUp`; move handler only publishes the transform.
- `src/app/useCanvasInteraction.ts` — calls `handleSelectionTransformUp` when a selection-only transform gesture ends.

## Tests

- `src/tools/eyedropper/eyedropper-interaction.test.ts` — new tests verify rapid moves coalesce into a single rAF sample and the fallback still works with no `requestAnimationFrame`.
- `src/app/interactions/move-handlers.test.ts` (new) — verifies quick-mask + marquee moves emit no GPU uploads / no `setSelection` and instead publish the analytic preview; commit on release does exactly one upload + one `setSelection`.
- `src/app/interactions/transform-handlers.test.ts` (new) — verifies selection-only transform resize publishes a transform per move but no `setSelection`; `handleSelectionTransformUp` materializes the mask on release.

## Test plan

- [x] `npm run typecheck` — passes (pre-existing WASM pkg missing error unrelated to this PR)
- [x] `npm run lint` — 0 errors (pixel-debt allowlist updated for new test file)
- [x] `npm run test` — 1471 tests pass
- [ ] Manual: eyedropper drag on 4K canvas + 20 layers stays smooth
- [ ] Manual: quick-mask marquee move on 4K canvas stays smooth (mask jumps on release, not per move)
- [ ] Manual: marquee selection resize on 4K canvas stays smooth

Fixes #641, #642, #643. Marked `autofix`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GryJdRxydk6cnXU7fBX3CY)_