### PR TITLE
feat(panels): new default dock layout + tab-bar-first drop zones

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -707,7 +707,7 @@ Seven panels — **Navigator, Info, Color, Layers, Channels, History, Paths** �
 - Panels re-added from the toolbar land in the **right dock**, inserted so the vertical order stays canonical (Navigator, Info, Color, Channels, History, Paths, then Layers at the bottom, mirroring the pre-dock sidebar).
 
 ### Default Layout
-- **Color above Layers** in the right dock (35% / 65% split); the other five panels start closed.
+- A **Color/Info** tab group above a **Layers/Channels** tab group in the right dock (50 / 50 split), with **Color** and **Layers** as the active tabs; the other three panels (Navigator, History, Paths) start closed.
 - Default dock thickness: left 280 px, right 312 px, top 220 px, bottom 220 px.
 - On a **coarse-pointer device** (touch), a first run starts with *no* panels open so the canvas gets the whole screen.
 
@@ -715,11 +715,11 @@ Seven panels — **Navigator, Info, Color, Layers, Channels, History, Paths** �
 Dragging starts on a tab (or a floating window's tab bar) after **5 px** of pointer movement; a ghost chip follows the cursor and a translucent indicator previews exactly where the panel will land.
 
 - **Workspace edge** — release within **28 px** of the host's left/right/top/bottom edge to dock there. The panel is appended to that dock's stack: left/right docks stack vertically, top/bottom docks stack horizontally.
-- **Center of an existing panel** — release over the middle region (28% inset from each side, capped at 56 px) to join it as a **tab**. Groups hold at most **3 tabs**; dropping on a full group's center falls through to a side split instead.
-- **Edge band of an existing panel** — release near one of its four sides to **split** that space 50/50, with the dropped panel on the side you aimed at.
+- **Upper portion of an existing panel** — release over the top two-thirds of a group (where its tab bar sits, by convention) to join it as a **tab**. Groups hold at most **3 tabs**; dropping on a full group falls through to a side split instead.
+- **Bottom third of an existing panel** — release over the bottom third to drop the panel as a new group **below** the target in the stack (reordering) rather than combining.
 - **Open space** — release a *tab* anywhere else to **float** it in a new window, sized from the group it came from (capped at 420 × 480). A whole floating window released over open space simply stays where it was dragged.
 - **Escape** during a drag cancels it; a dragged floating window snaps back to where it started.
-- Self-drops are no-ops: dropping a tab on its own group's center just activates it, and a lone tab can't split its own group.
+- Self-drops are no-ops: dropping a tab back on its own group just activates it, and a lone tab can't split its own group.
 - Dragging a floating window whose group is a single tab moves the **whole window**; with 2–3 tabs, dragging a tab extracts just that panel and dragging the empty part of the tab bar moves the window.
 
 ### Tab Keyboard Navigation

--- a/SPEC.md
+++ b/SPEC.md
@@ -439,13 +439,13 @@ Single letter to select tool (e.g., `V` move, `B` brush, `E` eraser, `G` gradien
 
 ### Panels — Dockable System
 - Panels (Navigator, Info, Color, Layers, Channels, History, Paths) live in a
-  docking system rather than a fixed sidebar. Default layout: Color above
-  Layers docked to the right edge.
+  docking system rather than a fixed sidebar. Default layout: a Color/Info tab
+  group above a Layers/Channels tab group, docked to the right edge.
 - Every panel can be moved independently by dragging its tab.
-- Panels dock to the left/right/top/bottom edges of the workspace, or to any
-  side of another panel (splitting the space alongside it).
-- Dropping a panel onto the center of another combines them into a tabbed
-  group — max 3 tabs per group.
+- Panels dock to the left/right/top/bottom edges of the workspace.
+- Dropping a panel over the upper part of another combines them into a tabbed
+  group (max 3 tabs); dropping over the bottom third instead places it below the
+  target in the stack.
 - Panels can float as draggable, resizable windows; docks and splits are
   resizable via dividers. Panel content fills the panel.
 - The layout persists across sessions; the panel toolbar (right rail)

--- a/e2e/channels-panel.spec.ts
+++ b/e2e/channels-panel.spec.ts
@@ -6,19 +6,15 @@ import { createDocument, waitForStore, drawRect } from './helpers';
 // ---------------------------------------------------------------------------
 
 async function openChannelsPanel(page: Parameters<typeof test>[1]['page']): Promise<void> {
-  // Click the Channels panel toggle button in the PanelToolbar
+  // Channels ships as an inactive tab in the default layout, and DockTabs only
+  // renders the active tab's section — so activate it via the toolbar button
+  // unless it's already the visible tab.
+  const section = page.locator('section[aria-label="Channels"]');
+  if (await section.isVisible()) return;
   const btn = page.locator('[role="toolbar"][aria-label="Panel visibility"] button[aria-label="Channels"]');
   await btn.waitFor({ state: 'visible' });
-  const isActive = await page.evaluate(() => {
-    const store = (window as unknown as Record<string, unknown>).__uiStore as {
-      getState: () => { visiblePanels: Set<string> };
-    };
-    return store.getState().visiblePanels.has('channels');
-  });
-  if (!isActive) {
-    await btn.click();
-    await page.waitForTimeout(100);
-  }
+  await btn.click();
+  await section.waitFor({ state: 'visible' });
 }
 
 async function getChannelVisibility(

--- a/e2e/dock-panels.spec.ts
+++ b/e2e/dock-panels.spec.ts
@@ -63,11 +63,15 @@ test.describe('dockable panels', () => {
     await createDocument(page, 400, 300, false);
   });
 
-  test('default layout: color above layers on the right dock', async ({ page }) => {
+  test('default layout: color+info above layers+channels on the right dock', async ({ page }) => {
     await expect(page.locator('[data-testid="dock-right"]')).toBeVisible();
+    // Color and Layers are the active tabs of their respective groups.
     await expect(page.locator('section[aria-label="Color"]')).toBeVisible();
     await expect(page.locator('section[aria-label="Layers"]')).toBeVisible();
-    expect(await getRightDockTabs(page)).toEqual([['color'], ['layers']]);
+    expect(await getRightDockTabs(page)).toEqual([
+      ['color', 'info'],
+      ['layers', 'channels'],
+    ]);
     await page.screenshot({ path: 'e2e/screenshots/dock-default-layout.png' });
   });
 
@@ -80,8 +84,10 @@ test.describe('dockable panels', () => {
       y: layersBox!.y + layersBox!.height / 2,
     });
 
-    expect(await getRightDockTabs(page)).toEqual([['layers', 'color']]);
-    // The dragged tab lands active; both tab buttons live in one tab bar now.
+    // Color joins the layers+channels group as a tab; its old sibling (info)
+    // is left behind as a lone group.
+    expect(await getRightDockTabs(page)).toEqual([['info'], ['layers', 'channels', 'color']]);
+    // The dragged tab lands active; the tab buttons live in one tab bar now.
     const bar = page.locator('[data-testid="dock-tabbar-color"]');
     await expect(bar.locator('[data-dock-tab="layers"]')).toBeVisible();
     await expect(bar.locator('[data-dock-tab="color"]')).toBeVisible();
@@ -96,10 +102,6 @@ test.describe('dockable panels', () => {
   });
 
   test('a group refuses a fourth tab', async ({ page }) => {
-    // Open History and Paths, then merge everything into the layers group.
-    await page.locator('[role="toolbar"][aria-label="Panel visibility"] button[aria-label="History"]').click();
-    await page.locator('[role="toolbar"][aria-label="Panel visibility"] button[aria-label="Paths"]').click();
-
     const layersCenter = async () => {
       const box = await page.locator('[data-dock-group]').filter({
         has: page.locator('[data-dock-tab="layers"]'),
@@ -108,11 +110,14 @@ test.describe('dockable panels', () => {
       return { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 };
     };
 
+    // Merge Color into the layers+channels group → three tabs (the cap).
     await dragFromTo(page, await tabCenter(page, 'color'), await layersCenter());
-    await dragFromTo(page, await tabCenter(page, 'history'), await layersCenter());
-    expect(await getRightDockTabs(page)).toEqual([['paths'], ['layers', 'color', 'history']]);
+    const full = (await getRightDockTabs(page)).find((tabs) => tabs.includes('layers'));
+    expect(full).toEqual(['layers', 'channels', 'color']);
 
-    // Paths cannot join: the center zone degrades to a side split.
+    // Open Paths and try to drop it into the now-full group — it cannot join;
+    // the center zone degrades to a side split instead.
+    await page.locator('[role="toolbar"][aria-label="Panel visibility"] button[aria-label="Paths"]').click();
     await dragFromTo(page, await tabCenter(page, 'paths'), await layersCenter());
     const groups = await getRightDockTabs(page);
     const fullGroup = groups.find((tabs) => tabs.includes('layers'));
@@ -135,7 +140,7 @@ test.describe('dockable panels', () => {
     await expect(floating).toBeVisible();
     await expect(floating.locator('section[aria-label="Color"]')).toBeVisible();
     expect((await getDockLayout(page)).floating).toHaveLength(1);
-    expect(await getRightDockTabs(page)).toEqual([['layers']]);
+    expect(await getRightDockTabs(page)).toEqual([['info'], ['layers', 'channels']]);
     await page.screenshot({ path: 'e2e/screenshots/dock-floating-panel.png' });
 
     // Drag the floating window by its tab to the left edge of the dock host.
@@ -155,25 +160,26 @@ test.describe('dockable panels', () => {
     await page.screenshot({ path: 'e2e/screenshots/dock-left-edge-docked.png' });
   });
 
-  test('splitting a group by dropping on its edge', async ({ page }) => {
-    // Drop Color on the left half of the Layers group → side-by-side split.
+  test('dropping a tab on the bottom third reorders it below the group', async ({ page }) => {
+    // Convention: the tab bar sits at the top, so only the bottom band reorders
+    // a dropped tab below the group instead of combining it as a tab.
     const layersGroup = page.locator('[data-dock-group]').filter({
       has: page.locator('[data-dock-tab="layers"]'),
     });
     const box = await layersGroup.boundingBox();
     expect(box).not.toBeNull();
     await dragFromTo(page, await tabCenter(page, 'color'), {
-      x: box!.x + 12,
-      y: box!.y + box!.height / 2,
+      x: box!.x + box!.width / 2,
+      y: box!.y + box!.height * 0.9,
     });
 
-    // Right dock now holds a row split: color | layers.
+    // Color lands as its own group below layers+channels; info is left behind.
+    expect(await getRightDockTabs(page)).toEqual([['info'], ['layers', 'channels'], ['color']]);
     const layout = await getDockLayout(page);
-    const right = layout.docks.right as { kind: string; direction?: string; children?: { tabs?: string[] }[] };
+    const right = layout.docks.right as { kind: string; direction?: string };
     expect(right.kind).toBe('split');
-    expect(right.direction).toBe('row');
-    expect(right.children?.map((c) => c.tabs)).toEqual([['color'], ['layers']]);
-    await page.screenshot({ path: 'e2e/screenshots/dock-side-split.png' });
+    expect(right.direction).toBe('column');
+    await page.screenshot({ path: 'e2e/screenshots/dock-reorder-below.png' });
   });
 
   test('the dock edge splitter resizes the right dock', async ({ page }) => {
@@ -206,29 +212,22 @@ test.describe('dockable panels', () => {
 
     await expect(page.locator('[data-testid="floating-panel-color"]')).toBeVisible();
     expect((await getDockLayout(page)).floating).toHaveLength(1);
-    expect(await getRightDockTabs(page)).toEqual([['layers']]);
+    expect(await getRightDockTabs(page)).toEqual([['info'], ['layers', 'channels']]);
   });
 
   test('tabs are keyboard-navigable with arrow keys (WAI-ARIA tabs pattern)', async ({ page }) => {
-    // Merge color + layers into one 2-tab group so there's something to arrow through.
-    const layersBox = await page.locator('section[aria-label="Layers"]').boundingBox();
-    await dragFromTo(page, await tabCenter(page, 'color'), {
-      x: layersBox!.x + layersBox!.width / 2,
-      y: layersBox!.y + layersBox!.height / 2,
-    });
-    expect(await getRightDockTabs(page)).toEqual([['layers', 'color']]);
-
-    // The active (color) tab is the roving-tabindex stop; focus it and arrow left.
-    const colorTab = page.locator('[data-dock-tab="color"]');
-    await colorTab.focus();
-    await expect(colorTab).toHaveAttribute('aria-selected', 'true');
-    await page.keyboard.press('ArrowLeft');
-
+    // The default layers+channels group already has two tabs to arrow through.
+    // Layers is the active (roving-tabindex) stop; focus it and arrow right.
     const layersTab = page.locator('[data-dock-tab="layers"]');
+    await layersTab.focus();
     await expect(layersTab).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('section[aria-label="Layers"]')).toBeVisible();
+    await page.keyboard.press('ArrowRight');
+
+    const channelsTab = page.locator('[data-dock-tab="channels"]');
+    await expect(channelsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('section[aria-label="Channels"]')).toBeVisible();
     // Focus follows the selection.
-    await expect(layersTab).toBeFocused();
+    await expect(channelsTab).toBeFocused();
   });
 
   test('escape cancels an in-progress tab drag', async ({ page }) => {
@@ -242,7 +241,10 @@ test.describe('dockable panels', () => {
     await expect(page.locator('[data-testid="dock-drag-ghost"]')).toHaveCount(0);
     await page.mouse.up();
 
-    expect(await getRightDockTabs(page)).toEqual([['color'], ['layers']]);
+    expect(await getRightDockTabs(page)).toEqual([
+      ['color', 'info'],
+      ['layers', 'channels'],
+    ]);
     expect((await getDockLayout(page)).floating).toHaveLength(0);
   });
 });

--- a/e2e/panels-closed-canvas.spec.ts
+++ b/e2e/panels-closed-canvas.spec.ts
@@ -21,18 +21,22 @@ test.describe('#669 canvas visible after closing all side panels', () => {
     await drawRect(page, 50, 50, 200, 150, { r: 255, g: 0, b: 0 });
     await page.waitForTimeout(200);
 
-    // Toggle off every side panel via the PanelToolbar buttons — this
-    // is what the user does; we don't reach into the store.
+    // Toggle off every side panel via the PanelToolbar buttons — this is what
+    // the user does; we don't reach into the store. Panels sharing a tab group
+    // need two clicks (activate the tab, then close it), so keep clicking each
+    // button until its panel leaves the visible set.
     const panels = ['Navigator', 'Info', 'Color', 'Layers', 'Channels', 'History', 'Paths'];
     for (const label of panels) {
-      const isActive = await page.evaluate((id) => {
-        const store = (window as unknown as Record<string, unknown>).__uiStore as {
-          getState: () => { visiblePanels: Set<string> };
-        };
-        return store.getState().visiblePanels.has(id);
-      }, label.toLowerCase());
-      if (isActive) {
-        const btn = page.locator(`[role="toolbar"][aria-label="Panel visibility"] button[aria-label="${label}"]`);
+      const id = label.toLowerCase();
+      const btn = page.locator(`[role="toolbar"][aria-label="Panel visibility"] button[aria-label="${label}"]`);
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const isVisible = await page.evaluate((pid) => {
+          const store = (window as unknown as Record<string, unknown>).__uiStore as {
+            getState: () => { visiblePanels: Set<string> };
+          };
+          return store.getState().visiblePanels.has(pid);
+        }, id);
+        if (!isVisible) break;
         await btn.click();
         await page.waitForTimeout(80);
       }

--- a/src/app/ui-store.ts
+++ b/src/app/ui-store.ts
@@ -337,7 +337,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   visiblePanels: new Set(
     typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches
       ? []
-      : ['color', 'layers'],
+      : ['color', 'info', 'layers', 'channels'],
   ),
   cursorPosition: { x: 0, y: 0 },
   cursorOnCanvas: false,

--- a/src/panels/dock/DockHost/DockHost.stories.tsx
+++ b/src/panels/dock/DockHost/DockHost.stories.tsx
@@ -68,7 +68,7 @@ export const WithFloatingWindow: Story = {
   render: () => {
     const layout: DockLayout = {
       ...createDefaultLayout(),
-      floating: [{ id: 'w1', tabs: ['channels'], activeTab: 'channels', x: 220, y: 90, width: 260, height: 240 }],
+      floating: [{ id: 'w1', tabs: ['history'], activeTab: 'history', x: 220, y: 90, width: 260, height: 240 }],
     };
     return <WithLayout layout={layout} />;
   },

--- a/src/panels/dock/dock-layout.test.ts
+++ b/src/panels/dock/dock-layout.test.ts
@@ -36,11 +36,26 @@ function layoutWithRight(node: DockLayout['docks']['right']): DockLayout {
   return { ...layout, docks: { ...layout.docks, right: node } };
 }
 
+/** A right dock of two single-tab groups stacked (color over layers). */
+function stackedRight(): DockLayout {
+  return layoutWithRight({
+    kind: 'split',
+    id: 'stack-root',
+    direction: 'column',
+    children: [createTabGroup(['color']), createTabGroup(['layers'])],
+    sizes: [0.5, 0.5],
+  });
+}
+
 describe('createDefaultLayout', () => {
-  it('stacks color above layers on the right', () => {
+  it('stacks color+info above layers+channels on the right', () => {
     const layout = createDefaultLayout();
     const groups = rightGroups(layout);
-    expect(groups.map((g) => g.tabs)).toEqual([['color'], ['layers']]);
+    expect(groups.map((g) => g.tabs)).toEqual([
+      ['color', 'info'],
+      ['layers', 'channels'],
+    ]);
+    expect(groups.map((g) => g.activeTab)).toEqual(['color', 'layers']);
     expect(layout.docks.left).toBeNull();
     expect(layout.floating).toEqual([]);
   });
@@ -53,7 +68,13 @@ describe('panelsInLayout / finders', () => {
       kind: 'float',
       rect: { x: 10, y: 10, width: 300, height: 300 },
     });
-    expect(panelsInLayout(layout).sort()).toEqual(['color', 'history', 'layers']);
+    expect(panelsInLayout(layout).sort()).toEqual([
+      'channels',
+      'color',
+      'history',
+      'info',
+      'layers',
+    ]);
 
     const colorGroup = rightGroups(layout).find((g) => g.tabs.includes('color'));
     expect(findPanelGroupId(layout, 'color')).toBe(colorGroup?.id);
@@ -76,7 +97,7 @@ describe('removePanel', () => {
   });
 
   it('dissolves an empty group and collapses the parent split', () => {
-    const layout = createDefaultLayout();
+    const layout = stackedRight();
     const next = removePanel(layout, 'color');
     expect(next.docks.right?.kind).toBe('tabs');
     expect(panelsInLayout(next)).toEqual(['layers']);
@@ -108,13 +129,17 @@ describe('insertNode', () => {
   });
 
   it('appends to an existing dock stack on edge drop', () => {
-    const layout = insertNode(createDefaultLayout(), createTabGroup(['info']), {
+    const layout = insertNode(createDefaultLayout(), createTabGroup(['history']), {
       kind: 'edge',
       side: 'right',
     });
     const root = layout.docks.right as SplitNode;
     expect(root.children).toHaveLength(3);
-    expect(rightGroups(layout).map((g) => g.tabs)).toEqual([['color'], ['layers'], ['info']]);
+    expect(rightGroups(layout).map((g) => g.tabs)).toEqual([
+      ['color', 'info'],
+      ['layers', 'channels'],
+      ['history'],
+    ]);
     expect(root.sizes.reduce((a, b) => a + b, 0)).toBeCloseTo(1);
   });
 
@@ -137,7 +162,7 @@ describe('insertNode', () => {
       region: 'center',
     });
     const group = rightGroups(next).find((g) => g.id === colorGroupId);
-    expect(group?.tabs).toEqual(['color', 'history']);
+    expect(group?.tabs).toEqual(['color', 'info', 'history']);
     expect(group?.activeTab).toBe('history');
   });
 
@@ -177,7 +202,11 @@ describe('insertNode', () => {
     const root = next.docks.right as SplitNode;
     expect(root.direction).toBe('column');
     expect(root.children.every((c) => c.kind === 'tabs')).toBe(true);
-    expect(collectGroups(root).map((g) => g.tabs)).toEqual([['color'], ['history'], ['layers']]);
+    expect(collectGroups(root).map((g) => g.tabs)).toEqual([
+      ['color', 'info'],
+      ['history'],
+      ['layers', 'channels'],
+    ]);
   });
 
   it('creates a floating window with min-size clamping', () => {
@@ -194,7 +223,7 @@ describe('insertNode', () => {
 
 describe('movePanel', () => {
   it('moves a docked panel into a floating window', () => {
-    const layout = createDefaultLayout();
+    const layout = stackedRight();
     const next = movePanel(layout, 'color', {
       kind: 'float',
       rect: { x: 40, y: 40, width: 320, height: 400 },
@@ -205,7 +234,7 @@ describe('movePanel', () => {
   });
 
   it('merges a panel into another group as a tab', () => {
-    const layout = createDefaultLayout();
+    const layout = stackedRight();
     const layersGroupId = findPanelGroupId(layout, 'layers') ?? '';
     const next = movePanel(layout, 'color', {
       kind: 'group',
@@ -284,7 +313,7 @@ describe('movePanel', () => {
 
 describe('dockFloatingWindow', () => {
   function floatingLayout(tabs: string[]): DockLayout {
-    let layout = createDefaultLayout();
+    let layout = stackedRight();
     for (const tab of tabs) {
       layout = removePanel(layout, tab);
     }
@@ -444,12 +473,20 @@ describe('addPanelToDefaultLocation', () => {
 
   it('inserts by canonical order into the right stack', () => {
     const next = addPanelToDefaultLocation(createDefaultLayout(), 'history', ORDER);
-    expect(rightGroups(next).map((g) => g.tabs)).toEqual([['color'], ['history'], ['layers']]);
+    expect(rightGroups(next).map((g) => g.tabs)).toEqual([
+      ['color', 'info'],
+      ['history'],
+      ['layers', 'channels'],
+    ]);
   });
 
   it('places navigator before color', () => {
     const next = addPanelToDefaultLocation(createDefaultLayout(), 'navigator', ORDER);
-    expect(rightGroups(next).map((g) => g.tabs)).toEqual([['navigator'], ['color'], ['layers']]);
+    expect(rightGroups(next).map((g) => g.tabs)).toEqual([
+      ['navigator'],
+      ['color', 'info'],
+      ['layers', 'channels'],
+    ]);
   });
 
   it('is a no-op when the panel is already present', () => {

--- a/src/panels/dock/dock-layout.ts
+++ b/src/panels/dock/dock-layout.ts
@@ -100,7 +100,7 @@ export function emptyLayout(): DockLayout {
   };
 }
 
-/** Mirrors the pre-dock sidebar: Color above Layers on the right edge. */
+/** Color+Info stacked over Layers+Channels on the right edge. */
 export function createDefaultLayout(): DockLayout {
   const layout = emptyLayout();
   return {
@@ -111,8 +111,8 @@ export function createDefaultLayout(): DockLayout {
         kind: 'split',
         id: newNodeId(),
         direction: 'column',
-        children: [createTabGroup(['color']), createTabGroup(['layers'])],
-        sizes: [0.35, 0.65],
+        children: [createTabGroup(['color', 'info']), createTabGroup(['layers', 'channels'])],
+        sizes: [0.5, 0.5],
       },
     },
   };

--- a/src/panels/dock/dock-store.test.ts
+++ b/src/panels/dock/dock-store.test.ts
@@ -25,12 +25,12 @@ beforeEach(reset);
 describe('togglePanel', () => {
   it('adds a missing panel at its default location', () => {
     useDockStore.getState().togglePanel('history');
-    expect(visible()).toEqual(['color', 'history', 'layers']);
+    expect(visible()).toEqual(['channels', 'color', 'history', 'info', 'layers']);
   });
 
   it('removes a panel whose tab is active', () => {
     useDockStore.getState().togglePanel('color');
-    expect(visible()).toEqual(['layers']);
+    expect(visible()).toEqual(['channels', 'info', 'layers']);
   });
 
   it('activates an inactive tab instead of removing it', () => {
@@ -45,8 +45,9 @@ describe('togglePanel', () => {
 
     useDockStore.getState().togglePanel('color');
     const groups = collectGroups(useDockStore.getState().layout.docks.right);
-    expect(groups[0]?.activeTab).toBe('color');
-    expect(visible()).toEqual(['color', 'layers']);
+    const colorGroup = groups.find((g) => g.tabs.includes('color'));
+    expect(colorGroup?.activeTab).toBe('color');
+    expect(visible()).toEqual(['channels', 'color', 'info', 'layers']);
   });
 
   it('mirrors visiblePanels into ui-store on every change', () => {
@@ -54,7 +55,13 @@ describe('togglePanel', () => {
     const lastCall = setState.mock.calls[setState.mock.calls.length - 1]?.[0] as {
       visiblePanels: Set<string>;
     };
-    expect([...lastCall.visiblePanels].sort()).toEqual(['color', 'history', 'layers']);
+    expect([...lastCall.visiblePanels].sort()).toEqual([
+      'channels',
+      'color',
+      'history',
+      'info',
+      'layers',
+    ]);
   });
 });
 
@@ -76,7 +83,8 @@ describe('revealPanel', () => {
 
     useDockStore.getState().revealPanel('color');
     const groups = collectGroups(useDockStore.getState().layout.docks.right);
-    expect(groups[0]?.activeTab).toBe('color');
+    const colorGroup = groups.find((g) => g.tabs.includes('color'));
+    expect(colorGroup?.activeTab).toBe('color');
   });
 });
 
@@ -122,6 +130,6 @@ describe('drag/drop actions', () => {
   it('resetLayout restores the default arrangement', () => {
     useDockStore.getState().togglePanel('color');
     useDockStore.getState().resetLayout();
-    expect(visible()).toEqual(['color', 'layers']);
+    expect(visible()).toEqual(['channels', 'color', 'info', 'layers']);
   });
 });

--- a/src/panels/dock/drop-zones.test.ts
+++ b/src/panels/dock/drop-zones.test.ts
@@ -9,16 +9,19 @@ function zones(partial?: Partial<DropZones>): DropZones {
 }
 
 describe('groupRegionAt', () => {
+  // y spans 100..300; the bottom third (>= ~233) reorders below, the rest combines.
   const rect = { x: 100, y: 100, width: 200, height: 200 };
 
-  it('detects the center', () => {
-    expect(groupRegionAt(200, 200, rect)).toBe('center');
+  it('combines as a tab anywhere in the upper portion', () => {
+    expect(groupRegionAt(200, 110, rect)).toBe('center'); // near the top
+    expect(groupRegionAt(200, 200, rect)).toBe('center'); // middle
+    expect(groupRegionAt(110, 200, rect)).toBe('center'); // left of middle
+    expect(groupRegionAt(290, 200, rect)).toBe('center'); // right of middle
+    expect(groupRegionAt(200, 233, rect)).toBe('center'); // just above the band
   });
 
-  it('detects each edge band', () => {
-    expect(groupRegionAt(110, 200, rect)).toBe('left');
-    expect(groupRegionAt(290, 200, rect)).toBe('right');
-    expect(groupRegionAt(200, 110, rect)).toBe('top');
+  it('reorders below only in the bottom band', () => {
+    expect(groupRegionAt(200, 234, rect)).toBe('bottom');
     expect(groupRegionAt(200, 290, rect)).toBe('bottom');
   });
 });
@@ -91,7 +94,7 @@ describe('resolveDropTarget', () => {
       ],
     });
     const target = resolveDropTarget(1195, 400, z);
-    expect(target).toEqual({ kind: 'group', groupId: 'g1', region: 'right' });
+    expect(target).toEqual({ kind: 'group', groupId: 'g1', region: 'center' });
   });
 
   it('merges into a floating window anywhere over it, unless full', () => {

--- a/src/panels/dock/drop-zones.ts
+++ b/src/panels/dock/drop-zones.ts
@@ -24,9 +24,8 @@ export interface DropZones {
 
 /** Pointer distance from a host edge that triggers edge docking. */
 export const EDGE_DOCK_BAND = 28;
-/** Fraction of a group's size treated as edge bands around the center zone. */
-const CENTER_INSET_RATIO = 0.28;
-const CENTER_INSET_MAX = 56;
+/** Height fraction at the bottom of a group that reorders below it. */
+const BELOW_BAND_RATIO = 1 / 3;
 
 function contains(rect: Rect, x: number, y: number): boolean {
   return x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height;
@@ -46,14 +45,15 @@ function nearestSide(x: number, y: number, rect: Rect): DockSide {
   return best;
 }
 
-/** Which region of a group rect the pointer is over. */
-export function groupRegionAt(x: number, y: number, rect: Rect): 'center' | DockSide {
-  const insetX = Math.min(CENTER_INSET_MAX, rect.width * CENTER_INSET_RATIO);
-  const insetY = Math.min(CENTER_INSET_MAX, rect.height * CENTER_INSET_RATIO);
-  const inCenterX = x >= rect.x + insetX && x < rect.x + rect.width - insetX;
-  const inCenterY = y >= rect.y + insetY && y < rect.y + rect.height - insetY;
-  if (inCenterX && inCenterY) return 'center';
-  return nearestSide(x, y, rect);
+/**
+ * Which region of a group rect the pointer is over. By convention a panel's
+ * tab bar sits at its top, so dropping over the upper portion combines the
+ * dragged panel into the group as a tab ('center'); only the bottom band
+ * reorders it below the group in the stack ('bottom').
+ */
+export function groupRegionAt(_x: number, y: number, rect: Rect): 'center' | DockSide {
+  const belowThreshold = rect.y + rect.height * (1 - BELOW_BAND_RATIO);
+  return y >= belowThreshold ? 'bottom' : 'center';
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related changes to the dockable panel system, both requested together.

### 1. New default panel layout
`createDefaultLayout()` now boots the right dock as a **Color/Info** tab group stacked over a **Layers/Channels** tab group (50/50), with **Color** and **Layers** as the active tabs — replacing the old lone Color-over-Layers (35/65). Because `DockTabs` only mounts the active tab's `<section>`, Info and Channels ship as inactive tabs: they aren't rendered until selected, so there's no runtime/perf change, just two extra tab buttons per tab bar.

### 2. Tab-bar-first drop zones
`groupRegionAt` no longer carves a panel into 5 directional zones. By the convention that a panel's tab bar sits at its top:
- **Top ~2/3 → combine as a tab** (`center`)
- **Bottom 1/3 → reorder below** the group in the stack (`bottom`)

**Behavior removal:** dropping on a panel's left/right/top *edge* no longer creates a side-by-side split — the whole upper area combines now. Side splits still occur automatically when dropping into a group already at the 3-tab cap (the combine degrades to a split).

## Verification
- **Typecheck + lint**: clean.
- **Unit tests**: full suite **1652 passed**. Updated `dock-layout`, `dock-store`, `drop-zones` tests; added a `stackedRight()` fixture so tests that only need "a stacked right dock" don't depend on the default's contents.
- **E2E**: all 7 panel-touching specs pass on chromium — `dock-panels` (rewrote 6 tests + replaced the edge-split test with a bottom-third-reorder test), `channels-panel`, `panels-closed-canvas`, `paths`, `selection-to-path`, `text-panel`, `composition-shapes`.
- **Docs**: `SPEC.md`, `FEATURES.md`, the `DockHost` story, and the `ui-store` initial `visiblePanels` guess updated.

## Persistence note
The `dock:layout:v1` storage key is **not** bumped, so existing saved layouts are preserved — only fresh sessions get the new default. Force-migrating existing sessions would be a one-line version bump if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)