### PR TITLE
fix(paste): paste an internal copy in place; cap pencil slider at 250

### DIFF
--- a/e2e/cut-paste-position.spec.ts
+++ b/e2e/cut-paste-position.spec.ts
@@ -304,6 +304,130 @@ test.describe('Cut/paste ellipse positioning', () => {
 
     await page.screenshot({ path: 'e2e/screenshots/cut-paste-position-no-selection.png' });
   });
+
+  test('system-clipboard paste-back of an internal copy lands at the copied position, not 0,0', async ({ page }) => {
+    // Reproduces the real-browser path that unit-headless tests miss: copy()
+    // mirrors the selection to the system clipboard as a position-less PNG, so
+    // a native Cmd+V paste event carries that image. The handler must recognise
+    // it as our own copy (by matching dimensions AND pixels) and paste in
+    // place, not drop a fresh layer at 0,0.
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await createDocument(page, 600, 400, true);
+    await page.waitForTimeout(300);
+
+    await drawEllipse(page, 450, 300, 40, 30, { r: 255, g: 128, b: 0 });
+
+    await setSelection(page, 410, 270, 80, 60);
+    await page.waitForTimeout(100);
+    await page.keyboard.press(`${mod}+KeyC`);
+    await page.waitForTimeout(200);
+
+    const afterCopy = await getEditorState(page);
+    expect(afterCopy.clipboard).not.toBeNull();
+    const offsetX = afterCopy.clipboard!.offsetX;
+    const offsetY = afterCopy.clipboard!.offsetY;
+    expect(offsetX).toBeGreaterThanOrEqual(410);
+    expect(offsetY).toBeGreaterThanOrEqual(270);
+
+    // copy() writes the real copied pixels to the system clipboard asynchronously.
+    await page.waitForFunction(async () => {
+      try {
+        const items = await navigator.clipboard.read();
+        return items.some((it) => it.types.some((t) => t.startsWith('image/')));
+      } catch {
+        return false;
+      }
+    }, undefined, { timeout: 5000 });
+
+    // Dispatch a native paste event carrying the *actual* PNG the OS clipboard
+    // now holds — content that matches the internal clipboard pixel-for-pixel.
+    await page.evaluate(async () => {
+      const items = await navigator.clipboard.read();
+      let blob: Blob | null = null;
+      for (const it of items) {
+        const type = it.types.find((t) => t.startsWith('image/'));
+        if (type) {
+          blob = await it.getType(type);
+          break;
+        }
+      }
+      if (!blob) throw new Error('no image on system clipboard');
+      const file = new File([blob], 'image.png', { type: 'image/png' });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const evt = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true });
+      window.dispatchEvent(evt);
+    });
+
+    await page.waitForFunction(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { layers: Array<{ name: string }> } };
+      };
+      return store.getState().document.layers.some((l) => l.name === 'Pasted Layer');
+    }, { timeout: 5000 });
+
+    const state = await getEditorState(page);
+    const pastedLayer = state.document.layers.find((l) => l.name === 'Pasted Layer');
+    expect(pastedLayer).toBeDefined();
+
+    // The bug: system-clipboard paste-back dropped the layer at 0,0.
+    // The fix: it pastes in place at the copied offset.
+    expect(pastedLayer!.x).toBe(offsetX);
+    expect(pastedLayer!.y).toBe(offsetY);
+    expect(pastedLayer!.x).not.toBe(0);
+    expect(pastedLayer!.y).not.toBe(0);
+  });
+
+  test('external image matching the copied dimensions still pastes as a new external layer at 0,0', async ({ page }) => {
+    // Guards the content-verification path: a *different* image that merely
+    // shares the copied dimensions must NOT be substituted with the internal
+    // clipboard's pixels — it is genuinely external and pastes at 0,0.
+    await createDocument(page, 600, 400, true);
+    await page.waitForTimeout(300);
+
+    await drawEllipse(page, 450, 300, 40, 30, { r: 255, g: 128, b: 0 });
+    await setSelection(page, 410, 270, 80, 60);
+    await page.waitForTimeout(100);
+    await page.keyboard.press(`${mod}+KeyC`);
+    await page.waitForTimeout(200);
+
+    const afterCopy = await getEditorState(page);
+    expect(afterCopy.clipboard).not.toBeNull();
+    const clipW = afterCopy.clipboard!.width;
+    const clipH = afterCopy.clipboard!.height;
+
+    // A solid blue PNG of the same dimensions — same size, different content.
+    await page.evaluate(async ({ w, h }) => {
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d')!;
+      ctx.fillStyle = 'rgba(0,0,255,1)';
+      ctx.fillRect(0, 0, w, h);
+      const blob: Blob = await new Promise((resolve) =>
+        canvas.toBlob((b) => resolve(b!), 'image/png'),
+      );
+      const file = new File([blob], 'image.png', { type: 'image/png' });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const evt = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true });
+      window.dispatchEvent(evt);
+    }, { w: clipW, h: clipH });
+
+    await page.waitForFunction(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { layers: Array<{ name: string }> } };
+      };
+      return store.getState().document.layers.some((l) => l.name === 'Pasted Layer');
+    }, { timeout: 5000 });
+
+    const state = await getEditorState(page);
+    const pastedLayer = state.document.layers.find((l) => l.name === 'Pasted Layer');
+    expect(pastedLayer).toBeDefined();
+    // External image → pasted via pasteOrOpenBlob at the origin, not in place.
+    expect(pastedLayer!.x).toBe(0);
+    expect(pastedLayer!.y).toBe(0);
+  });
 });
 
 // ===========================================================================

--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -45,6 +45,7 @@ const ALLOWLIST = {
   'src/app/store/actions/remove-layer.test.ts': 1,
   'src/app/store/actions/resize-canvas.test.ts': 1,
   'src/app/store/actions/resize-image.test.ts': 1,
+  'src/app/store/clipboard-image-match.test.ts': 1,
   'src/engine-wasm/engine-sync.test.ts': 3,
   'src/engine-wasm/sync-layers.test.ts': 7,            // +1: shared mask fixture for upload-retry-cap tests
   'src/engine/pixel-data-manager.test.ts': 2,

--- a/src/app/OptionsBar/tool-options/PencilOptions.tsx
+++ b/src/app/OptionsBar/tool-options/PencilOptions.tsx
@@ -13,7 +13,7 @@ export function PencilOptions() {
 
   return (
     <>
-      <Slider label="Size" value={pencilSize} min={1} max={sizeMax} onChange={(size) => setPencilSetting('size', size)} />
+      <Slider label="Size" value={pencilSize} min={1} max={sizeMax} sliderMax={250} onChange={(size) => setPencilSetting('size', size)} />
       <SymmetryControls />
     </>
   );

--- a/src/app/store/clipboard-image-match.test.ts
+++ b/src/app/store/clipboard-image-match.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { pixelsLikelySame } from './clipboard-image-match';
+
+/** Build a solid-color RGBA buffer of `count` pixels. */
+function solid(count: number, r: number, g: number, b: number, a: number): Uint8ClampedArray {
+  const buf = new Uint8ClampedArray(count * 4);
+  for (let i = 0; i < count; i++) {
+    buf[i * 4] = r;
+    buf[i * 4 + 1] = g;
+    buf[i * 4 + 2] = b;
+    buf[i * 4 + 3] = a;
+  }
+  return buf;
+}
+
+describe('pixelsLikelySame', () => {
+  it('returns true for identical opaque buffers', () => {
+    const a = solid(1000, 200, 100, 50, 255);
+    const b = solid(1000, 200, 100, 50, 255);
+    expect(pixelsLikelySame(a, b)).toBe(true);
+  });
+
+  it('returns false for buffers of different length', () => {
+    expect(pixelsLikelySame(solid(100, 0, 0, 0, 255), solid(101, 0, 0, 0, 255))).toBe(false);
+  });
+
+  it('returns false for empty buffers', () => {
+    expect(pixelsLikelySame(solid(0, 0, 0, 0, 0), solid(0, 0, 0, 0, 0))).toBe(false);
+  });
+
+  it('returns false when opaque colors clearly differ', () => {
+    const red = solid(1000, 255, 0, 0, 255);
+    const blue = solid(1000, 0, 0, 255, 255);
+    expect(pixelsLikelySame(red, blue)).toBe(false);
+  });
+
+  it('tolerates small RGB noise on opaque pixels (round-trip rounding)', () => {
+    const a = solid(1000, 128, 128, 128, 255);
+    const b = solid(1000, 128, 128, 128, 255);
+    // Nudge every channel by <= the 6-unit tolerance.
+    for (let i = 0; i < 1000; i++) {
+      b[i * 4] = 132;
+      b[i * 4 + 1] = 123;
+      b[i * 4 + 2] = 130;
+    }
+    expect(pixelsLikelySame(a, b)).toBe(true);
+  });
+
+  it('rejects RGB differences beyond tolerance on opaque pixels', () => {
+    const a = solid(1000, 100, 100, 100, 255);
+    const b = solid(1000, 120, 100, 100, 255); // +20 on red, well past tolerance
+    expect(pixelsLikelySame(a, b)).toBe(false);
+  });
+
+  it('returns false when the alpha shape differs', () => {
+    const opaque = solid(1000, 50, 50, 50, 255);
+    const transparent = solid(1000, 50, 50, 50, 0);
+    expect(pixelsLikelySame(opaque, transparent)).toBe(false);
+  });
+
+  it('ignores RGB under partial/low alpha (premultiplied round-trip is unreliable there)', () => {
+    // Same alpha shape (semi-transparent), wildly different RGB — should still
+    // match because RGB is only compared where both alphas are near-opaque.
+    const a = solid(1000, 10, 20, 30, 100);
+    const b = solid(1000, 200, 180, 160, 100);
+    expect(pixelsLikelySame(a, b)).toBe(true);
+  });
+
+  it('detects a differing region within otherwise-matching content', () => {
+    const a = solid(1000, 0, 0, 0, 255);
+    const b = solid(1000, 0, 0, 0, 255);
+    // Flip a large fraction of pixels to a very different color — well past the
+    // 2% mismatch threshold.
+    for (let i = 0; i < 500; i++) {
+      b[i * 4] = 255;
+      b[i * 4 + 1] = 255;
+      b[i * 4 + 2] = 255;
+    }
+    expect(pixelsLikelySame(a, b)).toBe(false);
+  });
+});

--- a/src/app/store/clipboard-image-match.ts
+++ b/src/app/store/clipboard-image-match.ts
@@ -1,0 +1,73 @@
+/**
+ * Helpers for deciding whether an image pasted from the system clipboard is a
+ * paste-back of content that was copied inside the app. Kept free of engine /
+ * store imports so the pixel-matching logic stays pure and unit-testable.
+ */
+
+/** Decode an image blob to straight (non-premultiplied) RGBA bytes. */
+export async function decodeBlobToRgba(
+  blob: Blob,
+): Promise<{ data: Uint8ClampedArray; width: number; height: number } | null> {
+  try {
+    // No color-space conversion / premultiplication so the decoded bytes match
+    // the raw GPU pixels the clipboard PNG was written from — otherwise a
+    // wide-gamut (Display-P3) round-trip could shift RGB past the match
+    // tolerance and drop a legitimate paste-back back to 0,0.
+    const bitmap = await createImageBitmap(blob, {
+      colorSpaceConversion: 'none',
+      premultiplyAlpha: 'none',
+    });
+    const { width, height } = bitmap;
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      bitmap.close();
+      return null;
+    }
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close();
+    return { data: ctx.getImageData(0, 0, width, height).data, width, height };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether two equal-length RGBA buffers hold (near-)identical content.
+ *
+ * A system-clipboard round-trip can nudge RGB values under partial alpha
+ * (canvas premultiplied-alpha decoding), so RGB is only compared where the
+ * pixel is near-opaque and alpha is compared everywhere with a small
+ * tolerance. Content is sampled — a few thousand pixels is plenty to tell our
+ * own copy apart from an unrelated image of the same dimensions.
+ */
+export function pixelsLikelySame(
+  a: Uint8Array | Uint8ClampedArray,
+  b: Uint8Array | Uint8ClampedArray,
+): boolean {
+  if (a.length !== b.length || a.length === 0) return false;
+  const pixelCount = a.length / 4;
+  const step = Math.max(1, Math.floor(pixelCount / 4096));
+  let checked = 0;
+  let mismatches = 0;
+  for (let p = 0; p < pixelCount; p += step) {
+    const i = p * 4;
+    checked++;
+    const aAlpha = a[i + 3]!;
+    const bAlpha = b[i + 3]!;
+    if (Math.abs(aAlpha - bAlpha) > 4) {
+      mismatches++;
+      continue;
+    }
+    if (aAlpha > 250 && bAlpha > 250) {
+      if (
+        Math.abs(a[i]! - b[i]!) > 6 ||
+        Math.abs(a[i + 1]! - b[i + 1]!) > 6 ||
+        Math.abs(a[i + 2]! - b[i + 2]!) > 6
+      ) {
+        mismatches++;
+      }
+    }
+  }
+  return checked > 0 && mismatches / checked < 0.02;
+}

--- a/src/app/store/clipboard-slice.ts
+++ b/src/app/store/clipboard-slice.ts
@@ -12,6 +12,7 @@ import {
   uploadClipboardPixels,
   compositeForExport,
 } from '../../engine-wasm/wasm-bridge';
+import { decodeBlobToRgba, pixelsLikelySame } from './clipboard-image-match';
 import type { ClipboardData, SliceCreator } from './types';
 
 function writeToSystemClipboard(width: number, height: number): void {
@@ -43,6 +44,13 @@ export interface ClipboardSlice {
   copyMerged: () => void;
   cut: () => void;
   paste: () => void;
+  /**
+   * If `blob` is a paste-back of content copied inside the app — same
+   * dimensions AND (near-)identical pixels as the GPU-resident clipboard —
+   * paste it in place at the copied offset and return true. Otherwise return
+   * false so the caller can treat it as an external image.
+   */
+  tryPasteInternalCopy: (blob: Blob) => Promise<boolean>;
   pasteImageData: (imageData: ImageData) => void;
   /** Create a layer for pixels already uploaded to the GPU by decodeAndUploadImage. */
   pasteGpuLayer: (layerId: string, width: number, height: number) => void;
@@ -215,6 +223,30 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
       },
       renderVersion: state.renderVersion + 1,
     });
+  },
+
+  tryPasteInternalCopy: async (blob: Blob): Promise<boolean> => {
+    const clip = get().clipboard;
+    if (!clip) return false;
+    const engine = getEngine();
+    if (!engine) return false;
+
+    const decoded = await decodeBlobToRgba(blob);
+    if (!decoded || decoded.width !== clip.width || decoded.height !== clip.height) return false;
+
+    // read_clipboard_pixels throws when the GPU clipboard texture is gone
+    // (e.g. after the engine was reset by File > New), which also guards
+    // paste() below from operating on a released clipboard.
+    let clipPixels: Uint8Array;
+    try {
+      clipPixels = readClipboardPixels(engine);
+    } catch {
+      return false;
+    }
+    if (!pixelsLikelySame(clipPixels, decoded.data)) return false;
+
+    get().paste();
+    return true;
   },
 
   pasteImageData: (imageData: ImageData) => {

--- a/src/app/store/document-slice.ts
+++ b/src/app/store/document-slice.ts
@@ -229,7 +229,9 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     clearEngine();
     const result = computeCreateDocument(width, height, transparentBg);
     applyActionResult(set, result);
-    set({ documentVersion: get().documentVersion + 1 });
+    // clearEngine() released the GPU clipboard texture; drop the stale JS
+    // clipboard so a subsequent paste doesn't operate on a freed texture.
+    set({ documentVersion: get().documentVersion + 1, clipboard: null });
     if (result.layerPixelData && result.document) {
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);
     }
@@ -243,7 +245,8 @@ export const createDocumentSlice: SliceCreator<DocumentSlice> = (set, get) => ({
     clearEngine();
     const result = computeOpenImage(imageData, name);
     applyActionResult(set, result);
-    set({ documentVersion: get().documentVersion + 1 });
+    // See createDocument: the GPU clipboard texture is gone after clearEngine().
+    set({ documentVersion: get().documentVersion + 1, clipboard: null });
     if (result.layerPixelData && result.document) {
       syncPixelDataToGpu(result.layerPixelData, result.document.layers);
     }

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -150,6 +150,7 @@ export interface EditorState {
   copyMerged: () => void;
   cut: () => void;
   paste: () => void;
+  tryPasteInternalCopy: (blob: Blob) => Promise<boolean>;
   pasteImageData: (imageData: ImageData) => void;
   pasteGpuLayer: (layerId: string, width: number, height: number) => void;
 

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -35,6 +35,25 @@ function cancelFallbackPaste(): void {
   }
 }
 
+/**
+ * Route a pasted image blob, preferring the internal clipboard when the image
+ * is a paste-back of content that was copied *inside* the app.
+ *
+ * `copy()`/`cut()` mirror the copied pixels to the system clipboard as a plain
+ * PNG so they can be pasted into other apps. That PNG carries no position, so
+ * routing it through `pasteOrOpenBlob` drops the new layer at 0,0 — losing the
+ * location the content was copied from. The internal clipboard, by contrast,
+ * records the copy offset and pastes in place. `tryPasteInternalCopy` uses it
+ * when the incoming image matches the internal clipboard's dimensions and
+ * pixels; otherwise this is a genuinely external image and we open it normally.
+ */
+async function pasteImageBlob(blob: Blob, name: string): Promise<void> {
+  const handledInternally = await useEditorStore.getState().tryPasteInternalCopy(blob);
+  if (!handledInternally) {
+    await pasteOrOpenBlob(blob, name);
+  }
+}
+
 interface KeyboardShortcutDeps {
   canvasRef: RefObject<HTMLCanvasElement | null>;
   /**
@@ -180,7 +199,7 @@ export function useKeyboardShortcuts({
         if (file && file.type.startsWith('image/')) {
           e.preventDefault();
           const name = file.name.replace(/\.[^.]+$/, '') || 'Copied File';
-          pasteOrOpenBlob(file, name).catch((err) =>
+          pasteImageBlob(file, name).catch((err) =>
             notifyError(`Failed to paste image: ${describeError(err)}`),
           );
           return;
@@ -197,7 +216,7 @@ export function useKeyboardShortcuts({
             const blob = item.getAsFile();
             if (blob) {
               e.preventDefault();
-              pasteOrOpenBlob(blob, 'Copied File').catch((err) =>
+              pasteImageBlob(blob, 'Copied File').catch((err) =>
                 notifyError(`Failed to paste image: ${describeError(err)}`),
               );
               return;
@@ -215,7 +234,7 @@ export function useKeyboardShortcuts({
             const imageType = clipboardItem.types.find((t: string) => t.startsWith('image/'));
             if (imageType) {
               const blob = await clipboardItem.getType(imageType);
-              await pasteOrOpenBlob(blob, 'Copied File');
+              await pasteImageBlob(blob, 'Copied File');
               return;
             }
           }


### PR DESCRIPTION
## Summary

Two changes from this session:

### 1. Paste an internal copy in place instead of at 0,0 (`fix(paste)`)

`copy()`/`cut()`/`copyMerged()` mirror the selection to the **system clipboard** as a position-less PNG so it can be pasted into other apps. In a real browser that PNG shows up in the paste event's `clipboardData`, so `handlePaste` routed it through `pasteOrOpenBlob` and dropped a fresh layer at **0,0** — losing the copied position. Headless e2e never caught this because `navigator.clipboard.write` is a no-op there, so paste silently fell through to the correct internal path.

System-clipboard images now go through `tryPasteInternalCopy`, which pastes in place via the internal clipboard **only when the incoming image matches the GPU-resident clipboard's dimensions AND pixels** (`pixelsLikelySame`). A same-size but *different* external image (e.g. a document-sized screenshot after `copyMerged`) is still opened normally at 0,0.

Hardening (from two adversarial review passes):
- **Content verification**, not just dimensions — avoids silently substituting stale clipboard content for a same-size external image.
- Decode with `colorSpaceConversion: 'none'` so a wide-gamut (Display-P3) round-trip doesn't shift RGB past the match tolerance and drop a legit paste-back back to 0,0.
- Read the clipboard pixels before calling `paste()`, so it never runs on a released GPU texture (no orphan history / double-paste).
- Null `state.clipboard` on `File > New` / open, since `clearEngine()` frees the GPU clipboard.

### 2. Cap pencil size slider knob at 250 (`feat(pencil)`)

Adds `sliderMax={250}` to the pencil size `Slider`, matching the convention the other size-slider tools already use (Brush/Eraser cap at 300, Spray at 500). The typeable component `max` (`docScaledMax`) is unchanged.

## Testing

- New e2e (`e2e/cut-paste-position.spec.ts`) reproduces the **real-browser path** — grants clipboard permissions, reads back the actual written PNG, and dispatches a native `paste` event. One test asserts paste-in-place at the copied offset; one asserts a same-size *different* image stays external at 0,0. Confirmed the positive test **fails without the fix** (`Expected: 410, Received: 0`).
- New unit tests for `pixelsLikelySame` (`clipboard-image-match.test.ts`).
- All 29 paste/clipboard e2e pass; **1477 unit tests pass**; typecheck + lint clean; pixel-debt check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)