### PR TITLE
test: fix nightly e2e failures (Firefox clipboard, stale WOFF2 flow, redo flake)

### DIFF
--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -163,6 +163,9 @@ test.describe('History - Multi-Step Operations', () => {
     await expect
       .poll(async () => (await getPixelAt(page, 10, 10, bgId)).r, {
         message: 'redo of the bg paint should restore the red rect',
+        // Under a software GPU with the full suite competing for CPU, the
+        // texture readback can lag well past the 5s poll default.
+        timeout: 30000,
       })
       .toBe(255);
 
@@ -173,6 +176,7 @@ test.describe('History - Multi-Step Operations', () => {
     await expect
       .poll(async () => (await getPixelAt(page, 60, 60, topId)).g, {
         message: 'redo of the top paint should restore the green rect',
+        timeout: 30000,
       })
       .toBe(255);
   });

--- a/e2e/text-clipboard.spec.ts
+++ b/e2e/text-clipboard.spec.ts
@@ -2,12 +2,24 @@ import { test, expect } from './fixtures';
 import { createDocument, getEditorState, waitForStore } from './helpers';
 import { getTextEditing, selectTextTool, typeTextAt } from './text-edit-helpers';
 
-/** Dispatch a native paste event carrying plain text (headless clipboard is unreliable). */
+/**
+ * Dispatch a native paste event carrying plain text (headless clipboard is
+ * unreliable). Firefox's ClipboardEvent constructor ignores the `clipboardData`
+ * option and hands the listener an empty DataTransfer, so we attach our own
+ * clipboardData with defineProperty — that delivers the payload in every browser.
+ */
 async function pasteText(page: import('./fixtures').Page, text: string): Promise<void> {
   await page.evaluate((t) => {
-    const dt = new DataTransfer();
-    dt.setData('text/plain', t);
-    const evt = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true });
+    const evt = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(evt, 'clipboardData', {
+      configurable: true,
+      value: {
+        getData: (type: string) => (type === 'text/plain' ? t : ''),
+        files: [] as unknown as FileList,
+        items: [] as unknown as DataTransferItemList,
+        types: ['text/plain'],
+      },
+    });
     window.dispatchEvent(evt);
   }, text);
   await page.waitForTimeout(80);

--- a/e2e/woff2-font-rendering.spec.ts
+++ b/e2e/woff2-font-rendering.spec.ts
@@ -110,7 +110,7 @@ async function getTextLayers(page: Page) {
             type: string;
             name: string;
             visible: boolean;
-            textProps?: { fontFamily?: string };
+            fontFamily?: string;
           }>;
         };
       };
@@ -120,7 +120,7 @@ async function getTextLayers(page: Page) {
       .map((l) => ({
         id: l.id,
         name: l.name,
-        fontFamily: l.textProps?.fontFamily ?? 'unknown',
+        fontFamily: l.fontFamily ?? 'unknown',
       }));
   });
 }
@@ -137,50 +137,37 @@ test.describe('WOFF2 TrueType font rendering', () => {
   });
 
   test('Bebas Neue (TrueType WOFF2) renders distinct glyphs, not Inter fallback', async ({ page }) => {
-    // Type with Inter first as baseline
-    await clickAtDoc(page, 300, 100);
+    // Create one committed text layer in Inter and measure its footprint.
+    // (Since #690, picking a font in the options bar re-styles the selected
+    // committed text layer in place, so we compare the same layer before and
+    // after the font swap rather than juggling two layers — two layers would
+    // both end up Bebas once the font is applied to the active one.)
+    await clickAtDoc(page, 300, 200);
     await page.keyboard.type('HELLO');
-    await page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('Shift+Enter'); // commit; layer stays active
     await page.waitForTimeout(300);
 
     const interLayers = await getTextLayers(page);
     expect(interLayers.length).toBe(1);
-    const interLayerId = interLayers[0]!.id;
+    const layerId = interLayers[0]!.id;
 
-    // Hide Inter layer
-    await page.locator(`[data-layer-id="${interLayerId}"]`)
-      .locator('button[aria-label="Hide layer"], button[aria-label="Show layer"]')
-      .click();
-    await page.waitForTimeout(100);
+    const interCount = await countOpaquePixels(page, layerId);
+    expect(interCount).toBeGreaterThan(50);
 
-    // Select Bebas Neue — a TrueType font that requires WOFF2 glyf transform decoding
+    // Swap the committed, still-active layer to Bebas Neue — a TrueType font that
+    // requires WOFF2 glyf-transform decoding.
     await selectFont(page, 'Bebas Neue');
     await waitForFontInEngine(page, 'Bebas Neue');
+    await page.waitForTimeout(600); // allow the async post-load re-render
 
-    // Create text with Bebas Neue
-    await clickAtDoc(page, 300, 200);
-    await page.keyboard.type('HELLO');
-    await page.keyboard.press('Shift+Enter');
-    await page.waitForTimeout(300);
-
-    const allLayers = await getTextLayers(page);
-    expect(allLayers.length).toBe(2);
-    const bebasLayer = allLayers.find((l) => l.id !== interLayerId);
-    expect(bebasLayer).toBeDefined();
-
-    // Show both for screenshot
-    await page.locator(`[data-layer-id="${interLayerId}"]`)
-      .locator('button[aria-label="Hide layer"], button[aria-label="Show layer"]')
-      .click();
-    await page.waitForTimeout(100);
+    // The layer's font family must have actually switched to Bebas Neue.
+    const afterLayers = await getTextLayers(page);
+    expect(afterLayers.length).toBe(1);
+    expect(afterLayers[0]!.fontFamily).toContain('Bebas Neue');
 
     await page.screenshot({ path: 'e2e/screenshots/woff2-bebas-neue-vs-inter.png' });
 
-    // Both must have rendered content
-    const interCount = await countOpaquePixels(page, interLayerId);
-    const bebasCount = await countOpaquePixels(page, bebasLayer!.id);
-
-    expect(interCount).toBeGreaterThan(50);
+    const bebasCount = await countOpaquePixels(page, layerId);
     expect(bebasCount).toBeGreaterThan(50);
 
     // Bebas Neue is a condensed display font — its pixel footprint should differ


### PR DESCRIPTION
## Nightly e2e triage — 2026-07-24

Full suite: **1570 passed, 5 failed, 1 flaky, 52 skipped** (44.6m, all projects). Every failure was **test-side — no product regressions.** Verification re-run after these fixes: **1575 passed, 0 failed, 1 flaky, 52 skipped** (exit 0).

### 1. Firefox clipboard paste (3 failures) — `text-clipboard.spec.ts`
`Pasting inserts text at the cursor`, `Pasting replaces the active selection`, `Pasting while editing does not create an image layer` failed on **Firefox only**.

**Root cause:** the `pasteText` helper built `new ClipboardEvent('paste', { clipboardData: dt })`. Firefox's constructor **ignores** the `clipboardData` option and hands the listener an empty `DataTransfer` (`getData('text/plain')` → `""`), so nothing was inserted; Chromium honours it. Confirmed empirically in both browsers.

**Fix:** attach `clipboardData` to the event via `Object.defineProperty`, which delivers the payload in every browser. The product paste handler (`useKeyboardShortcuts.ts`) is unchanged and correct.

### 2. Bebas Neue WOFF2 render (2 failures) — `woff2-font-rendering.spec.ts`
Failed on **both** browsers: `interCount` (483) equalled `bebasCount` (483).

**Root cause:** a stale test, not a decode regression. #690 added in-place font styling — picking a font in the options bar re-styles the *selected committed* text layer. The old flow created an Inter layer, left it selected, then picked Bebas for a second layer, which **retroactively switched the first layer to Bebas too** — both layers rendered identically. Diagnostics confirmed Bebas Neue fetches (jsDelivr `.ttf`), loads into the engine, and renders distinctly (Inter "HELLO" = 566 px, Bebas = 483 px).

**Fix:** measure one layer in Inter, swap its font to Bebas in place, assert the footprints differ. Also read `fontFamily` directly off the layer (it isn't nested under `textProps`).

### 3. Redo history flake (1 flaky) — `history.spec.ts`
`redo all steps after undoing everything` (chromium) fails its first attempt then passes on retry: the pixel-readback poll times out because rAF callbacks starve under full-suite CPU contention on SwiftShader. Rock-solid in isolation (~5.5s).

**Fix:** widen both redo polls to 30s. A poll exits the instant the pixel appears, so healthy runs pay nothing and no regression is hidden. This is a **mitigation** for a pre-existing load-sensitive flake, not a guaranteed elimination — it still flaked once at 15s under peak load, hence 30s.

## Verification
- The 5 previously-failing tests pass in **chromium and firefox**.
- Full-suite re-run: **0 failed** (the history test remained flaky-but-passing at 15s; bumped to 30s afterward).
- `npm run typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)