### PR TITLE
refactor(interactions): split CanvasGesture 'tool' into 'paint' + 'tool' (#444)

### DIFF
--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   gestureUsedGpuStroke,
+  withPaintGesture,
   withToolGesture,
   GESTURE_IDLE,
   INITIAL_INTERACTION_STATE,
@@ -23,19 +24,25 @@ describe('gestureUsedGpuStroke', () => {
     expect(gestureUsedGpuStroke(GESTURE_IDLE)).toBe(false);
   });
 
-  it('returns true for tool gesture with usedGpuStroke=true', () => {
-    const g: CanvasGesture = { kind: 'tool', usedGpuStroke: true };
+  it('returns true for paint gesture with usedGpuStroke=true', () => {
+    const g: CanvasGesture = { kind: 'paint', usedGpuStroke: true };
     expect(gestureUsedGpuStroke(g)).toBe(true);
   });
 
-  it('returns false for tool gesture with usedGpuStroke=false', () => {
-    const g: CanvasGesture = { kind: 'tool', usedGpuStroke: false };
+  it('returns false for paint gesture with usedGpuStroke=false', () => {
+    const g: CanvasGesture = { kind: 'paint', usedGpuStroke: false };
     expect(gestureUsedGpuStroke(g)).toBe(false);
   });
 
-  it('returns false for non-tool gestures regardless of context', () => {
+  it('returns false for tool gesture (non-paint tools cannot claim a GPU stroke)', () => {
+    const g: CanvasGesture = { kind: 'tool' };
+    expect(gestureUsedGpuStroke(g)).toBe(false);
+  });
+
+  it('returns false for non-paint gestures regardless of context', () => {
     const gestures: CanvasGesture[] = [
       { kind: 'idle' },
+      { kind: 'tool' },
       { kind: 'liquify', lastPoint: { x: 0, y: 0 } },
       { kind: 'tiltShift' },
       { kind: 'meshWarp' },
@@ -140,36 +147,84 @@ const makeBaseState = (overrides: Partial<InteractionState> = {}): InteractionSt
   ...overrides,
 });
 
-describe('withToolGesture', () => {
-  it('returns a tool gesture with the given usedGpuStroke flag', () => {
+describe('withPaintGesture', () => {
+  it('returns a paint gesture with the given usedGpuStroke flag', () => {
     const input = makeBaseState();
-    const output = withToolGesture(input, true);
-    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: true });
+    const output = withPaintGesture(input, true);
+    expect(output.gesture).toEqual({ kind: 'paint', usedGpuStroke: true });
   });
 
   it('preserves non-gesture fields from the input', () => {
     const input = makeBaseState({ layerId: 'abc', tool: 'pencil', drawing: true });
-    const output = withToolGesture(input, false);
+    const output = withPaintGesture(input, false);
     expect(output.layerId).toBe('abc');
     expect(output.tool).toBe('pencil');
     expect(output.drawing).toBe(true);
-    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: false });
+    expect(output.gesture).toEqual({ kind: 'paint', usedGpuStroke: false });
   });
 
   it('does not mutate the input state (no-mutation invariant from #444)', () => {
     const input = Object.freeze(makeBaseState({ gesture: GESTURE_IDLE }));
-    const output = withToolGesture(input, true);
+    const output = withPaintGesture(input, true);
     expect(input.gesture).toBe(GESTURE_IDLE);
     expect(output).not.toBe(input);
     expect(output.gesture).not.toBe(input.gesture);
   });
 
-  it('does not mutate a previously-set tool gesture object', () => {
-    const priorGesture: CanvasGesture = { kind: 'tool', usedGpuStroke: false };
+  it('does not mutate a previously-set paint gesture object', () => {
+    const priorGesture: CanvasGesture = { kind: 'paint', usedGpuStroke: false };
     const input = makeBaseState({ gesture: priorGesture });
-    const output = withToolGesture(input, true);
-    expect(priorGesture).toEqual({ kind: 'tool', usedGpuStroke: false });
+    const output = withPaintGesture(input, true);
+    expect(priorGesture).toEqual({ kind: 'paint', usedGpuStroke: false });
     expect(output.gesture).not.toBe(priorGesture);
-    expect(output.gesture).toEqual({ kind: 'tool', usedGpuStroke: true });
+    expect(output.gesture).toEqual({ kind: 'paint', usedGpuStroke: true });
+  });
+});
+
+describe('withToolGesture', () => {
+  it('returns a data-less tool gesture', () => {
+    const input = makeBaseState();
+    const output = withToolGesture(input);
+    expect(output.gesture).toEqual({ kind: 'tool' });
+  });
+
+  it('preserves non-gesture fields from the input', () => {
+    const input = makeBaseState({ layerId: 'abc', tool: 'fill', drawing: true });
+    const output = withToolGesture(input);
+    expect(output.layerId).toBe('abc');
+    expect(output.tool).toBe('fill');
+    expect(output.drawing).toBe(true);
+    expect(output.gesture).toEqual({ kind: 'tool' });
+  });
+
+  it('does not mutate the input state (no-mutation invariant from #444)', () => {
+    const input = Object.freeze(makeBaseState({ gesture: GESTURE_IDLE }));
+    const output = withToolGesture(input);
+    expect(input.gesture).toBe(GESTURE_IDLE);
+    expect(output).not.toBe(input);
+    expect(output.gesture).not.toBe(input.gesture);
+  });
+});
+
+describe('CanvasGesture paint/tool split (#444)', () => {
+  it('confines usedGpuStroke to the paint variant', () => {
+    type PaintVariant = Extract<CanvasGesture, { kind: 'paint' }>;
+    type ToolVariant = Extract<CanvasGesture, { kind: 'tool' }>;
+
+    const _paintHasFlag: PaintVariant['usedGpuStroke'] = true;
+    expect(_paintHasFlag).toBe(true);
+
+    type ToolHasUsedGpuStroke = 'usedGpuStroke' extends keyof ToolVariant ? true : false;
+    const _toolHasNoFlag: ToolHasUsedGpuStroke = false;
+    expect(_toolHasNoFlag).toBe(false);
+  });
+
+  it('narrows to the paint variant via the discriminant', () => {
+    const gesture: CanvasGesture = { kind: 'paint', usedGpuStroke: true };
+    if (gesture.kind !== 'paint') {
+      throw new Error('expected paint gesture');
+    }
+    const flag: boolean = gesture.usedGpuStroke;
+    expect(flag).toBe(true);
   });
 });

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -16,7 +16,8 @@ import type { TransformHandle, TransformState } from '../../tools/transform/tran
  */
 export type CanvasGesture =
   | { kind: 'idle' }
-  | { kind: 'tool'; usedGpuStroke: boolean }
+  | { kind: 'paint'; usedGpuStroke: boolean }
+  | { kind: 'tool' }
   | { kind: 'liquify'; lastPoint: Point }
   | { kind: 'tiltShift' }
   | { kind: 'meshWarp' }
@@ -29,26 +30,36 @@ export type CanvasGesture =
     };
 
 /**
- * True when the active tool gesture is a paint stroke that started on
- * the GPU path (brush/pencil/eraser with engine available, outside
- * mask/quick-mask modes). Replaces the legacy `_usedGpuStroke?` flag
- * on InteractionState. Lives on the gesture variant so it can't be
- * set unless we're actually inside a `tool` gesture.
+ * True when the active gesture is a paint stroke that started on the
+ * GPU path (brush/pencil/eraser with engine available, outside mask/
+ * quick-mask modes). Structurally scoped to the `paint` variant so
+ * non-paint tool gestures can't accidentally claim a GPU stroke.
+ * Replaces the legacy `_usedGpuStroke?` flag on InteractionState (#444).
  */
 export function gestureUsedGpuStroke(gesture: CanvasGesture): boolean {
-  return gesture.kind === 'tool' && gesture.usedGpuStroke;
+  return gesture.kind === 'paint' && gesture.usedGpuStroke;
 }
 
 /**
- * Construct a tool-gesture InteractionState from a down-handler's
- * freshly-returned state, without mutating the input. The dispatcher
- * used to write `newState.gesture = { kind: 'tool', … }` directly on
- * the returned object — the audit issue (#444) calls out post-return
- * mutation as the bag-of-flags smell. Returning a new object instead
- * keeps the no-mutation invariant.
+ * Construct a paint-gesture InteractionState from a paint-tool down
+ * handler's freshly-returned state, without mutating the input. Only
+ * paint tools (brush/pencil/eraser) carry the `usedGpuStroke` flag;
+ * splitting them out from the generic `tool` variant means the type
+ * system now guarantees a `tool` gesture can't claim a GPU stroke (#444).
  */
-export function withToolGesture(state: InteractionState, usedGpuStroke: boolean): InteractionState {
-  return { ...state, gesture: { kind: 'tool', usedGpuStroke } };
+export function withPaintGesture(state: InteractionState, usedGpuStroke: boolean): InteractionState {
+  return { ...state, gesture: { kind: 'paint', usedGpuStroke } };
+}
+
+/**
+ * Construct a non-paint tool-gesture InteractionState from a down
+ * handler's freshly-returned state, without mutating the input. The
+ * dispatcher used to write `newState.gesture = { kind: 'tool', … }`
+ * directly on the returned object — the audit issue (#444) calls out
+ * post-return mutation as the bag-of-flags smell.
+ */
+export function withToolGesture(state: InteractionState): InteractionState {
+  return { ...state, gesture: { kind: 'tool' } };
 }
 
 export const GESTURE_IDLE: CanvasGesture = { kind: 'idle' };

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -25,7 +25,12 @@ import type {
   FloatingSelection, PersistentTransform, LastPaintPoint,
   PreToolDownGuard,
 } from './interactions/interaction-types';
-import { gestureUsedGpuStroke, INITIAL_INTERACTION_STATE, withToolGesture } from './interactions/interaction-types';
+import {
+  gestureUsedGpuStroke,
+  INITIAL_INTERACTION_STATE,
+  withPaintGesture,
+  withToolGesture,
+} from './interactions/interaction-types';
 import { handleTransformDown } from './interactions/transform-handlers';
 import {
   handleMeshWarpDown,
@@ -304,7 +309,9 @@ export function useCanvasInteraction(
       const handler = toolHandlers[activeTool];
       const newState = handler?.down?.(finalCtx);
       if (newState) {
-        stateRef.current = withToolGesture(newState, !!useGpuStroke);
+        stateRef.current = isPaintTool
+          ? withPaintGesture(newState, !!useGpuStroke)
+          : withToolGesture(newState);
       }
     },
     [screenToCanvas, containerRef, buildContext, cancelHoldTimer],
@@ -343,6 +350,7 @@ export function useCanvasInteraction(
           return;
         case 'idle':
           return;
+        case 'paint':
         case 'tool':
           break;
       }
@@ -495,6 +503,7 @@ export function useCanvasInteraction(
         }
         break;
       case 'idle':
+      case 'paint':
       case 'tool':
         break;
     }


### PR DESCRIPTION
## Summary

Incremental slice on the interaction-state refactor tracked in #444. Splits the `tool` variant of `CanvasGesture` into two:

- `{ kind: 'paint'; usedGpuStroke: boolean }` — brush / pencil / eraser
- `{ kind: 'tool' }` — every other tool (fill, shape, gradient, dodge, burn, sponge, smudge, healing, stamp, selection tools, move, text, path, crop, eyedropper, hand)

Before this change, every tool gesture carried a `usedGpuStroke: boolean` field even though the flag can only ever be `true` for a paint tool on the GPU path (see `useGpuStroke = useGpu && isPaintTool` in `useCanvasInteraction.ts`). Non-paint tools always got `usedGpuStroke: false` — meaningless data structurally allowed to be `true`.

Now the type system rejects `{ kind: 'tool', usedGpuStroke: true }`. `gestureUsedGpuStroke()` narrows on `kind === 'paint'`, and the dispatcher routes handlers through the correct constructor: `withPaintGesture(state, useGpuStroke)` when `isPaintTool`, `withToolGesture(state)` otherwise. This maps directly to the audit issue's proposed `painting` variant.

The `switch` blocks in `handleToolMove` and `handleToolUp` now list `case 'paint':` alongside `case 'tool':` since both fall through to the tool-handler dispatch identically — the specialization is entirely on the `usedGpuStroke` scope, not on control flow.

## Acceptance criteria touched

- [x] Per-tool variants — `painting` split out from the catch-all `tool` variant. (Full split into `erasing`, `movingLayer`, `drawingSelection`, etc. remains for follow-up slices.)

## Test plan

- [x] `npx vitest run src/app/interactions/interaction-types.test.ts` — 20 / 20 pass
- [x] Full `npx vitest run` — 1474 / 1474 pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] New test `CanvasGesture paint/tool split (#444)` locks the invariant: `usedGpuStroke` is a required field on the `paint` variant and does not exist on the `tool` variant. If a future edit adds `usedGpuStroke` back to `tool`, the type assertion fails at compile time.

autofix

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsZZuNfLhmD2UBcBiwa6C4)_