### PR TITLE
fix(e2e): stabilize flaky redo pixel-readback test

### DIFF
--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -154,15 +154,20 @@ test.describe('History - Multi-Step Operations', () => {
     expect(empty.document.layers).toHaveLength(2);
     expect(empty.redoStackLength).toBe(3);
 
-    // Redo everything
+    // Redo everything — wait two frames after each so the compositor
+    // uploads the restored texture and renders before we readback.
+    const waitTwoFrames = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
     await redo(page); // redo paint bg
+    await page.evaluate(waitTwoFrames);
     const bgPixel = await getPixelAt(page, 10, 10, bgId);
     expect(bgPixel.r).toBe(255);
 
     await redo(page); // redo add layer
+    await page.evaluate(waitTwoFrames);
     expect((await getEditorState(page)).document.layers).toHaveLength(3);
 
     await redo(page); // redo paint top
+    await page.evaluate(waitTwoFrames);
     const topPixel = await getPixelAt(page, 60, 60, topId);
     expect(topPixel.g).toBe(255);
   });


### PR DESCRIPTION
## Summary
- The "redo all steps after undoing everything" history e2e test was flaky on chromium — `getPixelAt` would sometimes read stale GPU texture data (green channel = 0 instead of 255) because the compositor hadn't finished uploading the restored texture after redo.
- Added a double-`requestAnimationFrame` wait after each redo step to ensure the state sync and GPU render complete before pixel readback.
- Verified fix: 10/10 passes with `--retries=0 --repeat-each=10` (was failing ~1 in 3 before).

## Test plan
- [x] `npx playwright test e2e/history.spec.ts --project=chromium --retries=0 --repeat-each=10` — 10/10 passes
- [x] Full chromium suite: 750 passed, 0 failed
- [x] Full firefox suite: 323 passed, 0 failed  
- [x] Full mobile-chrome suite: 4 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)