### PR TITLE
feat(seamless): add wrap-around option to seamless preview

### DIFF
--- a/e2e/seamless-wrap.spec.ts
+++ b/e2e/seamless-wrap.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from './fixtures';
+import type { Page } from './fixtures';
+import { waitForStore, createDocument } from './helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readSeamlessState(page: Page): Promise<{
+  showSeamlessPattern: boolean;
+  dimSeamlessPattern: boolean;
+  wrapSeamlessPattern: boolean;
+}> {
+  return page.evaluate(() => {
+    const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+      getState: () => {
+        showSeamlessPattern: boolean;
+        dimSeamlessPattern: boolean;
+        wrapSeamlessPattern: boolean;
+      };
+    };
+    const s = ui.getState();
+    return {
+      showSeamlessPattern: s.showSeamlessPattern,
+      dimSeamlessPattern: s.dimSeamlessPattern,
+      wrapSeamlessPattern: s.wrapSeamlessPattern,
+    };
+  });
+}
+
+async function enableSeamlessPattern(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+      getState: () => { showSeamlessPattern: boolean; toggleSeamlessPattern: () => void };
+    };
+    if (!ui.getState().showSeamlessPattern) ui.getState().toggleSeamlessPattern();
+  });
+  await page.waitForTimeout(50);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Seamless "Wrap" option (#349)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 200, 100, false);
+    await page.waitForTimeout(150);
+  });
+
+  test('wrapSeamlessPattern defaults to false and dimSeamlessPattern defaults to true', async ({ page }) => {
+    const s = await readSeamlessState(page);
+    expect(s.showSeamlessPattern).toBe(false);
+    expect(s.dimSeamlessPattern).toBe(true);
+    expect(s.wrapSeamlessPattern).toBe(false);
+  });
+
+  test('Wrap checkbox is hidden when seamless preview is off', async ({ page }) => {
+    // With seamless off, neither the "Dim pattern" nor "Wrap" checkbox
+    // should be reachable in the options bar.
+    const wrap = page.locator('label:has-text("Wrap") input[type="checkbox"]');
+    await expect(wrap).toHaveCount(0);
+  });
+
+  test('Wrap checkbox appears next to "Dim pattern" when seamless is on', async ({ page }) => {
+    await enableSeamlessPattern(page);
+
+    const dim = page.locator('label:has-text("Dim pattern") input[type="checkbox"]');
+    const wrap = page.locator('label:has-text("Wrap") input[type="checkbox"]');
+    await expect(dim).toBeVisible();
+    await expect(wrap).toBeVisible();
+
+    // Default checkbox states reflect the store defaults.
+    expect(await dim.isChecked()).toBe(true);
+    expect(await wrap.isChecked()).toBe(false);
+  });
+
+  test('clicking Wrap flips wrapSeamlessPattern in the store; unclicking flips it back', async ({ page }) => {
+    await enableSeamlessPattern(page);
+
+    const wrap = page.locator('label:has-text("Wrap") input[type="checkbox"]');
+    await expect(wrap).toBeVisible();
+
+    // Toggle on.
+    await wrap.click();
+    await page.waitForTimeout(50);
+    expect(await wrap.isChecked()).toBe(true);
+    expect((await readSeamlessState(page)).wrapSeamlessPattern).toBe(true);
+
+    // Toggle off.
+    await wrap.click();
+    await page.waitForTimeout(50);
+    expect(await wrap.isChecked()).toBe(false);
+    expect((await readSeamlessState(page)).wrapSeamlessPattern).toBe(false);
+  });
+
+  test('turning seamless off hides the Wrap checkbox but preserves its stored value', async ({ page }) => {
+    // The Wrap flag persists so that turning seamless back on restores the
+    // user's previous choice. This is the same shape as "Dim pattern".
+    await enableSeamlessPattern(page);
+    const wrap = page.locator('label:has-text("Wrap") input[type="checkbox"]');
+    await wrap.click();
+    await page.waitForTimeout(50);
+    expect((await readSeamlessState(page)).wrapSeamlessPattern).toBe(true);
+
+    // Turn seamless off.
+    await page.evaluate(() => {
+      const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { toggleSeamlessPattern: () => void };
+      };
+      ui.getState().toggleSeamlessPattern();
+    });
+    await page.waitForTimeout(50);
+
+    // Checkbox is gone from the DOM, but the store retains wrap=true.
+    await expect(wrap).toHaveCount(0);
+    expect((await readSeamlessState(page)).wrapSeamlessPattern).toBe(true);
+  });
+});

--- a/engine-rs/crates/lopsy-wasm/src/api/overlay.rs
+++ b/engine-rs/crates/lopsy-wasm/src/api/overlay.rs
@@ -76,9 +76,10 @@ pub fn set_rulers_visible(engine: &mut Engine, visible: bool) {
 }
 
 #[wasm_bindgen(js_name = "setSeamlessPattern")]
-pub fn set_seamless_pattern(engine: &mut Engine, enabled: bool, dim: bool) {
+pub fn set_seamless_pattern(engine: &mut Engine, enabled: bool, dim: bool, wrap: bool) {
     engine.inner.seamless_pattern = enabled;
     engine.inner.seamless_dim = dim;
+    engine.inner.seamless_wrap = wrap;
     engine.inner.needs_recomposite = true;
 }
 

--- a/engine-rs/crates/lopsy-wasm/src/compositor.rs
+++ b/engine-rs/crates/lopsy-wasm/src/compositor.rs
@@ -437,6 +437,8 @@ fn blend_onto_composite(
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), tw as f32, th as f32); }
     if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcPremultiplied") { engine.gl.uniform1i(Some(&loc), if premultiplied { 1 } else { 0 }); }
+    let wrap_on = engine.seamless_pattern && engine.seamless_wrap;
+    if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), if wrap_on { 1 } else { 0 }); }
 
     // Color overlay — applied inline in the blend shader
     if let Some(ov) = overlay {
@@ -522,6 +524,8 @@ fn blend_onto_target(
     if let Some(loc) = shader.location(&engine.gl, "u_srcSize") { engine.gl.uniform2f(Some(&loc), tw as f32, th as f32); }
     if let Some(loc) = shader.location(&engine.gl, "u_docSize") { engine.gl.uniform2f(Some(&loc), doc_w, doc_h); }
     if let Some(loc) = shader.location(&engine.gl, "u_srcPremultiplied") { engine.gl.uniform1i(Some(&loc), if premultiplied { 1 } else { 0 }); }
+    let wrap_on = engine.seamless_pattern && engine.seamless_wrap;
+    if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), if wrap_on { 1 } else { 0 }); }
 
     if let Some(ov) = overlay {
         if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 1); }
@@ -592,6 +596,7 @@ fn render_mask_overlay(
     if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_maskOverlay") { engine.gl.uniform1i(Some(&loc), 1); }
+    if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
 
     engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_a);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);
@@ -643,6 +648,7 @@ fn render_quick_mask_overlay(engine: &mut EngineInner) {
     if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_maskOverlay") { engine.gl.uniform1i(Some(&loc), 1); }
+    if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
 
     engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_a);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);
@@ -694,6 +700,7 @@ fn blend_effect_onto_composite(engine: &mut EngineInner) {
     if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
     if let Some(loc) = shader.location(&engine.gl, "u_maskOverlay") { engine.gl.uniform1i(Some(&loc), 0); }
+    if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
 
     engine.fbo_pool.bind(&engine.gl, engine.scratch_fbo_b);
     engine.gl.viewport(0, 0, doc_w as i32, doc_h as i32);

--- a/engine-rs/crates/lopsy-wasm/src/engine.rs
+++ b/engine-rs/crates/lopsy-wasm/src/engine.rs
@@ -251,6 +251,12 @@ pub struct EngineInner {
     pub path_overlay: Option<String>,
     pub seamless_pattern: bool,
     pub seamless_dim: bool,
+    /// When true (and seamless_pattern is on), layer compositing wraps
+    /// modularly at the document edges — content that overhangs one side
+    /// reappears on the opposite side. The layer texture itself is untouched
+    /// so repeated moves keep transforming the original content, not the
+    /// already-wrapped result.
+    pub seamless_wrap: bool,
     pub channel_mask: [f32; 4],
     pub selection_time: f64,
     /// Per-document image adjustments — exposure/contrast/highlights/
@@ -408,6 +414,7 @@ impl EngineInner {
             path_overlay: None,
             seamless_pattern: false,
             seamless_dim: true,
+            seamless_wrap: false,
             channel_mask: [1.0, 1.0, 1.0, 1.0],
             selection_time: 0.0,
             adjustments: ImageAdjustmentState::default(),

--- a/engine-rs/crates/lopsy-wasm/src/gpu/shaders/blend.glsl
+++ b/engine-rs/crates/lopsy-wasm/src/gpu/shaders/blend.glsl
@@ -16,6 +16,10 @@ uniform vec2 u_srcOffset;  // layer position in document pixels
 uniform vec2 u_srcSize;    // layer texture size in pixels
 uniform vec2 u_docSize;    // document size in pixels
 uniform int u_srcPremultiplied; // 1 if source is premultiplied alpha
+// When 1, the layer texture wraps modularly across the document — content
+// that overhangs one edge appears on the opposite side. Enabled by the
+// "Wrap" checkbox next to "Dim pattern" in the seamless-preview options.
+uniform int u_wrapLayer;
 uniform int u_overlayEnabled;   // 1 if color overlay is active
 uniform vec3 u_overlayColor;    // overlay color (RGB)
 uniform float u_overlayOpacity; // overlay mix factor
@@ -119,9 +123,19 @@ vec3 blendMode(vec3 s, vec3 d) {
 void main() {
     vec4 dst = texture(u_dstTex, v_uv);
 
-    // Map document UV to layer-local UV
+    // Map document UV to layer-local UV. When u_wrapLayer is on, pick the
+    // integer shift `n` per axis that puts the fragment closest to the
+    // nearest tiled copy of the layer's center — turning overhang on one
+    // edge into coverage on the opposite edge. The shift is applied to
+    // u_srcOffset (not to the layer texture), so repeated moves keep
+    // sampling from the original pixels.
     vec2 docPos = v_uv * u_docSize;
-    vec2 layerUV = (docPos - u_srcOffset) / u_srcSize;
+    vec2 effectiveOffset = u_srcOffset;
+    if (u_wrapLayer == 1) {
+        vec2 n = floor((docPos - u_srcOffset - u_srcSize * 0.5) / u_docSize + 0.5);
+        effectiveOffset = u_srcOffset + n * u_docSize;
+    }
+    vec2 layerUV = (docPos - effectiveOffset) / u_srcSize;
 
     // Outside layer bounds: pass through destination
     if (layerUV.x < 0.0 || layerUV.x > 1.0 || layerUV.y < 0.0 || layerUV.y > 1.0) {
@@ -153,9 +167,10 @@ void main() {
         src.rgb = mix(src.rgb, u_overlayColor, u_overlayOpacity);
     }
 
-    // Apply layer mask: multiply source alpha by mask value
+    // Apply layer mask: multiply source alpha by mask value.
+    // Use the same effectiveOffset so the mask wraps with the layer.
     if (u_hasMask == 1) {
-        vec2 maskUV = (docPos - u_srcOffset) / u_maskSize;
+        vec2 maskUV = (docPos - effectiveOffset) / u_maskSize;
         if (maskUV.x >= 0.0 && maskUV.x <= 1.0 && maskUV.y >= 0.0 && maskUV.y <= 1.0) {
             float maskVal = texture(u_maskTex, maskUV).r;
             src.a *= maskVal;

--- a/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
+++ b/engine-rs/crates/lopsy-wasm/src/layer_manager.rs
@@ -246,6 +246,7 @@ pub fn merge_layers(
         if let Some(loc) = shader.location(&engine.gl, "u_srcPremultiplied") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
+        if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
         engine.draw_fullscreen_quad();
     }
 
@@ -276,6 +277,7 @@ pub fn merge_layers(
         if let Some(loc) = shader.location(&engine.gl, "u_srcPremultiplied") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
+        if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
         engine.draw_fullscreen_quad();
     }
 
@@ -1133,6 +1135,7 @@ pub fn composite_float(
         if let Some(loc) = shader.location(&engine.gl, "u_srcPremultiplied") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_overlayEnabled") { engine.gl.uniform1i(Some(&loc), 0); }
         if let Some(loc) = shader.location(&engine.gl, "u_hasMask") { engine.gl.uniform1i(Some(&loc), 0); }
+        if let Some(loc) = shader.location(&engine.gl, "u_wrapLayer") { engine.gl.uniform1i(Some(&loc), 0); }
         engine.draw_fullscreen_quad();
     });
 

--- a/src/app/OptionsBar/OptionsBar.tsx
+++ b/src/app/OptionsBar/OptionsBar.tsx
@@ -26,6 +26,8 @@ export function OptionsBar() {
   const showSeamlessPattern = useUIStore((s) => s.showSeamlessPattern);
   const dimSeamlessPattern = useUIStore((s) => s.dimSeamlessPattern);
   const toggleDimSeamlessPattern = useUIStore((s) => s.toggleDimSeamlessPattern);
+  const wrapSeamlessPattern = useUIStore((s) => s.wrapSeamlessPattern);
+  const toggleWrapSeamlessPattern = useUIStore((s) => s.toggleWrapSeamlessPattern);
   const docWidth = useEditorStore((s) => s.document.width);
   const docHeight = useEditorStore((s) => s.document.height);
 
@@ -88,6 +90,16 @@ export function OptionsBar() {
                 onChange={toggleDimSeamlessPattern}
               />
               Dim pattern
+            </label>
+          )}
+          {showSeamlessPattern && (
+            <label className={styles.checkbox}>
+              <input
+                type="checkbox"
+                checked={wrapSeamlessPattern}
+                onChange={toggleWrapSeamlessPattern}
+              />
+              Wrap
             </label>
           )}
         </div>

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -126,6 +126,11 @@ interface UIState {
   showGuides: boolean;
   showSeamlessPattern: boolean;
   dimSeamlessPattern: boolean;
+  /** When enabled alongside `showSeamlessPattern`, layer compositing wraps
+   *  at the document edges — content moved off one side reappears on the
+   *  opposite side. The layer texture is left untouched so repeated moves
+   *  operate on the original pixels, not on the already-wrapped result. */
+  wrapSeamlessPattern: boolean;
   snapToGrid: boolean;
   snapToLayers: boolean;
   /** Temporary snap alignment lines shown during move/transform. */
@@ -192,6 +197,7 @@ interface UIState {
   toggleGuides: () => void;
   toggleSeamlessPattern: () => void;
   toggleDimSeamlessPattern: () => void;
+  toggleWrapSeamlessPattern: () => void;
   toggleSnapToGrid: () => void;
   toggleSnapToLayers: () => void;
   setSnapLines: (lines: readonly SnapLine[]) => void;
@@ -273,6 +279,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   showGuides: true,
   showSeamlessPattern: false,
   dimSeamlessPattern: true,
+  wrapSeamlessPattern: false,
   snapToGrid: false,
   snapToLayers: false,
   snapLines: [],
@@ -371,6 +378,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   toggleGuides: () => set((state) => ({ showGuides: !state.showGuides })),
   toggleSeamlessPattern: () => set((state) => ({ showSeamlessPattern: !state.showSeamlessPattern })),
   toggleDimSeamlessPattern: () => set((state) => ({ dimSeamlessPattern: !state.dimSeamlessPattern })),
+  toggleWrapSeamlessPattern: () => set((state) => ({ wrapSeamlessPattern: !state.wrapSeamlessPattern })),
   toggleSnapToGrid: () => set((state) => ({ snapToGrid: !state.snapToGrid })),
   toggleSnapToLayers: () => set((state) => ({ snapToLayers: !state.snapToLayers })),
   setSnapLines: (lines) => set({ snapLines: lines }),

--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -201,7 +201,7 @@ function renderFrameGpu(
   syncSelection(engine, selection);
   syncGrid(engine, showGrid, gridSize);
   syncRulers(engine, showRulers);
-  syncSeamlessPattern(engine, uiState.showSeamlessPattern, uiState.dimSeamlessPattern);
+  syncSeamlessPattern(engine, uiState.showSeamlessPattern, uiState.dimSeamlessPattern, uiState.wrapSeamlessPattern);
   syncChannelVisibility(engine, uiState.channelVisibility);
   syncAdjustments(engine, adjustments, adjustmentsEnabled);
   syncGroupAdjustments(engine, layers);

--- a/src/engine-wasm/engine-sync.test.ts
+++ b/src/engine-wasm/engine-sync.test.ts
@@ -169,6 +169,45 @@ describe('syncChannelVisibility — per-frame diffing (#595 follow-up)', () => {
   });
 });
 
+describe('syncSeamlessPattern — per-frame diffing + wrap flag (#349)', () => {
+  beforeEach(() => {
+    vi.mocked(bridge.setSeamlessPattern).mockClear();
+  });
+
+  it('pushes once for repeated identical state, again when show/dim/wrap changes', () => {
+    const engine = makeFakeEngine();
+    sync.syncSeamlessPattern(engine, false, true, false);
+    // Initial call from cleared tracked state → first push.
+    sync.syncSeamlessPattern(engine, false, true, false);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(0);
+    // (tracked state initialises to the same values, so the first call above
+    // was a no-op. Turning on `show` should push.)
+    sync.syncSeamlessPattern(engine, true, true, false);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenLastCalledWith(engine, true, true, false);
+
+    // Flipping wrap independently pushes again — this is the new bit from #349.
+    sync.syncSeamlessPattern(engine, true, true, true);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenLastCalledWith(engine, true, true, true);
+
+    // Same values three times → no extra pushes.
+    sync.syncSeamlessPattern(engine, true, true, true);
+    sync.syncSeamlessPattern(engine, true, true, true);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-pushes after resetTrackedState so undo/redo full re-sync includes wrap', () => {
+    const engine = makeFakeEngine();
+    sync.syncSeamlessPattern(engine, true, false, true);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(1);
+    sync.resetTrackedState(engine);
+    sync.syncSeamlessPattern(engine, true, false, true);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(bridge.setSeamlessPattern)).toHaveBeenLastCalledWith(engine, true, false, true);
+  });
+});
+
 describe('syncMaskEditMode — per-frame diffing (#595 follow-up)', () => {
   beforeEach(() => {
     vi.mocked(bridge.setMaskEditLayer).mockClear();

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -217,12 +217,17 @@ export function syncRulers(engine: Engine, showRulers: boolean): void {
   }
 }
 
-export function syncSeamlessPattern(engine: Engine, show: boolean, dim: boolean): void {
+export function syncSeamlessPattern(engine: Engine, show: boolean, dim: boolean, wrap: boolean): void {
   const tracked = getTracked(engine);
-  if (tracked.showSeamlessPattern !== show || tracked.dimSeamlessPattern !== dim) {
-    setSeamlessPattern(engine, show, dim);
+  if (
+    tracked.showSeamlessPattern !== show
+    || tracked.dimSeamlessPattern !== dim
+    || tracked.wrapSeamlessPattern !== wrap
+  ) {
+    setSeamlessPattern(engine, show, dim, wrap);
     tracked.showSeamlessPattern = show;
     tracked.dimSeamlessPattern = dim;
+    tracked.wrapSeamlessPattern = wrap;
   }
 }
 

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -47,6 +47,7 @@ export interface TrackedState {
   showRulers: boolean;
   showSeamlessPattern: boolean;
   dimSeamlessPattern: boolean;
+  wrapSeamlessPattern: boolean;
   /** Last channel mask pushed to the engine as an "r,g,b,a" key.
    *  Empty string = unknown (first frame / after reset), forces a push. */
   channelMask: string;
@@ -142,6 +143,7 @@ function createTrackedState(): TrackedState {
     showRulers: false,
     showSeamlessPattern: false,
     dimSeamlessPattern: true,
+    wrapSeamlessPattern: false,
     channelMask: '',
     maskEditLayerId: undefined,
     adjustmentsRef: null,


### PR DESCRIPTION
Closes #349.

## Summary

- Adds a **Wrap** checkbox next to *Dim pattern* in the options bar. Visible whenever Show Seamless Pattern is on; hidden (but state-preserving) otherwise, matching the existing *Dim pattern* pattern.
- When enabled, layer compositing wraps modularly at the document edges — content moved off one side reappears on the opposite side, without ever mutating the layer texture. Repeated moves keep transforming the original content, not the already-wrapped result — the invariant the issue calls out.

## Design

The wrap happens in the blend shader. For each fragment we pick the integer shift `n` per axis that puts the fragment closest to the nearest tiled copy of the layer's centre, then apply that shift to `u_srcOffset` (not to the texture). The layer stays represented at its original position — the shader just also lets it "reach" fragments in neighbouring virtual tiles inside the document.

```glsl
vec2 n = floor((docPos - u_srcOffset - u_srcSize * 0.5) / u_docSize + 0.5);
vec2 effectiveOffset = u_srcOffset + n * u_docSize;
vec2 layerUV = (docPos - effectiveOffset) / u_srcSize;
```

Wrap is scoped to the two main layer→composite paths (`blend_onto_composite`, `blend_onto_target`). Every other use of the blend shader (mask overlays, effect blends, `merge_down`, float composite/restore) explicitly sets `u_wrapLayer = 0`, so a stale uniform from a previous frame can't leak wrap into paths where it doesn't belong.

Both flags must be true (`seamless_pattern && seamless_wrap`) for wrap to take effect, so turning off the seamless preview also turns off the wrap — matching the UI where the checkbox is hidden when seamless is off.

## Test plan

- [x] Unit tests: `syncSeamlessPattern` diffs the new `wrap` param, pushes on change, re-pushes after `resetTrackedState`. `src/engine-wasm/engine-sync.test.ts` — 27 tests pass.
- [x] Full unit suite: 1470 tests pass.
- [x] New e2e spec `e2e/seamless-wrap.spec.ts` (5 tests): default values, checkbox hidden when seamless is off, checkbox appears with correct default when seamless is on, clicking flips the store both ways, turning seamless off preserves the stored `wrap` value.
- [x] Regression coverage: existing `e2e/rendering.spec.ts` (88 tests) + `e2e/history.spec.ts` — all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KvdtodPixUrRxd9LuauQq4)_