### PR TITLE
docs(features): note Spray size auto-scales with document

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -105,7 +105,7 @@ The toolbar exposes Size, Opacity, Hardness, Fade, and the symmetry toggle. Ever
 - **Shift+click**: smudges along a straight line from the previous stroke endpoint
 
 ### Spray
-- **Size**: 1 - 500 px
+- **Size**: 1 - 500 px (base range; auto-scaled by document size)
 - **Density**: 1 - 100 (number of dots emitted per dab)
 - **Opacity**: 1 - 100%
 - **Softness**: 0 - 100% (per-dot hardness falloff)


### PR DESCRIPTION
## What

The **Spray** tool's Size line in FEATURES.md listed a flat `1 - 500 px`, but the Spray options-bar Size slider uses the same `docScaledMax(docWidth, docHeight, 500)` path (`src/app/OptionsBar/tool-options/SprayOptions.tsx:11`) as every other paint tool — so its effective max grows with the document (`1.5 × longest side`, capped at 5000 px in `src/utils/slider-ranges.ts`).

Every sibling paint tool (Brush, Pencil, Eraser, Dodge/Burn, Smudge, Clone Stamp, Sponge, Healing) already carries an "auto-scaled by document size" note. This aligns Spray's wording.

## Why

Found during the scheduled FEATURES.md accuracy audit. This run cross-checked the full filter registry (all filter param min/max/default), every adjustment-node range, and all tool option ranges against the code — **every other entry matched exactly**. Spray Size was the only discrepancy.

## Change

- `- **Size**: 1 - 500 px` → `- **Size**: 1 - 500 px (base range; auto-scaled by document size)`

Docs-only. No new commits on `origin/main` since the 07-06 batch; the last-2-days window was empty of feature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)