### PR TITLE
perf(text-on-path): rasterize to glyph bbox, reuse scratch canvas

### DIFF
--- a/src/app/useCanvasRendering.ts
+++ b/src/app/useCanvasRendering.ts
@@ -195,12 +195,20 @@ function renderFrameGpu(
     (l): l is import('../types').TextLayer => l.type === 'text' && !!(l as import('../types').TextLayer).pathId,
   );
   if (textLayersWithPath.length > 0) {
-    syncPathTextLayers(engine, textLayersWithPath, editorState.paths, doc.width, doc.height, textEditing);
-    for (const tl of textLayersWithPath) {
-      if (tl.x !== 0 || tl.y !== 0) {
-        editorState.updateTextLayerProperties(tl.id, { x: 0, y: 0 });
-      }
-    }
+    syncPathTextLayers(
+      engine,
+      textLayersWithPath,
+      editorState.paths,
+      doc.width,
+      doc.height,
+      textEditing,
+      (layerId, x, y) => {
+        const layer = textLayersWithPath.find((l) => l.id === layerId);
+        if (layer && (layer.x !== x || layer.y !== y)) {
+          editorState.updateTextLayerProperties(layerId, { x, y });
+        }
+      },
+    );
   }
 
   syncSelection(engine, selection);

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -805,6 +805,11 @@ export function flushLayerSync(state: {
  * Re-render path-text layers (TextLayer.pathId is set) using Canvas2D composition.
  * Called each frame; only uploads when the layer's content key has changed
  * (text, font, color, or the path's anchors).
+ *
+ * `onPositionChange` is invoked with the top-left offset of the rendered
+ * texture in document space so the caller can align the Zustand layer.x/y
+ * with the compact texture. Without this the bounded texture would render
+ * at the layer's stale position and appear offset.
  */
 export function syncPathTextLayers(
   engine: Engine,
@@ -812,7 +817,8 @@ export function syncPathTextLayers(
   paths: readonly StoredPath[],
   docWidth: number,
   docHeight: number,
-  textEditing?: TextEditingState | null,
+  textEditing: TextEditingState | null,
+  onPositionChange: (layerId: string, x: number, y: number) => void,
 ): void {
   const tracked = getTracked(engine);
   if (!tracked.pathTextKeys) {
@@ -861,9 +867,11 @@ export function syncPathTextLayers(
     const result = renderTextOnPath(layerWithLiveText, path.anchors, path.closed, docWidth, docHeight);
     if (result) {
       uploadLayerPixels(engine, layer.id, result.pixels, result.width, result.height, result.x, result.y);
+      onPositionChange(layer.id, result.x, result.y);
     } else {
-      // Empty result — clear the layer texture
+      // Empty result — clear the layer texture and park it at the origin.
       uploadLayerPixels(engine, layer.id, new Uint8Array(4), 1, 1, 0, 0);
+      onPositionChange(layer.id, 0, 0);
     }
     tracked.pathTextKeys.set(layer.id, key);
   }

--- a/src/tools/text/render-text-on-path.test.ts
+++ b/src/tools/text/render-text-on-path.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { computeBounds } from './render-text-on-path';
+import type { GlyphPlacement } from './text-on-path';
+
+// #695 — path-text rasterization used to size to the full document, producing
+// a 64 MB canvas on a 4096×4096 doc. The fix is a per-glyph bounding box.
+// These tests pin the bbox math so a regression can't silently reintroduce
+// the full-document allocation.
+
+function placement(x: number, y: number, char = 'A', charIndex = 0, rotation = 0): GlyphPlacement {
+  return { charIndex, char, x, y, rotation };
+}
+
+describe('renderTextOnPath / computeBounds', () => {
+  it('returns null when there are no placements', () => {
+    expect(computeBounds([], [], 20, 4096, 4096)).toBeNull();
+  });
+
+  it('sizes to the glyphs, not the document', () => {
+    const placements = [placement(100, 200), placement(120, 200), placement(140, 200)];
+    const bounds = computeBounds(placements, [16, 16, 16], 20, 4096, 4096);
+    expect(bounds).not.toBeNull();
+    // Bounded — must be radically smaller than the doc on both axes.
+    // A 20px font over ~40px of horizontal extent should never approach 4K.
+    expect(bounds!.w).toBeLessThan(200);
+    expect(bounds!.h).toBeLessThan(200);
+  });
+
+  it('encloses every placement with padding for ascender + advance', () => {
+    // Padding = fontSize + advance/2. With fontSize=20 and advance=16 the
+    // extent per glyph is 28 units from centre. A single glyph at (500, 500)
+    // must produce a bbox spanning at least (472,472)..(528,528).
+    const bounds = computeBounds([placement(500, 500)], [16], 20, 4096, 4096);
+    expect(bounds).not.toBeNull();
+    expect(bounds!.x).toBeLessThanOrEqual(472);
+    expect(bounds!.y).toBeLessThanOrEqual(472);
+    expect(bounds!.x + bounds!.w).toBeGreaterThanOrEqual(528);
+    expect(bounds!.y + bounds!.h).toBeGreaterThanOrEqual(528);
+  });
+
+  it('clips against the document — never returns negative origin or overflow', () => {
+    // Glyph at the origin — half its bbox would go negative; must be clipped
+    // to 0.
+    const bounds = computeBounds([placement(0, 0)], [16], 20, 100, 100);
+    expect(bounds).not.toBeNull();
+    expect(bounds!.x).toBe(0);
+    expect(bounds!.y).toBe(0);
+    expect(bounds!.x + bounds!.w).toBeLessThanOrEqual(100);
+    expect(bounds!.y + bounds!.h).toBeLessThanOrEqual(100);
+  });
+
+  it('returns null when every placement is outside the document', () => {
+    // Glyph is beyond the far edge; after clip, w or h collapses to <= 0.
+    const bounds = computeBounds([placement(5000, 5000)], [16], 20, 100, 100);
+    expect(bounds).toBeNull();
+  });
+
+  it('unions bounds across many placements', () => {
+    const placements = [
+      placement(100, 100),
+      placement(200, 300),
+      placement(400, 150),
+    ];
+    const bounds = computeBounds(placements, [16, 16, 16], 20, 4096, 4096);
+    expect(bounds).not.toBeNull();
+    // Must cover the extremes of every placement centre.
+    expect(bounds!.x).toBeLessThanOrEqual(100);
+    expect(bounds!.y).toBeLessThanOrEqual(100);
+    expect(bounds!.x + bounds!.w).toBeGreaterThanOrEqual(400);
+    expect(bounds!.y + bounds!.h).toBeGreaterThanOrEqual(300);
+  });
+
+  it('scales bbox padding with fontSize', () => {
+    const smallFont = computeBounds([placement(1000, 1000)], [16], 12, 4096, 4096);
+    const largeFont = computeBounds([placement(1000, 1000)], [16], 96, 4096, 4096);
+    expect(smallFont).not.toBeNull();
+    expect(largeFont).not.toBeNull();
+    // A 96px glyph must reserve more room than a 12px glyph.
+    expect(largeFont!.w).toBeGreaterThan(smallFont!.w);
+    expect(largeFont!.h).toBeGreaterThan(smallFont!.h);
+  });
+
+  it('never returns a doc-sized bbox for a short glyph run on a large doc', () => {
+    // Regression guard for #695 — a five-glyph label on a 4K doc must not
+    // rasterize into a 4K×4K surface.
+    const placements = [
+      placement(100, 100, 'H', 0),
+      placement(115, 100, 'e', 1),
+      placement(125, 100, 'l', 2),
+      placement(135, 100, 'l', 3),
+      placement(150, 100, 'o', 4),
+    ];
+    const bounds = computeBounds(placements, [15, 10, 10, 15, 20], 20, 4096, 4096);
+    expect(bounds).not.toBeNull();
+    // Bail before the render if the bbox ever grows to document scale.
+    expect(bounds!.w * bounds!.h).toBeLessThan(4096 * 4096 / 100);
+  });
+});

--- a/src/tools/text/render-text-on-path.ts
+++ b/src/tools/text/render-text-on-path.ts
@@ -1,40 +1,104 @@
 /**
  * Render text-on-path using Canvas2D composition.
  *
- * Strategy (Option B from spec): use an offscreen Canvas2D that is the same
- * size as the document. Each glyph is drawn at its path-derived position using
- * ctx.translate/rotate/fillText. The resulting ImageData is then uploaded to
- * the GPU as the text layer's texture.
+ * The rasterization is sized to the placed glyphs' bounding box, not the
+ * document, so a small text label on a 4K canvas costs ~kilobytes rather
+ * than tens of megabytes per re-render. The returned `x` / `y` give the
+ * top-left offset of the texture in document space — the caller must place
+ * the layer there.
  *
- * This bypasses the Rust text engine for path text but produces correct visual
- * output with no Rust/WASM changes required.
+ * A single canvas is reused across calls (grow-only) so anchor-drag frames
+ * don't churn the GC with document-sized allocations.
  */
 
 import type { PathAnchor } from '../path/path';
 import type { TextLayer } from '../../types/layers';
 import { buildFontString } from './text';
-import { placeTextOnPath } from './text-on-path';
+import { placeTextOnPath, type GlyphPlacement } from './text-on-path';
 import { contextOptions } from '../../engine/color-space';
 
 export interface PathTextRenderResult {
   /** RGBA pixel data, row-major top-down. */
   pixels: Uint8Array;
-  /** Width of the rendered texture (= docWidth). */
+  /** Width of the rendered texture. */
   width: number;
-  /** Height of the rendered texture (= docHeight). */
+  /** Height of the rendered texture. */
   height: number;
-  /** Document-space x of the top-left of the texture (always 0). */
+  /** Document-space x of the top-left of the texture. */
   x: number;
-  /** Document-space y of the top-left of the texture (always 0). */
+  /** Document-space y of the top-left of the texture. */
   y: number;
 }
 
+let scratchCanvas: HTMLCanvasElement | null = null;
+let scratchCtx: CanvasRenderingContext2D | null = null;
+
+function getScratchContext(minWidth: number, minHeight: number): CanvasRenderingContext2D | null {
+  if (scratchCanvas === null) {
+    scratchCanvas = document.createElement('canvas');
+  }
+  // Grow-only so we don't reallocate on every frame during a drag. Small waste
+  // in memory beats large allocation churn.
+  const targetW = Math.max(scratchCanvas.width, minWidth);
+  const targetH = Math.max(scratchCanvas.height, minHeight);
+  if (scratchCanvas.width !== targetW || scratchCanvas.height !== targetH) {
+    scratchCanvas.width = targetW;
+    scratchCanvas.height = targetH;
+    // Resizing invalidates the context state, so drop the cache.
+    scratchCtx = null;
+  }
+  if (scratchCtx === null) {
+    scratchCtx = scratchCanvas.getContext('2d', contextOptions);
+  }
+  return scratchCtx;
+}
+
+export function computeBounds(
+  placements: readonly GlyphPlacement[],
+  glyphWidths: readonly number[],
+  fontSize: number,
+  docWidth: number,
+  docHeight: number,
+): { x: number; y: number; w: number; h: number } | null {
+  if (placements.length === 0) return null;
+
+  // Per-glyph padding covers ascender + descender + advance regardless of
+  // rotation. A glyph's tightest bounding radius from its centre is at most
+  // sqrt((advance/2)^2 + fontSize^2); we use a looser fontSize + advance/2
+  // per axis, which is cheap and always safe.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const p of placements) {
+    const advance = glyphWidths[p.charIndex] ?? fontSize * 0.6;
+    const pad = fontSize + advance / 2;
+    if (p.x - pad < minX) minX = p.x - pad;
+    if (p.y - pad < minY) minY = p.y - pad;
+    if (p.x + pad > maxX) maxX = p.x + pad;
+    if (p.y + pad > maxY) maxY = p.y + pad;
+  }
+
+  // Clip to document — anything outside is never composited anyway.
+  const x0 = Math.max(0, Math.floor(minX));
+  const y0 = Math.max(0, Math.floor(minY));
+  const x1 = Math.min(docWidth, Math.ceil(maxX));
+  const y1 = Math.min(docHeight, Math.ceil(maxY));
+
+  const w = x1 - x0;
+  const h = y1 - y0;
+  if (w <= 0 || h <= 0) return null;
+
+  return { x: x0, y: y0, w, h };
+}
+
 /**
- * Render `layer`'s text along the given Bezier path into a canvas the size of
- * the document (docWidth × docHeight) and return the pixel data.
+ * Render `layer`'s text along the given Bezier path and return the pixel
+ * data plus the document-space offset the caller should place the layer at.
  *
- * Returns null if the text is empty, the path has fewer than two anchors, or
- * the canvas context cannot be created.
+ * Returns null if the text is empty, the path has fewer than two anchors,
+ * or the canvas context cannot be created.
  */
 export function renderTextOnPath(
   layer: TextLayer,
@@ -47,11 +111,10 @@ export function renderTextOnPath(
 
   if (!text.trim() || anchors.length < 2) return null;
 
-  const canvas = document.createElement('canvas');
-  canvas.width = docWidth;
-  canvas.height = docHeight;
-  const ctx = canvas.getContext('2d', contextOptions);
-  if (!ctx) return null;
+  // Measure glyph widths using the shared scratch context. We haven't sized
+  // it yet — a single-pixel canvas is enough for measureText.
+  const measureCtx = getScratchContext(1, 1);
+  if (!measureCtx) return null;
 
   const fontString = buildFontString({
     fontSize,
@@ -63,39 +126,55 @@ export function renderTextOnPath(
     letterSpacing,
     textAlign: 'left',
   });
-  ctx.font = fontString;
-  ctx.textBaseline = 'alphabetic';
-  ctx.fillStyle = `rgba(${color.r},${color.g},${color.b},${color.a})`;
+  measureCtx.font = fontString;
+  measureCtx.textBaseline = 'alphabetic';
 
-  // Measure glyph widths for each character in the text.
-  // We include letterSpacing as an additive per-glyph offset.
   const glyphWidths: number[] = [];
   for (const char of text) {
-    const metrics = ctx.measureText(char);
+    const metrics = measureCtx.measureText(char);
     glyphWidths.push(metrics.width + letterSpacing);
   }
 
   const placements = placeTextOnPath(text, glyphWidths, anchors, pathClosed, fontSize);
   if (placements.length === 0) return null;
 
+  const bounds = computeBounds(placements, glyphWidths, fontSize, docWidth, docHeight);
+  if (!bounds) return null;
+
+  const ctx = getScratchContext(bounds.w, bounds.h);
+  if (!ctx) return null;
+
+  // Reapply state — either a fresh context or one whose transform/font may
+  // have been left over from a previous call.
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, bounds.w, bounds.h);
+  ctx.font = fontString;
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillStyle = `rgba(${color.r},${color.g},${color.b},${color.a})`;
+
   for (const placement of placements) {
     ctx.save();
-    ctx.translate(placement.x, placement.y);
+    ctx.translate(placement.x - bounds.x, placement.y - bounds.y);
     ctx.rotate(placement.rotation);
-    // Draw glyph centred horizontally over the placement point.
-    // Canvas2D fillText with textAlign 'left' draws from the left edge,
-    // so offset by -width/2 to centre.
     const charWidth = glyphWidths[placement.charIndex] ?? fontSize * 0.6;
     ctx.fillText(placement.char, -(charWidth / 2), 0);
     ctx.restore();
   }
 
-  const imageData = ctx.getImageData(0, 0, docWidth, docHeight);
+  const imageData = ctx.getImageData(0, 0, bounds.w, bounds.h);
   return {
-    pixels: new Uint8Array(imageData.data.buffer),
-    width: docWidth,
-    height: docHeight,
-    x: 0,
-    y: 0,
+    pixels: new Uint8Array(imageData.data.buffer, imageData.data.byteOffset, imageData.data.byteLength),
+    width: bounds.w,
+    height: bounds.h,
+    x: bounds.x,
+    y: bounds.y,
   };
+}
+
+/**
+ * Test-only: drop the cached scratch canvas so subsequent tests start clean.
+ */
+export function __resetScratchCanvasForTests(): void {
+  scratchCanvas = null;
+  scratchCtx = null;
 }


### PR DESCRIPTION
## Summary

Fixes #695. Path-text used to allocate a full-document Canvas2D on every re-render, `getImageData` the whole surface, and `uploadLayerPixels` the whole buffer to the GPU. On a 4096×4096 document that's a 64 MB canvas alloc + 67 MB CPU readback + 67 MB CPU→GPU upload per pointer-move of a path-anchor drag — p90 frame time climbed to 628 ms in the issue's repro.

Two changes:

- **Bounded rasterization.** `renderTextOnPath` now computes an axis-aligned bounding box around the placed glyphs (padded for ascender + advance, clipped to the document) and rasterizes into a canvas that size. The returned `x` / `y` are the top-left of the texture in document space; `syncPathTextLayers` propagates them to the layer's Zustand `x`/`y` through a new position callback so the compositor places the compact texture correctly. This mirrors how `syncTextLayers` handles horizontal text.
- **Scratch canvas reuse.** A single canvas element is cached at module scope and grown as needed instead of `document.createElement('canvas')` on every call — no more discarding a fresh 64 MB backing store per pointer event.

Effect on the issue's repro (5-glyph "Hello" on a 4096² doc): rasterization surface shrinks from `4096 × 4096` (~67 MB) to roughly the glyph run's bbox (kilobytes). Cache key drops `docWidth`/`docHeight` from mattering to correctness (it's still included defensively so a doc resize invalidates) but they no longer drive the cost.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run test` — 1702/1702 pass, including 8 new tests in `src/tools/text/render-text-on-path.test.ts` that pin the bbox math (bounded to glyphs, unions across placements, clipped to document, scales with fontSize, regression guard against doc-sized bbox for short text on a 4K doc)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYWXq3ajZPRzs4USFqoqiJ)_