### PR TITLE
Dock panels follow-up: stories, LiquifyPanel fix, and review hardening

### DIFF
--- a/e2e/GUIDE.md
+++ b/e2e/GUIDE.md
@@ -153,8 +153,8 @@ you missed.
 
 **Always write tests by screenshot first, assertion second.** The
 screenshot is the contract — it's the visual record of what the test
-is actually verifying, committed alongside the spec file for future
-reviewers.
+is actually verifying, and the thing you reconcile your assertions
+against while writing and debugging.
 
 ### The screenshot-first workflow
 
@@ -179,19 +179,18 @@ reviewers.
    looks correct, your assertion values or coordinates are wrong —
    not the feature.
 
-### Screenshots are committed to git
+### Screenshots are local artifacts — don't commit them
 
-Every test that saves a screenshot commits it. This is intentional:
+`e2e/screenshots/` is a scratch directory. Tests write into it on every
+run, and those files stay out of git — never add them to a commit.
 
-- **Reviewers** can open the screenshot and verify that the assertions
-  correspond to visible facts in the image. Without the screenshot, a
-  reviewer has no way to tell whether `expect(pixel.r).toBe(255)` is
-  correct — maybe the shape tool never rendered the red fill and the
-  test is reading an unrelated pixel.
-- **Regressions** are easier to diagnose. When a test fails months
-  later, the committed screenshot is the reference for what the test
-  used to see. Compare it against Playwright's failure screenshot in
-  `test-results/` to pinpoint what changed.
+- **Regenerate instead of archiving.** If you need to know what a test
+  sees, run it and look at the fresh output. A stale image checked in
+  months ago is worse than no image.
+- **Assertions carry the contract into review.** Since a reviewer
+  can't open the image, the pixel probes have to be self-explanatory:
+  name the coordinates, say what's expected to be there, and make the
+  reason obvious from the test code alone.
 - **Stable output is a feature, not a side effect.** Two runs of the
   same test should produce byte-for-byte identical screenshots unless
   production code changed. If your test produces non-deterministic
@@ -559,9 +558,9 @@ you to model the output.
 ### Screenshots belong with the test
 
 See "Screenshots are the source of truth" at the top of this file. In
-short: save to `e2e/screenshots/<descriptive-name>.png`, commit
-alongside the spec, and make sure a reviewer can look at the
-screenshot and verify your assertions without running the test.
+short: save to `e2e/screenshots/<descriptive-name>.png`, leave those
+files out of the commit, and write assertions specific enough that a
+reviewer can follow them without seeing the image.
 
 ---
 
@@ -569,10 +568,11 @@ screenshot and verify your assertions without running the test.
 
 1. **Run the single failing test** to get the real error message, not a
    summary count. `npx playwright test --project=chromium e2e/<file> -g "<name>"`.
-2. **Open the committed screenshot for this test** (or Playwright's
-   failure screenshot in `test-results/` if there's no baseline).
-   That's the source of truth — you're reconciling the assertions
-   against what's actually on screen, not the other way around.
+2. **Open the screenshot the run just produced** in `e2e/screenshots/`
+   (or Playwright's failure screenshot in `test-results/` if the test
+   died before saving one). That's the source of truth — you're
+   reconciling the assertions against what's actually on screen, not
+   the other way around.
 3. **Read the test and ask: what is it trying to verify?** Compare
    the assertion's claim ("pixel at (50, 50) should be red") to the
    screenshot. If they don't agree, one of them is wrong.

--- a/e2e/dock-panels.spec.ts
+++ b/e2e/dock-panels.spec.ts
@@ -209,6 +209,28 @@ test.describe('dockable panels', () => {
     expect(await getRightDockTabs(page)).toEqual([['layers']]);
   });
 
+  test('tabs are keyboard-navigable with arrow keys (WAI-ARIA tabs pattern)', async ({ page }) => {
+    // Merge color + layers into one 2-tab group so there's something to arrow through.
+    const layersBox = await page.locator('section[aria-label="Layers"]').boundingBox();
+    await dragFromTo(page, await tabCenter(page, 'color'), {
+      x: layersBox!.x + layersBox!.width / 2,
+      y: layersBox!.y + layersBox!.height / 2,
+    });
+    expect(await getRightDockTabs(page)).toEqual([['layers', 'color']]);
+
+    // The active (color) tab is the roving-tabindex stop; focus it and arrow left.
+    const colorTab = page.locator('[data-dock-tab="color"]');
+    await colorTab.focus();
+    await expect(colorTab).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press('ArrowLeft');
+
+    const layersTab = page.locator('[data-dock-tab="layers"]');
+    await expect(layersTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('section[aria-label="Layers"]')).toBeVisible();
+    // Focus follows the selection.
+    await expect(layersTab).toBeFocused();
+  });
+
   test('escape cancels an in-progress tab drag', async ({ page }) => {
     const from = await tabCenter(page, 'color');
     const canvasBox = await page.locator('[data-testid="canvas-container"]').boundingBox();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -217,7 +217,10 @@ export function App() {
         <MenuBar />
         <OptionsBar />
       </div>
-      <div className={styles.body}>
+      <div
+        className={styles.body}
+        style={{ '--right-dock-width': `${rightDockWidth}px` } as React.CSSProperties}
+      >
         <Toolbox />
         <DockHost renderPanel={renderPanel}>
           <main
@@ -246,10 +249,7 @@ export function App() {
         )}
         <GuideColorPicker />
         {isLiquifyOpen && <LiquifyPanel />}
-        <div
-          className={styles.sidebarArea}
-          style={{ '--right-dock-width': `${rightDockWidth}px` } as React.CSSProperties}
-        >
+        <div className={styles.sidebarArea}>
           {showEffectsDrawer && (
             <div
               className={styles.effectsDrawer}

--- a/src/components/LiquifyPanel/LiquifyPanel.module.css
+++ b/src/components/LiquifyPanel/LiquifyPanel.module.css
@@ -1,7 +1,9 @@
 .panel {
   position: fixed;
   top: calc(var(--header-height) + var(--options-bar-height) + var(--space-4));
-  right: calc(var(--sidebar-width) + var(--space-4));
+  /* Sit just left of the panel rail + right dock (dock width is dynamic,
+     fed from App as --right-dock-width; falls back to 0 with no right dock). */
+  right: calc(var(--toolbox-width) + var(--right-dock-width, 0px) + var(--space-4));
   width: 220px;
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);

--- a/src/panels/dock/DockHost/DockHost.module.css
+++ b/src/panels/dock/DockHost/DockHost.module.css
@@ -5,6 +5,9 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  /* Own stacking context so floating windows and the drop indicator layer
+     cleanly against the canvas/docks rather than the app-level z-scale. */
+  isolation: isolate;
 }
 
 .middleRow {

--- a/src/panels/dock/DockHost/DockHost.stories.tsx
+++ b/src/panels/dock/DockHost/DockHost.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import type { DockLayout } from '../dock-layout';
+import { createDefaultLayout, createTabGroup, emptyLayout } from '../dock-layout';
+import { useDockStore } from '../dock-store';
+import { DockHost } from './DockHost';
+
+const meta: Meta<typeof DockHost> = {
+  component: DockHost,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: 460, display: 'flex' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DockHost>;
+
+function placeholder(panelId: string): ReactNode {
+  return <div style={{ padding: 12, color: 'var(--color-text-secondary)' }}>{panelId} content</div>;
+}
+
+const canvas = (
+  <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--color-bg-canvas)', color: 'var(--color-text-secondary)' }}>
+    canvas
+  </div>
+);
+
+function WithLayout({ layout }: { layout: DockLayout }) {
+  useEffect(() => {
+    useDockStore.setState({ layout, drag: null });
+  }, [layout]);
+  return <DockHost renderPanel={placeholder}>{canvas}</DockHost>;
+}
+
+export const DefaultLayout: Story = {
+  render: () => <WithLayout layout={createDefaultLayout()} />,
+};
+
+export const AllFourEdges: Story = {
+  render: () => {
+    const base = emptyLayout();
+    const layout: DockLayout = {
+      ...base,
+      docks: {
+        left: createTabGroup(['navigator']),
+        right: {
+          kind: 'split',
+          id: 'story-right',
+          direction: 'column',
+          children: [createTabGroup(['color']), createTabGroup(['layers'])],
+          sizes: [0.4, 0.6],
+        },
+        top: createTabGroup(['info']),
+        bottom: createTabGroup(['history', 'paths']),
+      },
+    };
+    return <WithLayout layout={layout} />;
+  },
+};
+
+export const WithFloatingWindow: Story = {
+  render: () => {
+    const layout: DockLayout = {
+      ...createDefaultLayout(),
+      floating: [{ id: 'w1', tabs: ['channels'], activeTab: 'channels', x: 220, y: 90, width: 260, height: 240 }],
+    };
+    return <WithLayout layout={layout} />;
+  },
+};

--- a/src/panels/dock/DockSplitter/DockSplitter.module.css
+++ b/src/panels/dock/DockSplitter/DockSplitter.module.css
@@ -5,7 +5,7 @@
   touch-action: none;
   user-select: none;
   position: relative;
-  z-index: 1;
+  z-index: var(--z-dock-splitter);
   transition: background var(--transition-fast);
 }
 

--- a/src/panels/dock/DockSplitter/DockSplitter.stories.tsx
+++ b/src/panels/dock/DockSplitter/DockSplitter.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { DockSplitter } from './DockSplitter';
+
+const meta: Meta<typeof DockSplitter> = {
+  component: DockSplitter,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DockSplitter>;
+
+const pane = (flex: number): React.CSSProperties => ({
+  flex,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'var(--color-bg-primary)',
+  color: 'var(--color-text-secondary)',
+  minWidth: 0,
+  minHeight: 0,
+});
+
+function SplitDemo({ orientation }: { orientation: 'vertical' | 'horizontal' }) {
+  const [firstFlex, setFirstFlex] = useState(1);
+  const [start, setStart] = useState(1);
+  const isRow = orientation === 'vertical';
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: isRow ? 'row' : 'column',
+        width: 360,
+        height: 240,
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      <div style={pane(firstFlex)}>Pane A</div>
+      <DockSplitter
+        orientation={orientation}
+        label="Resize panels"
+        onDragStart={() => setStart(firstFlex)}
+        onDrag={(delta) => setFirstFlex(Math.max(0.2, start + delta / 180))}
+      />
+      <div style={pane(Math.max(0.2, 2 - firstFlex))}>Pane B</div>
+    </div>
+  );
+}
+
+export const Vertical: Story = {
+  render: () => <SplitDemo orientation="vertical" />,
+};
+
+export const Horizontal: Story = {
+  render: () => <SplitDemo orientation="horizontal" />,
+};

--- a/src/panels/dock/DockSplitter/DockSplitter.tsx
+++ b/src/panels/dock/DockSplitter/DockSplitter.tsx
@@ -15,7 +15,7 @@ export function DockSplitter({ orientation, onDragStart, onDrag, label }: DockSp
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (e.button !== 0) return;
+      if (e.button !== 0 || dragRef.current) return;
       e.preventDefault();
       e.currentTarget.setPointerCapture(e.pointerId);
       dragRef.current = {
@@ -42,6 +42,13 @@ export function DockSplitter({ orientation, onDragStart, onDrag, label }: DockSp
     dragRef.current = null;
   }, []);
 
+  // If capture is lost (element unmounts mid-drag, browser steals it) the
+  // pointerup on this element never arrives — clear the ref so a stale drag
+  // can't resume on the next pointerdown.
+  const handleLostCapture = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
   return (
     <div
       className={orientation === 'vertical' ? styles.vertical : styles.horizontal}
@@ -52,6 +59,7 @@ export function DockSplitter({ orientation, onDragStart, onDrag, label }: DockSp
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
+      onLostPointerCapture={handleLostCapture}
     />
   );
 }

--- a/src/panels/dock/DockTabs/DockTabs.stories.tsx
+++ b/src/panels/dock/DockTabs/DockTabs.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import { DockTabs } from './DockTabs';
+
+const meta: Meta<typeof DockTabs> = {
+  component: DockTabs,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 300, height: 260, display: 'flex', border: '1px solid var(--color-border)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DockTabs>;
+
+function placeholder(panelId: string): ReactNode {
+  return <div style={{ padding: 12, color: 'var(--color-text-secondary)' }}>{panelId} content</div>;
+}
+
+export const SingleTab: Story = {
+  args: {
+    groupId: 'story-single',
+    tabs: ['color'],
+    activeTab: 'color',
+    renderPanel: placeholder,
+  },
+};
+
+export const ThreeTabs: Story = {
+  args: {
+    groupId: 'story-three',
+    tabs: ['navigator', 'color', 'layers'],
+    activeTab: 'color',
+    renderPanel: placeholder,
+  },
+};
+
+export const Floating: Story = {
+  args: {
+    groupId: 'story-floating',
+    tabs: ['history', 'paths'],
+    activeTab: 'history',
+    variant: 'floating',
+    renderPanel: placeholder,
+  },
+};

--- a/src/panels/dock/DockTabs/DockTabs.tsx
+++ b/src/panels/dock/DockTabs/DockTabs.tsx
@@ -15,6 +15,9 @@ interface DockTabsProps {
   variant?: 'docked' | 'floating';
 }
 
+const tabDomId = (groupId: string, panelId: string): string => `dock-tab-${groupId}-${panelId}`;
+const panelDomId = (groupId: string): string => `dock-panel-${groupId}`;
+
 export function DockTabs({ groupId, tabs, activeTab, renderPanel, variant = 'docked' }: DockTabsProps) {
   const activateTab = useDockStore((s) => s.activateTab);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -28,7 +31,6 @@ export function DockTabs({ groupId, tabs, activeTab, renderPanel, variant = 'doc
 
   const handleTabPointerDown = (e: React.PointerEvent<HTMLButtonElement>, panelId: string) => {
     e.stopPropagation();
-    activateTab(groupId, panelId);
     // A floating window's only tab drags the whole window — extracting it
     // into a new window would just orphan an identical one.
     if (variant === 'floating' && tabs.length === 1) {
@@ -36,11 +38,32 @@ export function DockTabs({ groupId, tabs, activeTab, renderPanel, variant = 'doc
       return;
     }
     beginTabDrag(e, panelId, groupId);
+    // Activation happens on click (fires for both mouse and keyboard), not
+    // here — so a click activates exactly once and a drag doesn't activate a
+    // tab it's about to move elsewhere.
   };
 
   const handleBarPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (variant !== 'floating') return;
     beginWindowDrag(e, groupId);
+  };
+
+  // WAI-ARIA tabs keyboard pattern: arrows move (and follow focus to) the
+  // active tab; Home/End jump to the ends.
+  const handleTablistKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const index = tabs.indexOf(activeTab);
+    if (index === -1) return;
+    let next = index;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (index + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (index - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = tabs.length - 1;
+    else return;
+    const nextPanel = tabs[next];
+    if (nextPanel === undefined || nextPanel === activeTab) return;
+    e.preventDefault();
+    activateTab(groupId, nextPanel);
+    document.getElementById(tabDomId(groupId, nextPanel))?.focus();
   };
 
   const title = getPanelTitle(activeTab);
@@ -51,14 +74,18 @@ export function DockTabs({ groupId, tabs, activeTab, renderPanel, variant = 'doc
         className={styles.tabBar}
         role="tablist"
         onPointerDown={handleBarPointerDown}
+        onKeyDown={handleTablistKeyDown}
         data-testid={`dock-tabbar-${activeTab}`}
       >
         {tabs.map((panelId) => (
           <button
             key={panelId}
+            id={tabDomId(groupId, panelId)}
             type="button"
             role="tab"
             aria-selected={panelId === activeTab}
+            aria-controls={panelDomId(groupId)}
+            tabIndex={panelId === activeTab ? 0 : -1}
             className={panelId === activeTab ? styles.tabActive : styles.tab}
             data-dock-tab={panelId}
             onPointerDown={(e) => handleTabPointerDown(e, panelId)}
@@ -68,7 +95,7 @@ export function DockTabs({ groupId, tabs, activeTab, renderPanel, variant = 'doc
           </button>
         ))}
       </div>
-      <section className={styles.content} role="tabpanel" aria-label={title}>
+      <section id={panelDomId(groupId)} className={styles.content} role="tabpanel" aria-label={title}>
         {renderPanel(activeTab)}
       </section>
     </div>

--- a/src/panels/dock/DockZone/DockZone.stories.tsx
+++ b/src/panels/dock/DockZone/DockZone.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import type { SplitNode } from '../dock-layout';
+import { createTabGroup } from '../dock-layout';
+import { DockZone } from './DockZone';
+
+const meta: Meta<typeof DockZone> = {
+  component: DockZone,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 340, height: 300, display: 'flex', border: '1px solid var(--color-border)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DockZone>;
+
+function placeholder(panelId: string): ReactNode {
+  return <div style={{ padding: 12, color: 'var(--color-text-secondary)' }}>{panelId} content</div>;
+}
+
+export const SingleGroup: Story = {
+  args: {
+    node: createTabGroup(['color']),
+    renderPanel: placeholder,
+  },
+};
+
+export const ColumnSplit: Story = {
+  args: {
+    node: {
+      kind: 'split',
+      id: 'story-col',
+      direction: 'column',
+      children: [createTabGroup(['color']), createTabGroup(['layers'])],
+      sizes: [0.4, 0.6],
+    } satisfies SplitNode,
+    renderPanel: placeholder,
+  },
+};
+
+export const NestedSplit: Story = {
+  args: {
+    node: {
+      kind: 'split',
+      id: 'story-outer',
+      direction: 'row',
+      children: [
+        createTabGroup(['navigator']),
+        {
+          kind: 'split',
+          id: 'story-inner',
+          direction: 'column',
+          children: [createTabGroup(['color', 'info']), createTabGroup(['layers'])],
+          sizes: [0.5, 0.5],
+        },
+      ],
+      sizes: [0.35, 0.65],
+    } satisfies SplitNode,
+    renderPanel: placeholder,
+  },
+};

--- a/src/panels/dock/DropIndicator/DropIndicator.module.css
+++ b/src/panels/dock/DropIndicator/DropIndicator.module.css
@@ -8,7 +8,7 @@
   border: 2px solid var(--color-accent);
   border-radius: var(--radius-sm);
   pointer-events: none;
-  z-index: 40;
+  z-index: var(--z-dock-drop-indicator);
 }
 
 .ghost {
@@ -28,5 +28,5 @@
   box-shadow: var(--shadow-md);
   pointer-events: none;
   white-space: nowrap;
-  z-index: 41;
+  z-index: var(--z-dock-drop-ghost);
 }

--- a/src/panels/dock/DropIndicator/DropIndicator.stories.tsx
+++ b/src/panels/dock/DropIndicator/DropIndicator.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import type { DockDragState } from '../dock-store';
+import { useDockStore } from '../dock-store';
+import { DropIndicator } from './DropIndicator';
+
+const meta: Meta<typeof DropIndicator> = {
+  component: DropIndicator,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ position: 'relative', width: '100%', height: 360, background: 'var(--color-bg-canvas)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropIndicator>;
+
+/** Push a synthetic drag into the store so the overlay has something to draw. */
+function WithDrag({ drag }: { drag: DockDragState }) {
+  useEffect(() => {
+    useDockStore.setState({ drag });
+    return () => useDockStore.setState({ drag: null });
+  }, [drag]);
+  return <DropIndicator />;
+}
+
+export const EdgeDock: Story = {
+  render: () => (
+    <WithDrag
+      drag={{
+        source: { kind: 'tab', panelId: 'color', groupId: 'g1' },
+        pointer: { x: 40, y: 180 },
+        target: { kind: 'edge', side: 'left' },
+        indicator: { x: 0, y: 0, width: 220, height: 360 },
+        title: 'Color',
+        showGhost: true,
+      }}
+    />
+  ),
+};
+
+export const TabMerge: Story = {
+  render: () => (
+    <WithDrag
+      drag={{
+        source: { kind: 'tab', panelId: 'layers', groupId: 'g1' },
+        pointer: { x: 360, y: 150 },
+        target: { kind: 'group', groupId: 'g2', region: 'center' },
+        indicator: { x: 300, y: 60, width: 240, height: 220 },
+        title: 'Layers',
+        showGhost: true,
+      }}
+    />
+  ),
+};

--- a/src/panels/dock/FloatingPanel/FloatingPanel.module.css
+++ b/src/panels/dock/FloatingPanel/FloatingPanel.module.css
@@ -11,7 +11,7 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  z-index: 20;
+  z-index: var(--z-dock-floating);
 }
 
 .resizeN,

--- a/src/panels/dock/FloatingPanel/FloatingPanel.stories.tsx
+++ b/src/panels/dock/FloatingPanel/FloatingPanel.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import type { FloatingWindow } from '../dock-layout';
+import { emptyLayout } from '../dock-layout';
+import { useDockStore } from '../dock-store';
+import { FloatingPanel } from './FloatingPanel';
+
+const meta: Meta<typeof FloatingPanel> = {
+  component: FloatingPanel,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ position: 'relative', width: '100%', height: 420, background: 'var(--color-bg-canvas)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FloatingPanel>;
+
+function placeholder(panelId: string): ReactNode {
+  return <div style={{ padding: 12, color: 'var(--color-text-secondary)' }}>{panelId} content</div>;
+}
+
+/** Seed the store so focus/resize actions operate on this window. */
+function WithWindow({ window: win }: { window: FloatingWindow }) {
+  useEffect(() => {
+    useDockStore.setState({ layout: { ...emptyLayout(), floating: [win] }, drag: null });
+  }, [win]);
+  return <FloatingPanel window={win} renderPanel={placeholder} />;
+}
+
+export const SingleTab: Story = {
+  render: () => (
+    <WithWindow window={{ id: 'w-single', tabs: ['color'], activeTab: 'color', x: 60, y: 40, width: 260, height: 300 }} />
+  ),
+};
+
+export const TwoTabs: Story = {
+  render: () => (
+    <WithWindow
+      window={{ id: 'w-two', tabs: ['history', 'paths'], activeTab: 'history', x: 80, y: 30, width: 300, height: 320 }}
+    />
+  ),
+};

--- a/src/panels/dock/FloatingPanel/FloatingPanel.tsx
+++ b/src/panels/dock/FloatingPanel/FloatingPanel.tsx
@@ -37,7 +37,7 @@ export function FloatingPanel({ window: win, renderPanel }: FloatingPanelProps) 
 
   const handleResizeDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>, dir: ResizeDir) => {
-      if (e.button !== 0) return;
+      if (e.button !== 0 || resizeRef.current) return;
       e.preventDefault();
       e.stopPropagation();
       e.currentTarget.setPointerCapture(e.pointerId);
@@ -72,6 +72,12 @@ export function FloatingPanel({ window: win, renderPanel }: FloatingPanelProps) 
     resizeRef.current = null;
   }, []);
 
+  // Capture can be lost if the handle unmounts mid-resize (e.g. the window is
+  // docked away); clear the ref so no stale resize state lingers.
+  const handleLostCapture = useCallback(() => {
+    resizeRef.current = null;
+  }, []);
+
   return (
     <div
       className={styles.window}
@@ -101,6 +107,7 @@ export function FloatingPanel({ window: win, renderPanel }: FloatingPanelProps) 
           onPointerMove={handleResizeMove}
           onPointerUp={handleResizeEnd}
           onPointerCancel={handleResizeEnd}
+          onLostPointerCapture={handleLostCapture}
         />
       ))}
     </div>

--- a/src/panels/dock/dock-drag-controller.ts
+++ b/src/panels/dock/dock-drag-controller.ts
@@ -172,7 +172,10 @@ function handlePointerCancel(e: PointerEvent): void {
 }
 
 function handleKeyDown(e: KeyboardEvent): void {
-  if (e.key !== 'Escape' || !active) return;
+  // Only consume Escape once the gesture has actually crossed the drag
+  // threshold — a bare pointerdown that never moved must not swallow Escape
+  // from modals or tool-cancel handlers.
+  if (e.key !== 'Escape' || !active?.activated) return;
   e.stopPropagation();
   cancelDrag();
 }
@@ -228,9 +231,4 @@ export function beginWindowDrag(e: PointerDownLike, windowId: string): void {
     { kind: 'window', windowId, originX: window_.x, originY: window_.y },
     windowId,
   );
-}
-
-/** True while a dock drag gesture is in progress (post-threshold). */
-export function isDockDragActive(): boolean {
-  return active?.activated ?? false;
 }

--- a/src/panels/dock/dock-layout.test.ts
+++ b/src/panels/dock/dock-layout.test.ts
@@ -362,13 +362,24 @@ describe('floating window geometry', () => {
     expect(bringFloatingToFront(next, firstId)).toBe(next);
   });
 
-  it('clamps windows back into the host', () => {
+  it('clamps windows fully back inside the host (no overflow past the edges)', () => {
     let layout = base();
     const id = layout.floating[0]?.id ?? '';
     layout = moveFloatingWindow(layout, id, 5000, 5000);
     const next = clampFloatingToHost(layout, 1200, 800);
-    expect(next.floating[0]?.x).toBeLessThanOrEqual(1200 - 48);
-    expect(next.floating[0]?.y).toBeLessThanOrEqual(800 - 48);
+    const w = next.floating[0];
+    expect(w).toBeDefined();
+    expect(w!.x).toBeGreaterThanOrEqual(0);
+    expect(w!.y).toBeGreaterThanOrEqual(0);
+    expect(w!.x + w!.width).toBeLessThanOrEqual(1200);
+    expect(w!.y + w!.height).toBeLessThanOrEqual(800);
+  });
+
+  it('leaves a window that already fits untouched', () => {
+    let layout = base();
+    const id = layout.floating[0]?.id ?? '';
+    layout = moveFloatingWindow(layout, id, 100, 60);
+    expect(clampFloatingToHost(layout, 1200, 800).floating[0]).toMatchObject({ x: 100, y: 60 });
   });
 });
 

--- a/src/panels/dock/dock-layout.ts
+++ b/src/panels/dock/dock-layout.ts
@@ -525,17 +525,22 @@ export function bringFloatingToFront(layout: DockLayout, windowId: string): Dock
   return { ...layout, floating };
 }
 
-/** Keep at least a grabbable strip of the window inside the host. */
+/**
+ * Keep floating windows fully inside the host. Windows are children of the
+ * dock host, whose right/bottom edges border the panel rail and drawers; a
+ * window allowed to overflow those edges would be painted *under* the rail
+ * (different stacking context) and become partly unreachable. So we clamp the
+ * whole window into [0, host] — snapping it back on resize / drop.
+ */
 export function clampFloatingToHost(
   layout: DockLayout,
   hostWidth: number,
   hostHeight: number,
 ): DockLayout {
-  const MARGIN = 48;
   let changed = false;
   const floating = layout.floating.map((w) => {
-    const x = Math.min(Math.max(w.x, MARGIN - w.width), Math.max(0, hostWidth - MARGIN));
-    const y = Math.min(Math.max(w.y, 0), Math.max(0, hostHeight - MARGIN));
+    const x = Math.min(Math.max(w.x, 0), Math.max(0, hostWidth - w.width));
+    const y = Math.min(Math.max(w.y, 0), Math.max(0, hostHeight - w.height));
     if (x === w.x && y === w.y) return w;
     changed = true;
     return { ...w, x, y };

--- a/src/panels/dock/dock-persist.test.ts
+++ b/src/panels/dock/dock-persist.test.ts
@@ -108,6 +108,66 @@ describe('sanitizeLayout', () => {
     expect(layout?.floating[0]).toMatchObject({ x: 50, y: 60, width: 200, height: 140 });
   });
 
+  it('forces every node/window id to be unique across the layout', () => {
+    const raw = {
+      docks: {
+        left: { kind: 'tabs', id: 'dup', tabs: ['navigator'], activeTab: 'navigator' },
+        right: {
+          kind: 'split',
+          id: 'dup',
+          direction: 'column',
+          children: [
+            { kind: 'tabs', id: 'dup', tabs: ['color'], activeTab: 'color' },
+            { kind: 'tabs', id: 'dup', tabs: ['layers'], activeTab: 'layers' },
+          ],
+          sizes: [0.5, 0.5],
+        },
+      },
+      floating: [{ id: 'dup', tabs: ['history'], activeTab: 'history', x: 0, y: 0, width: 300, height: 300 }],
+    };
+    const layout = sanitizeLayout(raw, PANELS);
+    expect(layout).not.toBeNull();
+    const ids: string[] = [];
+    const walk = (node: { kind: string; id: string; children?: { kind: string; id: string }[] } | null) => {
+      if (!node) return;
+      ids.push(node.id);
+      if (node.kind === 'split' && 'children' in node) {
+        for (const child of node.children ?? []) walk(child as never);
+      }
+    };
+    for (const side of ['left', 'right', 'top', 'bottom'] as const) walk(layout?.docks[side] as never);
+    for (const w of layout?.floating ?? []) ids.push(w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // Every panel still survives — dedup of ids must not drop content.
+    expect(panelsInLayout(layout ?? createDefaultLayout()).sort()).toEqual([
+      'color',
+      'history',
+      'layers',
+      'navigator',
+    ]);
+  });
+
+  it('floors a persisted zero-size pane to a visible fraction', () => {
+    const raw = {
+      docks: {
+        right: {
+          kind: 'split',
+          id: 's',
+          direction: 'column',
+          children: [
+            { kind: 'tabs', id: 'g1', tabs: ['color'], activeTab: 'color' },
+            { kind: 'tabs', id: 'g2', tabs: ['layers'], activeTab: 'layers' },
+          ],
+          sizes: [1, 0],
+        },
+      },
+    };
+    const layout = sanitizeLayout(raw, PANELS);
+    const sizes = (layout?.docks.right as SplitNode).sizes;
+    expect(sizes.every((s) => s > 0)).toBe(true);
+    expect(sizes[1]).toBeGreaterThan(0);
+  });
+
   it('collapses a split left with one child after invalid children are dropped', () => {
     const raw = {
       docks: {

--- a/src/panels/dock/dock-persist.ts
+++ b/src/panels/dock/dock-persist.ts
@@ -40,13 +40,32 @@ function sanitizeNumber(value: unknown, min: number, max: number, fallback: numb
 }
 
 /**
- * Validate a node tree. `seen` accumulates panel ids across the whole
- * layout so a panel can never appear twice (first occurrence wins).
+ * Mint a stable id for a persisted node/window: reuse the incoming id only if
+ * it's a non-empty string that hasn't already been claimed elsewhere in the
+ * layout; otherwise generate a fresh one. This guarantees every node/window
+ * id is unique — the tree ops (replaceGroupInNode replaces *every* matching
+ * id, the element registry keys by id) rely on that invariant, and a crafted
+ * or corrupted payload must not be able to violate it.
+ */
+function uniqueId(raw: unknown, usedIds: Set<string>): string {
+  const id = typeof raw === 'string' && raw.length > 0 && !usedIds.has(raw) ? raw : crypto.randomUUID();
+  usedIds.add(id);
+  return id;
+}
+
+/** Smallest fraction a persisted split pane may hold, so it never collapses. */
+const MIN_SPLIT_FRACTION = 0.05;
+
+/**
+ * Validate a node tree. `seen` accumulates panel ids across the whole layout
+ * so a panel can never appear twice (first occurrence wins); `usedIds`
+ * accumulates node ids so no two nodes/windows share one.
  */
 function sanitizeNode(
   raw: unknown,
   knownPanels: readonly string[],
   seen: Set<string>,
+  usedIds: Set<string>,
 ): LayoutNode | null {
   if (!isRecord(raw)) return null;
   if (raw.kind === 'tabs') {
@@ -62,8 +81,7 @@ function sanitizeNode(
     if (!first) return null;
     const activeTab =
       typeof raw.activeTab === 'string' && tabs.includes(raw.activeTab) ? raw.activeTab : first;
-    const id = typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID();
-    const group: TabGroupNode = { kind: 'tabs', id, tabs, activeTab };
+    const group: TabGroupNode = { kind: 'tabs', id: uniqueId(raw.id, usedIds), tabs, activeTab };
     return group;
   }
   if (raw.kind === 'split') {
@@ -73,19 +91,20 @@ function sanitizeNode(
     const children: LayoutNode[] = [];
     const sizes: number[] = [];
     raw.children.forEach((child, i) => {
-      const node = sanitizeNode(child, knownPanels, seen);
+      const node = sanitizeNode(child, knownPanels, seen, usedIds);
       if (!node) return;
       children.push(node);
       const size = rawSizes[i];
-      sizes.push(typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : 0);
+      // Floor every pane to a small positive share so a persisted 0 (or a
+      // negative/NaN) can't yield a pane the flexbox renderer collapses away.
+      sizes.push(typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : MIN_SPLIT_FRACTION);
     });
     const only = children[0];
     if (!only) return null;
     if (children.length === 1) return only;
     const sum = sizes.reduce((a, b) => a + b, 0);
     const normalized = sum > 0 ? sizes.map((s) => s / sum) : sizes.map(() => 1 / sizes.length);
-    const id = typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID();
-    const split: SplitNode = { kind: 'split', id, direction, children, sizes: normalized };
+    const split: SplitNode = { kind: 'split', id: uniqueId(raw.id, usedIds), direction, children, sizes: normalized };
     return split;
   }
   return null;
@@ -95,6 +114,7 @@ function sanitizeFloating(
   raw: unknown,
   knownPanels: readonly string[],
   seen: Set<string>,
+  usedIds: Set<string>,
 ): FloatingWindow | null {
   if (!isRecord(raw) || !Array.isArray(raw.tabs)) return null;
   const tabs: string[] = [];
@@ -109,7 +129,7 @@ function sanitizeFloating(
   const activeTab =
     typeof raw.activeTab === 'string' && tabs.includes(raw.activeTab) ? raw.activeTab : first;
   return {
-    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID(),
+    id: uniqueId(raw.id, usedIds),
     tabs,
     activeTab,
     x: sanitizeNumber(raw.x, -10_000, 10_000, 0),
@@ -122,9 +142,10 @@ function sanitizeFloating(
 export function sanitizeLayout(raw: unknown, knownPanels: readonly string[]): DockLayout | null {
   if (!isRecord(raw) || !isRecord(raw.docks)) return null;
   const seen = new Set<string>();
+  const usedIds = new Set<string>();
   const docks = {} as Record<DockSide, LayoutNode | null>;
   for (const side of DOCK_SIDES) {
-    const node = sanitizeNode(raw.docks[side], knownPanels, seen);
+    const node = sanitizeNode(raw.docks[side], knownPanels, seen, usedIds);
     docks[side] = node ? normalizeNode(node) : null;
   }
   const rawSizes = isRecord(raw.dockSizes) ? raw.dockSizes : {};
@@ -140,7 +161,7 @@ export function sanitizeLayout(raw: unknown, knownPanels: readonly string[]): Do
   const floating: FloatingWindow[] = [];
   if (Array.isArray(raw.floating)) {
     for (const entry of raw.floating) {
-      const window = sanitizeFloating(entry, knownPanels, seen);
+      const window = sanitizeFloating(entry, knownPanels, seen, usedIds);
       if (window) floating.push(window);
     }
   }

--- a/src/panels/dock/dock-store.test.ts
+++ b/src/panels/dock/dock-store.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDockStore } from './dock-store';
 import { setVisiblePanelsSink } from './dock-ui-bridge';
-import { collectGroups, createDefaultLayout, findPanelGroupId, panelsInLayout } from './dock-layout';
+import { collectGroups, findPanelGroupId, panelsInLayout } from './dock-layout';
 
 // The dock store publishes visiblePanels through the bridge (ui-store
 // registers the real sink); capture publishes here.
@@ -9,7 +9,10 @@ const setState = vi.fn();
 setVisiblePanelsSink((panels) => setState({ visiblePanels: panels }));
 
 function reset(): void {
-  useDockStore.setState({ layout: createDefaultLayout(), drag: null });
+  // Go through the real action so the store's internal visible-panels
+  // dedup key stays in sync with the layout we reset to.
+  useDockStore.setState({ drag: null });
+  useDockStore.getState().resetLayout();
   setState.mockClear();
 }
 
@@ -89,6 +92,24 @@ describe('drag/drop actions', () => {
     state = useDockStore.getState();
     expect(state.layout.floating).toHaveLength(0);
     expect(collectGroups(state.layout.docks.left).map((g) => g.tabs)).toEqual([['color']]);
+  });
+
+  it('does not republish visiblePanels during a geometry-only change', () => {
+    // Float a panel (this changes nothing about which panels are open — the
+    // same set stays visible), then move the window repeatedly.
+    useDockStore.getState().dropTab('color', { kind: 'float', rect: { x: 0, y: 0, width: 300, height: 300 } });
+    const id = useDockStore.getState().layout.floating[0]?.id ?? '';
+    setState.mockClear();
+    useDockStore.getState().moveWindow(id, 40, 40);
+    useDockStore.getState().moveWindow(id, 80, 80);
+    useDockStore.getState().resizeWindow(id, { x: 80, y: 80, width: 320, height: 340 });
+    expect(setState).not.toHaveBeenCalled();
+  });
+
+  it('republishes visiblePanels when the open set actually changes', () => {
+    setState.mockClear();
+    useDockStore.getState().togglePanel('history');
+    expect(setState).toHaveBeenCalled();
   });
 
   it('resizeDock clamps and stores px sizes', () => {

--- a/src/panels/dock/dock-store.ts
+++ b/src/panels/dock/dock-store.ts
@@ -76,8 +76,20 @@ function createInitialLayout(): DockLayout {
   return createDefaultLayout();
 }
 
+// null until the first publish, so the initial reconcile always fires even
+// when the booted layout is empty (ui-store's own guess may differ).
+let lastVisibleKey: string | null = null;
+
 function syncVisiblePanelsMirror(layout: DockLayout): void {
-  publishVisiblePanels(new Set(panelsInLayout(layout)));
+  const panels = panelsInLayout(layout);
+  // Geometry drags (move/resize a window, drag a splitter) commit a new
+  // layout every pointer frame but never change *which* panels are open.
+  // Skip the publish when the set is unchanged so visiblePanels subscribers
+  // (PanelToolbar) don't re-render 60×/sec during a drag.
+  const key = [...panels].sort().join(',');
+  if (key === lastVisibleKey) return;
+  lastVisibleKey = key;
+  publishVisiblePanels(new Set(panels));
 }
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -65,6 +65,12 @@
   --z-modal: 500;
   --z-tooltip: 600;
 
+  /* Dock layers — scoped inside the dock host's stacking context */
+  --z-dock-splitter: 1;
+  --z-dock-floating: 20;
+  --z-dock-drop-indicator: 40;
+  --z-dock-drop-ghost: 41;
+
   /* Shadows */
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
@@ -76,7 +82,6 @@
 
   /* Panel sizes */
   --toolbox-width: 44px;
-  --sidebar-width: 312px;
   --header-height: 36px;
   --options-bar-height: 32px;
   --status-bar-height: 24px;


### PR DESCRIPTION
Follow-up to the dockable panel system (#679). Fills the gaps that PR left open and hardens the system against an adversarial review.

## What's here

**Stories** — Storybook stories for all 6 dock components (`DockHost`, `DockZone`, `DockTabs`, `DockSplitter`, `FloatingPanel`, `DropIndicator`). #679 shipped without them; the repo convention is a story per component.

**LiquifyPanel positioning** — it was pinned to the removed fixed sidebar via `--sidebar-width`, so it overlapped the now-resizable right dock. Anchored to the live right-dock width (`--right-dock-width` on `.body`, consumed via `--toolbox-width + that`). Dead `--sidebar-width` token removed.

**Perf** — `commitLayout` mirrored the open-panel set into `ui-store` on every layout change, re-rendering `PanelToolbar` ~60×/sec while dragging a floating window or splitter. Now guarded on a content key so it fires only when the set of open panels actually changes.

**Review hardening** — from a 21-agent adversarial review (9 confirmed / 8 rejected, each finding independently verified):
- **Persistence** — force unique node/window ids (`replaceGroupInNode` and the element registry key by id, so a crafted `localStorage` payload with duplicate ids could corrupt drag/merge); floor persisted split sizes so a stored `0` can't collapse a pane.
- **Floating windows** — clamp fully inside the host so they can't overflow under the panel rail into a lower stacking context.
- **Tabs a11y** — full WAI-ARIA keyboard pattern (arrows/Home/End move and follow focus, roving `tabindex`, `aria-controls`); activate a tab exactly once per interaction (was firing on both `pointerdown` and `click`).
- **Pointer robustness** — reset splitter/resize refs on `lostpointercapture` and reject re-entrant gestures; scope the drag-cancel `Escape` to a post-threshold drag so it can't swallow `Escape` from modals/tool-cancel.
- **Style** — dock layer z-indexes moved onto `tokens.css` variables.

**Docs** — `e2e/GUIDE.md` updated to match actual practice: `e2e/screenshots/` is a scratch dir, not committed.

## Verification
- `typecheck` clean · `lint` clean · **1611 unit tests** pass (76 dock) · Storybook builds
- Full chromium e2e: 779 passed. The 3 `transform.spec.ts` free-transform failures are **pre-existing** — reproduced on clean `origin/main` and on the pre-dock commit `d2c7ac44`, so unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)