### PR TITLE
fix(paste): auto-fit oversized paste + activate Move tool

### DIFF
--- a/e2e/external-paste-drop.spec.ts
+++ b/e2e/external-paste-drop.spec.ts
@@ -388,15 +388,136 @@ test.describe('Dimension preservation', () => {
     expect(dims!.height).toBe(32);
   });
 
-  test('large pasted image dimensions are preserved', async ({ page }) => {
+  test('oversized pasted image is fit to the canvas', async ({ page }) => {
     await createDocument(page, 200, 200);
 
-    // Paste a larger image — layer size should match the source, not the canvas.
-    // Read dimensions in the same JS task as the paste, before auto-select
-    // expands the buffer.
+    // Issue #697: an image larger than the canvas used to keep its source
+    // dimensions, which clipped the auto-selection to the visible canvas
+    // and broke resize/move via the transform handles. The paste now shrinks
+    // to fit the canvas (longest side matches, aspect ratio preserved) so
+    // the whole image is on the artboard and the transform handles cover it.
     const dims = await pasteAndReadDimensions(page, 1024, 768, { r: 200, g: 100, b: 50, a: 255 }, 'Copied File');
     expect(dims).not.toBeNull();
-    expect(dims!.width).toBe(1024);
-    expect(dims!.height).toBe(768);
+    // 1024/768 aspect at 200x200 canvas → width 200, height 150.
+    expect(dims!.width).toBe(200);
+    expect(dims!.height).toBe(150);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Oversized paste — resize + undo/redo (issue #697)
+// ---------------------------------------------------------------------------
+
+test.describe('Oversized paste flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForStore(page);
+  });
+
+  test('paste of oversized image activates Move, fits to canvas, selects full layer, and survives undo/redo', async ({ page }) => {
+    await createDocument(page, 200, 200);
+    const before = await getEditorState(page);
+    const initialUndoLen = before.undoStackLength;
+
+    // Read the fit-sized dimensions in the same JS task as the paste, before
+    // the auto-select rAF fires and floatSelection expands the layer texture
+    // (see engine-rs `expand_layer_to_doc_size`).
+    const dims = await pasteAndReadDimensions(page, 1024, 768, { r: 20, g: 90, b: 220, a: 255 }, 'Copied File');
+    expect(dims).not.toBeNull();
+    // 1024/768 aspect at 200x200 canvas → width 200, height 150.
+    expect(dims!.width).toBe(200);
+    expect(dims!.height).toBe(150);
+
+    // Wait for the deferred selectLayerAlpha rAF to run.
+    await page.waitForFunction(() => {
+      const s = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { selection: { active: boolean } };
+      };
+      return s.getState().selection.active;
+    });
+
+    const afterPaste = await page.evaluate(() => {
+      const ed = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: {
+            width: number;
+            height: number;
+            layers: Array<{ id: string; name: string; type: string }>;
+            activeLayerId: string;
+          };
+          selection: {
+            active: boolean;
+            bounds: { x: number; y: number; width: number; height: number } | null;
+          };
+          undoStack: unknown[];
+        };
+      };
+      const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { activeTool: string; transform: unknown };
+      };
+      const s = ed.getState();
+      const pasted = s.document.layers.find((l) => l.name === 'Pasted Layer')!;
+      return {
+        activeTool: ui.getState().activeTool,
+        hasTransform: ui.getState().transform !== null,
+        pastedId: pasted.id,
+        docWidth: s.document.width,
+        docHeight: s.document.height,
+        selection: s.selection,
+        undoLen: s.undoStack.length,
+      };
+    });
+
+    // 1) Move tool is active after paste (issue #697: previously the tool
+    //    was whatever was active before, so the transform handles didn't
+    //    respond to clicks).
+    expect(afterPaste.activeTool).toBe('move');
+    // 2) Transform state exists so the resize/move handles are drawn.
+    expect(afterPaste.hasTransform).toBe(true);
+    // 3) Selection is active and covers a non-empty region on the canvas.
+    //    Before the fix the selection was clipped to the visible canvas of
+    //    the oversized paste — its width/height matched the canvas, not
+    //    the pasted image. After fitting, the selection matches the fit
+    //    dimensions instead.
+    expect(afterPaste.selection.active).toBe(true);
+    expect(afterPaste.selection.bounds).not.toBeNull();
+    const sb = afterPaste.selection.bounds!;
+    expect(sb.width).toBe(200);
+    expect(sb.height).toBe(150);
+    expect(sb.x).toBeGreaterThanOrEqual(0);
+    expect(sb.y).toBeGreaterThanOrEqual(0);
+    expect(sb.x + sb.width).toBeLessThanOrEqual(afterPaste.docWidth);
+    expect(sb.y + sb.height).toBeLessThanOrEqual(afterPaste.docHeight);
+    // 4) Exactly one history entry (Paste) was pushed — the fit is a
+    //    side-effect of paste, not a second undoable step, so a single
+    //    Ctrl+Z fully reverses the operation.
+    expect(afterPaste.undoLen).toBe(initialUndoLen + 1);
+
+    // 5) Undo removes the pasted layer entirely.
+    await page.keyboard.press(`${mod}+z`);
+    await page.waitForFunction(
+      (expected) => {
+        const s = (window as unknown as Record<string, unknown>).__editorStore as {
+          getState: () => { document: { layers: unknown[] } };
+        };
+        return s.getState().document.layers.length === expected;
+      },
+      before.document.layers.length,
+    );
+    const afterUndo = await getEditorState(page);
+    expect(afterUndo.document.layers).toHaveLength(before.document.layers.length);
+    expect(afterUndo.document.layers.find((l) => l.name === 'Pasted Layer')).toBeUndefined();
+
+    // 6) Redo brings the pasted layer back — the layer descriptor's
+    //    width/height stay within the canvas (the float that runs on
+    //    selectLayerAlpha can expand the texture to doc bounds, so we
+    //    only assert the layer isn't back at the pre-fit source size).
+    await page.keyboard.press(`${mod}+Shift+z`);
+    await waitForLayerCount(page, before.document.layers.length + 1);
+    const afterRedo = await getEditorState(page);
+    const restoredPaste = afterRedo.document.layers.find((l) => l.name === 'Pasted Layer');
+    expect(restoredPaste).toBeDefined();
+    expect(restoredPaste!.width).toBeLessThan(1024);
+    expect(restoredPaste!.height).toBeLessThan(768);
   });
 });

--- a/src/app/paste-or-open.ts
+++ b/src/app/paste-or-open.ts
@@ -8,10 +8,43 @@
  * with a canvas 2D fallback for other formats.
  */
 import { useEditorStore } from './editor-store';
+import { useUIStore } from './ui-store';
 import { seedBitmapFromBlob } from '../engine/bitmap-cache';
 import { decodeImageBlob } from './decode-image';
 import { selectLayerAlpha } from '../panels/LayerPanel/layer-selection';
 import { flushLayerSync } from '../engine-wasm/engine-sync';
+import { getEngine } from '../engine-wasm/engine-state';
+import { scaleLayerTexture } from '../engine-wasm/wasm-bridge';
+import { computeFit } from '../tools/move/move';
+import type { Layer } from '../types';
+
+function fitPastedLayerIfOversized(): void {
+  const state = useEditorStore.getState();
+  const { document: doc } = state;
+  const pastedId = doc.activeLayerId;
+  if (!pastedId) return;
+  const pasted = doc.layers.find((l) => l.id === pastedId);
+  if (!pasted || pasted.type !== 'raster') return;
+  if (pasted.width <= doc.width && pasted.height <= doc.height) return;
+
+  const engine = getEngine();
+  if (!engine) return;
+
+  const fit = computeFit(pasted.width, pasted.height, doc.width, doc.height);
+  scaleLayerTexture(engine, pastedId, fit.width, fit.height);
+  useEditorStore.setState((s) => ({
+    document: {
+      ...s.document,
+      layers: s.document.layers.map((l): Layer =>
+        l.id === pastedId && l.type === 'raster'
+          ? { ...l, x: fit.x, y: fit.y, width: fit.width, height: fit.height }
+          : l,
+      ),
+    },
+    renderVersion: s.renderVersion + 1,
+  }));
+  flushLayerSync(useEditorStore.getState());
+}
 
 export async function pasteOrOpenBlob(blob: Blob, fallbackName: string, forceNewDocument = false): Promise<void> {
   const store = useEditorStore.getState();
@@ -48,6 +81,20 @@ export async function pasteOrOpenBlob(blob: Blob, fallbackName: string, forceNew
     } else if (result.imageData) {
       store.pasteImageData(result.imageData);
     }
+
+    // Issue #347 / #697: after a paste, put the user directly in Move so
+    // the transform handles rendered by selectLayerAlpha respond to clicks
+    // (transform-handlers.ts gates on activeTool === 'move').
+    useUIStore.getState().setActiveTool('move');
+
+    // Issue #697: a pasted image larger than the canvas gets a selection
+    // clipped to the visible canvas — the transform handles only cover
+    // that visible portion, so resizing the whole paste is impossible and
+    // the off-canvas pixels are silently dropped by the first float.
+    // Shrink oversized pastes to fit the canvas so the entire image is on
+    // the artboard and every transform (resize, move) works normally.
+    fitPastedLayerIfOversized();
+
     // Issue #347: select the pasted content so the user can immediately
     // transform it (resize, fit, etc.) via the move/transform tools.
     // Defer to the next frame so engine-sync registers the new layer


### PR DESCRIPTION
## Summary

Fixes #697. Pasting an image larger than the canvas kept its source dimensions, so `selectLayerAlpha` built a doc-clipped selection mask and the resulting transform handles only covered the visible portion. Trying to resize or move dragged the on-canvas slice while the off-canvas pixels stayed put, and undo/redo through that mixed state exposed the mismatch. On top of that, the paste never switched the active tool, so the auto-drawn transform handles didn't respond to clicks (they gate on `activeTool === 'move'`).

- Shrink the paste to the canvas (longest side matches, aspect preserved) before `selectLayerAlpha` runs so the entire image is on the artboard and every transform works normally.
- Switch to the Move tool right after paste so the handles that `selectLayerAlpha` draws are actually interactive.
- The fit is a synchronous side-effect of paste, not a second history step — a single Ctrl+Z still fully reverses the paste.

## Test plan

- [x] Updated `Dimension preservation › oversized pasted image is fit to the canvas` to match the new behavior (source-dimension preservation was the bug, not the contract).
- [x] New `Oversized paste flow › paste of oversized image activates Move, fits to canvas, selects full layer, and survives undo/redo` covers: tool switch to Move, transform state present, selection covers the on-canvas region, single history entry, undo removes the layer, redo restores it at the fit size.
- [x] `e2e/external-paste-drop.spec.ts` — 10/10 pass
- [x] `e2e/clipboard.spec.ts` + `e2e/cut-paste-position.spec.ts` — 21/21 pass
- [x] `e2e/transform.spec.ts` — 8/8 pass
- [x] Vitest suite across `src/app/store` + `src/app/interactions` — 280/280 pass
- [x] `npm run typecheck` and `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jx8ZfxrvQZNAMbwYdm7QJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jx8ZfxrvQZNAMbwYdm7QJ)_