### PR TITLE
fix(interactions): move tool drops the marquee snapshot on pointer-down (#687)

### DIFF
--- a/e2e/zoom-status-bar.spec.ts
+++ b/e2e/zoom-status-bar.spec.ts
@@ -63,10 +63,21 @@ test.describe('Status-bar zoom indicator', () => {
     expect(midZoom).toBeGreaterThan(1.4);
     expect(midZoom).toBeLessThan(1.8);
 
-    // Drag left far beyond min — should clamp to 10%.
+    // Drag left past the min — should clamp to 10%. The scrub is
+    // measured from the pointer-down x, and the zoom label sits ~25px
+    // from the left edge; Firefox clamps pointer clientX to the
+    // viewport, so a leftward drag can never be wider than that. Start
+    // from a low zoom so dragging to x=0 overshoots the 10% floor in
+    // every browser rather than relying on off-screen coordinates.
+    await page.evaluate(() => {
+      const s = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { setZoom: (z: number) => void };
+      };
+      s.getState().setZoom(0.15);
+    });
     await page.mouse.move(startX, y);
     await page.mouse.down();
-    await page.mouse.move(startX - 500, y, { steps: 10 });
+    await page.mouse.move(0, y, { steps: 10 });
     const lowZoom = await page.evaluate(() => (window as unknown as { __editorStore: { getState: () => { viewport: { zoom: number } } } }).__editorStore.getState().viewport.zoom);
     await page.mouse.up();
     expect(lowZoom).toBeCloseTo(0.1, 2);

--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -32,6 +32,7 @@ const ALLOWLIST = {
   // ──────────────────────────────────────────────────────────────────────
   'src/app/editor-store.test.ts': 5,
   'src/app/tool-settings-store.test.ts': 5,
+  'src/app/interactions/interaction-types.test.ts': 1,
   'src/app/interactions/move-handlers.test.ts': 1,
   'src/app/interactions/quick-mask-move.test.ts': 2,
   'src/app/interactions/transform-handlers.test.ts': 1,

--- a/src/app/interactions/interaction-types.test.ts
+++ b/src/app/interactions/interaction-types.test.ts
@@ -3,6 +3,8 @@ import {
   gestureUsedGpuStroke,
   withPaintGesture,
   withToolGesture,
+  withMoveGesture,
+  resolveDownGesture,
   GESTURE_IDLE,
   INITIAL_INTERACTION_STATE,
   type CanvasGesture,
@@ -201,6 +203,60 @@ describe('withToolGesture', () => {
     expect(input.gesture).toBe(GESTURE_IDLE);
     expect(output).not.toBe(input);
     expect(output.gesture).not.toBe(input.gesture);
+  });
+});
+
+describe('resolveDownGesture', () => {
+  const marqueeMask = new Uint8ClampedArray([1, 2, 3, 4]);
+  const makeMoveState = () =>
+    withMoveGesture(makeBaseState({ tool: 'move' }), {
+      originalMask: marqueeMask,
+      originalBounds: { x: 10, y: 20, width: 30, height: 40 },
+    });
+
+  it('wraps paint-tool state in the paint variant', () => {
+    const output = resolveDownGesture(makeBaseState(), { isPaintTool: true, usedGpuStroke: true });
+    expect(output.gesture).toEqual({ kind: 'paint', usedGpuStroke: true });
+  });
+
+  it('wraps a gesture-less non-paint tool in the generic tool variant', () => {
+    const output = resolveDownGesture(makeBaseState({ tool: 'fill' }), {
+      isPaintTool: false,
+      usedGpuStroke: false,
+    });
+    expect(output.gesture).toEqual({ kind: 'tool' });
+  });
+
+  it('keeps the move variant its handler already chose', () => {
+    const input = makeMoveState();
+    const output = resolveDownGesture(input, { isPaintTool: false, usedGpuStroke: false });
+    expect(output.gesture.kind).toBe('move');
+  });
+
+  it('preserves the marquee snapshot the move handler packed inline', () => {
+    const input = makeMoveState();
+    const output = resolveDownGesture(input, { isPaintTool: false, usedGpuStroke: false });
+    if (output.gesture.kind !== 'move') {
+      throw new Error('expected the move gesture to survive dispatch');
+    }
+    // Dropping these left the marquee pinned in place while the floated
+    // pixels moved under it — handleMoveMove needs originalBounds to
+    // re-derive the selection rectangle on every pointer-move.
+    expect(output.gesture.originalBounds).toEqual({ x: 10, y: 20, width: 30, height: 40 });
+    expect(output.gesture.originalMask).toBe(marqueeMask);
+  });
+
+  it('keeps other handler-chosen variants intact', () => {
+    const input = makeBaseState({ gesture: makeTransformGesture(), tool: 'move' });
+    const output = resolveDownGesture(input, { isPaintTool: false, usedGpuStroke: false });
+    expect(output.gesture.kind).toBe('transform');
+  });
+
+  it('does not mutate the input state', () => {
+    const input = Object.freeze(makeBaseState());
+    const output = resolveDownGesture(input, { isPaintTool: true, usedGpuStroke: false });
+    expect(input.gesture).toBe(GESTURE_IDLE);
+    expect(output).not.toBe(input);
   });
 });
 

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -108,6 +108,25 @@ export function withMoveGesture(
   };
 }
 
+/**
+ * Decide which gesture variant a down handler's freshly-returned state
+ * should carry. Paint tools always get the paint variant (it is the
+ * dispatcher, not the handler, that knows whether the stroke went down
+ * the GPU path). Every other tool keeps whatever variant its handler
+ * already chose — `handleMoveDown` packs the marquee and quick-mask
+ * snapshots inline on the `move` variant, and blanket-wrapping it in the
+ * generic `tool` gesture silently discarded them, leaving the selection
+ * marquee pinned in place while the pixels moved under it.
+ */
+export function resolveDownGesture(
+  state: InteractionState,
+  opts: { isPaintTool: boolean; usedGpuStroke: boolean },
+): InteractionState {
+  if (opts.isPaintTool) return withPaintGesture(state, opts.usedGpuStroke);
+  if (state.gesture.kind !== 'idle') return state;
+  return withToolGesture(state);
+}
+
 export const GESTURE_IDLE: CanvasGesture = { kind: 'idle' };
 
 /**

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -28,8 +28,7 @@ import type {
 import {
   gestureUsedGpuStroke,
   INITIAL_INTERACTION_STATE,
-  withPaintGesture,
-  withToolGesture,
+  resolveDownGesture,
 } from './interactions/interaction-types';
 import { handleTransformDown, flushSelectionTransform } from './interactions/transform-handlers';
 import {
@@ -309,9 +308,10 @@ export function useCanvasInteraction(
       const handler = toolHandlers[activeTool];
       const newState = handler?.down?.(finalCtx);
       if (newState) {
-        stateRef.current = isPaintTool
-          ? withPaintGesture(newState, !!useGpuStroke)
-          : withToolGesture(newState);
+        stateRef.current = resolveDownGesture(newState, {
+          isPaintTool,
+          usedGpuStroke: !!useGpuStroke,
+        });
       }
     },
     [screenToCanvas, containerRef, buildContext, cancelHoldTimer],


### PR DESCRIPTION
Nightly full e2e run surfaced 4 failing tests. One is a real product regression, one is a test that only ever passed by accident on Chromium.

## 1. Move tool leaves the marquee behind — `#687`

Dragging a marquee selection with the move tool moved the pixels but left the selection outline pinned in place (`selection.bounds` unchanged for the whole drag).

The pointer-down dispatcher in `useCanvasInteraction` wrapped every non-paint tool's returned state in `withToolGesture`, overwriting the `move` gesture variant `handleMoveDown` had just built. That variant carries `originalMask` / `originalBounds` (and the quick-mask pixel snapshots), packed inline by the #444 refactor. With the payload gone, `handleMoveMove`'s `state.gesture.kind === 'move' ? … : null` fell to `null`, so it composited the float at the new offset but skipped the `setSelectionBounds` / `setTransform` update that keeps the marquee attached. The quick-mask marquee-content translate path (#315) was dead for the same reason.

Fixed by extracting the decision into `resolveDownGesture`: paint tools still get the paint variant — only the dispatcher knows whether the stroke took the GPU path — and every other tool keeps whatever variant its handler already chose.

Covered by 6 new unit tests in `interaction-types.test.ts`, including one asserting the marquee snapshot survives dispatch.

## 2. Zoom scrub e2e drags off-screen (Firefox only)

`zoom-status-bar.spec.ts` dragged 500px left of the zoom label to test the 10% clamp. The label sits ~25px from the viewport edge; Firefox clamps pointer `clientX` to the viewport while Chromium passes negative coordinates through, so in Firefox the drag was only ~25px wide and the zoom stopped at 1.35. Rewritten to start the leg from a low zoom and drag to `x=0`, which overshoots the floor in both browsers without off-screen coordinates.

## Verification

- Full e2e suite (chromium + firefox + mobile-chrome, no test skipped): **1538 passed, 52 skipped, 0 failed, 0 flaky**
- `npm test` — 1617 passed
- `npm run typecheck`, `npm run lint` — clean

Before the fix the same suite reported 7 failures across those 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)