### PR TITLE
perf(engine-sync): stop sticky dirtyLayerIds + JS-side move-grab readback

### DIFF
--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -50,7 +50,7 @@ const ALLOWLIST = {
   'src/app/store/actions/resize-image.test.ts': 1,
   'src/app/store/clipboard-image-match.test.ts': 1,
   'src/engine-wasm/engine-sync.test.ts': 3,
-  'src/engine-wasm/sync-layers.test.ts': 7,            // +1: shared mask fixture for upload-retry-cap tests
+  'src/engine-wasm/sync-layers.test.ts': 8,            // +1: shared sticky-dirty fixture buffer for #700 regression tests
   'src/engine/pixel-data-manager.test.ts': 2,
   'src/engine/pixel-data.test.ts': 1,
   'src/filters/auto-enhance.test.ts': 1,

--- a/src/app/interactions/move-handlers.test.ts
+++ b/src/app/interactions/move-handlers.test.ts
@@ -33,6 +33,10 @@ vi.mock('../../engine-wasm/wasm-bridge', () => ({
   setSelectionMask: vi.fn(),
   readQuickMaskPixels: vi.fn(() => new Uint8Array(8)),
   uploadQuickMaskPixels: vi.fn(),
+  cropLayerToContent: vi.fn(() => new Float64Array([0, 0, 0, 0])),
+  // Spy so the handleMoveDown regression test can assert it is NEVER called
+  // (issue #701). The GPU-side crop replaces the JS-side readback path.
+  readLayerPixels: vi.fn(() => new Uint8Array()),
 }));
 
 const engine: { __engine: string } | null = { __engine: 'mock' };
@@ -68,10 +72,24 @@ const editorState = {
   setSelection: vi.fn(),
   setSelectionBounds: vi.fn(),
   notifyRender: vi.fn(),
+  pushHistory: vi.fn(),
+  pushPrebuiltSnapshot: vi.fn(),
+  duplicateLayer: vi.fn(),
+  updateLayerPosition: vi.fn(),
+  expandLayerForEditing: vi.fn(),
+  cropLayerToContent: vi.fn(),
 };
 
 vi.mock('../editor-store', () => ({
-  useEditorStore: { getState: () => editorState },
+  useEditorStore: {
+    getState: () => editorState,
+    setState: (updater: unknown) => {
+      const next = typeof updater === 'function'
+        ? (updater as (s: typeof editorState) => Partial<typeof editorState>)(editorState)
+        : updater as Partial<typeof editorState>;
+      Object.assign(editorState, next);
+    },
+  },
 }));
 
 const uiState = {
@@ -90,12 +108,17 @@ vi.mock('../ui-store', () => ({
 }));
 
 import {
+  handleMoveDown,
   handleMoveMove,
   handleMoveUp,
   flushQuickMaskDrag,
 } from './move-handlers';
-import type { InteractionState, FloatingSelection, PersistentTransform } from './interaction-types';
+import type { InteractionState, FloatingSelection, PersistentTransform, InteractionContext, LastPaintPoint } from './interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS, withMoveGesture } from './interaction-types';
+import * as bridge from '../../engine-wasm/wasm-bridge';
+import { clearJsPixelData } from '../store/clear-js-pixel-data';
+import { DEFAULT_EFFECTS } from '../../layers/layer-model';
+import type { Layer, RasterLayer, Point } from '../../types';
 
 function makeMoveState(overrides: Partial<InteractionState> = {}): InteractionState {
   const mask = new Uint8ClampedArray(DOC_W * DOC_H);
@@ -256,5 +279,129 @@ describe('handleMoveMove (quick-mask + marquee move)', () => {
     handleMoveMove(state, { x: 3, y: 3 }, floatRef);
     tickFrame();
     expect(editorState.setSelection).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleMoveDown — whole-layer move grab (issue #701)', () => {
+  // The whole-layer move grab used to call `editorState.expandLayerForEditing`
+  // and `editorState.cropLayerToContent` on pointer-down. Those two together
+  // did a full GPU→CPU readback (`readLayerPixels`) plus a JS-side ImageData
+  // allocation (67 MB at 4096×4096) plus a CPU alpha scan — all on the frame
+  // the user starts dragging. The fix routes the crop through the WASM
+  // `cropLayerToContent`, which crops the GPU texture in place and returns
+  // the new bounds. No JS readback, no ImageData allocation, no CPU scan.
+
+  const makeContext = (
+    activeLayer: Layer,
+    { altKey = false }: { altKey?: boolean } = {},
+  ): InteractionContext => {
+    const canvasPos: Point = { x: 10, y: 10 };
+    return {
+      canvasPos,
+      layerPos: canvasPos,
+      shiftKey: false,
+      altKey,
+      metaKey: false,
+      activeLayer,
+      activeLayerId: activeLayer.id,
+      clientX: 10,
+      clientY: 10,
+      stateRef: { current: { drawing: false, tool: 'move' } as InteractionState },
+      floatingSelectionRef: { current: null },
+      persistentTransformRef: { current: null },
+      stampSourceRef: { current: null },
+      stampOffsetRef: { current: null },
+      lastPaintPointRef: { current: null as LastPaintPoint | null },
+    };
+  };
+
+  const baseRaster: RasterLayer = {
+    id: 'raster-1',
+    name: 'Raster',
+    type: 'raster',
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blendMode: 'normal',
+    x: 0,
+    y: 0,
+    width: DOC_W,
+    height: DOC_H,
+    clipToBelow: false,
+    effects: DEFAULT_EFFECTS,
+    mask: null,
+  };
+
+  beforeEach(() => {
+    editorState.document.layers = [baseRaster];
+    editorState.selection = {
+      active: false,
+      mask: null,
+      bounds: null,
+      maskWidth: 0,
+      maskHeight: 0,
+    };
+    editorState.pushHistory.mockClear();
+    editorState.expandLayerForEditing.mockClear();
+    editorState.cropLayerToContent.mockClear();
+    uiState.maskMode = 'off';
+    vi.mocked(bridge.cropLayerToContent).mockReset();
+    vi.mocked(bridge.readLayerPixels).mockClear();
+    vi.mocked(clearJsPixelData).mockClear();
+  });
+
+  it('routes the pre-move crop through the WASM cropLayerToContent (not the JS expand + CPU scan)', () => {
+    vi.mocked(bridge.cropLayerToContent).mockReturnValue(new Float64Array([2, 3, 20, 15]));
+    handleMoveDown(makeContext(baseRaster));
+
+    expect(vi.mocked(bridge.cropLayerToContent)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(bridge.cropLayerToContent).mock.calls[0]![1]).toBe(baseRaster.id);
+
+    // The JS-side CPU-scan path must not run — that's the whole point.
+    expect(editorState.expandLayerForEditing).not.toHaveBeenCalled();
+    expect(editorState.cropLayerToContent).not.toHaveBeenCalled();
+  });
+
+  it('never triggers a JS-side readLayerPixels for the whole-layer grab', () => {
+    vi.mocked(bridge.cropLayerToContent).mockReturnValue(new Float64Array([0, 0, DOC_W, DOC_H]));
+    handleMoveDown(makeContext(baseRaster));
+
+    // The 67 MB readback the issue is about lived behind
+    // readLayerAsImageData → readLayerPixels. Neither belongs on this path.
+    expect(vi.mocked(bridge.readLayerPixels)).not.toHaveBeenCalled();
+  });
+
+  it('updates layer bounds from the GPU crop result and clears stale JS pixel data', () => {
+    vi.mocked(bridge.cropLayerToContent).mockReturnValue(new Float64Array([4, 5, 12, 8]));
+    handleMoveDown(makeContext(baseRaster));
+
+    const updated = editorState.document.layers[0] as RasterLayer;
+    expect(updated.x).toBe(4);
+    expect(updated.y).toBe(5);
+    expect(updated.width).toBe(12);
+    expect(updated.height).toBe(8);
+    expect(vi.mocked(clearJsPixelData)).toHaveBeenCalledWith(baseRaster.id);
+  });
+
+  it('leaves layer bounds untouched when the GPU crop reports the same bounds', () => {
+    vi.mocked(bridge.cropLayerToContent).mockReturnValue(new Float64Array([0, 0, DOC_W, DOC_H]));
+    handleMoveDown(makeContext(baseRaster));
+
+    const updated = editorState.document.layers[0] as RasterLayer;
+    expect(updated.x).toBe(0);
+    expect(updated.y).toBe(0);
+    expect(updated.width).toBe(DOC_W);
+    expect(updated.height).toBe(DOC_H);
+    // Bounds unchanged ⇒ no need to drop cached JS pixel data.
+    expect(vi.mocked(clearJsPixelData)).not.toHaveBeenCalled();
+  });
+
+  it('does not crop non-raster layers (text/shape/group have no crop-to-content concept)', () => {
+    const shape: Layer = { ...baseRaster, id: 'shape-1', type: 'shape' } as unknown as Layer;
+    editorState.document.layers = [shape];
+    vi.mocked(bridge.cropLayerToContent).mockReturnValue(new Float64Array([0, 0, 10, 10]));
+    handleMoveDown(makeContext(shape));
+
+    expect(vi.mocked(bridge.cropLayerToContent)).not.toHaveBeenCalled();
   });
 });

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -14,6 +14,7 @@ import {
   setSelectionMask,
   readQuickMaskPixels,
   uploadQuickMaskPixels,
+  cropLayerToContent as cropLayerToContentGpu,
 } from '../../engine-wasm/wasm-bridge';
 import { selectLayerAlpha } from '../../panels/LayerPanel/layer-selection';
 import type {
@@ -291,12 +292,48 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   }
 
   // Crop the layer to content bounds before moving so that only opaque
-  // pixels are repositioned — transparent areas should stay behind.
-  editorState.expandLayerForEditing(activeLayerId);
-  editorState.cropLayerToContent(activeLayerId);
-  const croppedLayer = useEditorStore.getState().document.layers.find(
-    (l) => l.id === activeLayerId,
-  );
+  // pixels are repositioned — transparent areas should stay behind. Use
+  // the GPU-side crop rather than expandLayerForEditing + cropLayerToContent,
+  // which used to force a full JS-side GPU→CPU readback + CPU alpha scan +
+  // 67 MB ImageData allocation on the pointer-down that begins the drag
+  // (issue #701). The WASM path crops the actual GPU texture in place and
+  // returns the new bounds so the Zustand layer can be aligned to match.
+  // Raster-only: text/shape/group layers have no crop-to-content concept
+  // and their GPU textures aren't managed the same way.
+  let croppedX = activeLayer.x;
+  let croppedY = activeLayer.y;
+  const engineForCrop = getEngine();
+  if (engineForCrop && activeLayer.type === 'raster') {
+    const bounds = cropLayerToContentGpu(engineForCrop, activeLayerId);
+    if (bounds.length === 4 && (bounds[2] ?? 0) > 0) {
+      const newX = bounds[0]!;
+      const newY = bounds[1]!;
+      const newW = bounds[2]!;
+      const newH = bounds[3]!;
+      const boundsChanged =
+        newX !== activeLayer.x || newY !== activeLayer.y ||
+        newW !== (activeLayer.width ?? 0) || newH !== (activeLayer.height ?? 0);
+      if (boundsChanged) {
+        useEditorStore.setState((s) => ({
+          document: {
+            ...s.document,
+            layers: s.document.layers.map((l) =>
+              l.id === activeLayerId
+                ? { ...l, x: newX, y: newY, width: newW, height: newH }
+                : l,
+            ),
+          },
+          renderVersion: s.renderVersion + 1,
+        }));
+        // The GPU texture is now the smaller cropped version. Any cached JS
+        // pixel data has stale dimensions; drop it so syncLayers doesn't
+        // re-expand the texture to the old size on the next frame.
+        clearJsPixelData(activeLayerId);
+      }
+      croppedX = newX;
+      croppedY = newY;
+    }
+  }
 
   const baseWholeLayer: InteractionState = {
     drawing: true,
@@ -304,8 +341,8 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
     layerId: activeLayerId,
     tool: 'move',
     startPoint: canvasPos,
-    layerStartX: croppedLayer?.x ?? activeLayer.x,
-    layerStartY: croppedLayer?.y ?? activeLayer.y,
+    layerStartX: croppedX,
+    layerStartY: croppedY,
     ...DEFAULT_TRANSFORM_FIELDS,
   };
   // Whole-layer move (no marquee): the move gesture still owns its

--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -504,6 +504,122 @@ describe('buildPassThroughOpacityMap', () => {
   });
 });
 
+describe('syncLayers — sticky dirtyLayerIds (#700)', () => {
+  // A layer flagged in dirtyLayerIds should upload once per new pixel-data
+  // reference. Previously the `|| isDirty` short-circuit in the pixel and
+  // sparse upload branches unconditionally bypassed the tracked-version
+  // ref-diff, so a sticky dirty flag (dirtyLayerIds is only cleared by
+  // pushHistory / undo / redo) drove a full-layer re-upload every frame.
+  // At 4096×4096 that's 67 MB across the WASM bridge per frame per layer.
+
+  // Shared fixture (pixel-debt budget): one backing buffer, one sparse
+  // indices Uint32Array. Tests that need a distinct "new reference" get a
+  // subarray view rather than allocating another buffer.
+  const stickyBuffer = new Uint8ClampedArray(16 * 16 * 4);
+  const stickyIndices = new Uint32Array([0]);
+
+  const makeImageData = (offset: number, length: number, width: number, height: number): ImageData => ({
+    data: stickyBuffer.subarray(offset, offset + length),
+    width,
+    height,
+  } as ImageData);
+
+  beforeEach(async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    pixelDataManager.dropLayer('sticky');
+    stickyBuffer.fill(0);
+    vi.mocked(bridge.uploadLayerPixels).mockReset();
+    vi.mocked(bridge.uploadLayerSparsePixels).mockReset();
+    vi.mocked(bridge.addLayer).mockReset();
+    vi.mocked(bridge.updateLayer).mockReset();
+  });
+
+  afterEach(async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    pixelDataManager.dropLayer('sticky');
+    vi.mocked(bridge.uploadLayerPixels).mockReset();
+    vi.mocked(bridge.uploadLayerSparsePixels).mockReset();
+  });
+
+  it('uploads dense pixel data exactly once across N frames with a sticky dirty flag', async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    const engine = makeFakeEngine();
+    const layer: RasterLayer = { ...baseRasterLayer, id: 'sticky' };
+
+    pixelDataManager.setDense(layer.id, makeImageData(0, 16 * 16 * 4, 16, 16));
+
+    // Constant dirty set across five frames — same layer, same data ref.
+    const dirty = new Set([layer.id]);
+    for (let i = 0; i < 5; i++) {
+      syncLayers(engine, [layer], [layer.id], dirty);
+    }
+
+    expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(1);
+  });
+
+  it('uploads sparse pixel data exactly once across N frames with a sticky dirty flag', async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    const engine = makeFakeEngine();
+    const layer: RasterLayer = { ...baseRasterLayer, id: 'sticky' };
+
+    pixelDataManager.setSparse(layer.id, {
+      offsetX: 0,
+      offsetY: 0,
+      sparse: {
+        width: 4,
+        height: 4,
+        count: 1,
+        indices: stickyIndices,
+        rgba: stickyBuffer.subarray(0, 4),
+      },
+    });
+
+    const dirty = new Set([layer.id]);
+    for (let i = 0; i < 5; i++) {
+      syncLayers(engine, [layer], [layer.id], dirty);
+    }
+
+    expect(vi.mocked(bridge.uploadLayerSparsePixels)).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-uploads dense data when the ImageData reference actually changes', async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    const engine = makeFakeEngine();
+    const layer: RasterLayer = { ...baseRasterLayer, id: 'sticky' };
+
+    const first = makeImageData(0, 16 * 16 * 4, 16, 16);
+    pixelDataManager.setDense(layer.id, first);
+    const dirty = new Set([layer.id]);
+    syncLayers(engine, [layer], [layer.id], dirty);
+
+    // Same backing buffer, different ImageData reference (subarray view over
+    // a different offset). syncLayers ref-diffs on the ImageData object.
+    const second = makeImageData(4, 16 * 16 * 4, 16, 16);
+    pixelDataManager.setDense(layer.id, second);
+    syncLayers(engine, [layer], [layer.id], dirty);
+
+    expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(2);
+  });
+
+  it('still uploads on the first dirty frame (dirty ⇒ invalidate, not skip)', async () => {
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    const engine = makeFakeEngine();
+    const layer: RasterLayer = { ...baseRasterLayer, id: 'sticky' };
+
+    // First: sync layer with clean state so tracked version is set.
+    const imageData = makeImageData(0, 16 * 16 * 4, 16, 16);
+    pixelDataManager.setDense(layer.id, imageData);
+    syncLayers(engine, [layer], [layer.id], new Set());
+    expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(1);
+
+    // Second: someone edits the same buffer in place (data ref stable) and
+    // flags dirty. The dirty flag alone must still drive an upload.
+    imageData.data.fill(200);
+    syncLayers(engine, [layer], [layer.id], new Set([layer.id]));
+    expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('syncLayers — bounded retries for failing uploads (#595 follow-up)', () => {
   // A failed upload leaves tracked versions stale so the next frame retries.
   // Without a cap, a permanent failure (GPU OOM, detached buffer) retries —

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -342,10 +342,21 @@ export function syncLayers(
     const data = pixelDataManager.get(layer.id);
     const sparseEntry = pixelDataManager.getSparse(layer.id);
     const isDirty = dirtyLayerIds.has(layer.id);
+    // Treat isDirty as "invalidate the tracked version" rather than "force
+    // upload". Otherwise a sticky dirty flag (dirtyLayerIds is only cleared
+    // by pushHistory / undo / redo) makes the ref-diff below unconditional,
+    // and every rendered frame re-uploads the full layer buffer even when
+    // the data reference hasn't changed. Once the tracked version is stale,
+    // the ref-diff drives exactly one upload per new data reference. See
+    // issue #700.
+    if (isDirty) {
+      tracked.pixelDataVersions.delete(layer.id);
+      tracked.sparseVersions.delete(layer.id);
+    }
     const pixelChanged = tracked.pixelDataVersions.get(layer.id) !== data;
     const sparseChanged = tracked.sparseVersions.get(layer.id) !== sparseEntry;
 
-    if (data && (pixelChanged || isDirty)) {
+    if (data && pixelChanged) {
       // On upload failure, leave the tracked version stale so the next
       // frame retries instead of rendering a stale texture forever — but
       // stop attempting once the same payload has failed repeatedly.
@@ -360,7 +371,7 @@ export function syncLayers(
           recordUploadFailure(tracked, `${layer.id}:pixels`, data, 'uploadLayerPixels', layer.id, e);
         }
       }
-    } else if (!data && sparseEntry && (sparseChanged || isDirty)) {
+    } else if (!data && sparseEntry && sparseChanged) {
       if (shouldAttemptUpload(tracked, `${layer.id}:sparse`, sparseEntry)) {
         try {
           const indices = new Uint32Array(sparseEntry.sparse.indices);
@@ -386,14 +397,21 @@ export function syncLayers(
       }
     } else if (!data && !sparseEntry) {
       // No JS data — GPU texture is source of truth (GPU paint or undo restore).
-      // Only clear the GPU texture if we previously had JS data AND the layer is dirty
-      // (meaning JS data was explicitly removed, not just never set).
-      if (isDirty && (tracked.pixelDataVersions.get(layer.id) !== undefined || tracked.sparseVersions.get(layer.id) !== undefined)) {
-        // JS data was cleared but layer is dirty — GPU already has the correct data
-        // from uploadCompressed or GPU stroke. Just update tracking.
-        tracked.pixelDataVersions.set(layer.id, undefined);
-        tracked.sparseVersions.set(layer.id, undefined);
-      }
+      // isDirty already cleared tracked pixel/sparse versions above; nothing
+      // more to do here. Previously this branch re-set the tracked entries
+      // to undefined so a subsequent frame with the same missing-data state
+      // wouldn't re-enter; deletion has the same effect for the ref-diff.
+    }
+
+    // Drop the dirty flag for this layer once we've processed it — see the
+    // isDirty gate above. Without this the sticky set (only cleared by
+    // pushHistory / undo / redo) would force us to invalidate + re-upload
+    // on every rendered frame, which at 4K works out to 67 MB/frame per
+    // layer across the WASM bridge (issue #700). Mutating the caller's Set
+    // is fine: dirtyLayerIds is not React-selected, only engine-sync reads
+    // it, and syncLayers is the sole consumer per frame.
+    if (isDirty) {
+      dirtyLayerIds.delete(layer.id);
     }
 
     // Upload mask — only when the JS-side data reference actually changes,


### PR DESCRIPTION
Fixes #700 and #701. Both are engine-sync hot paths that turned pointer
interaction into per-frame full-layer traffic across the WASM bridge —
independent bugs but in the same code area, so bundled here.

## #700 — sticky `dirtyLayerIds` re-uploaded every frame

`dirtyLayerIds` is only ever cleared by `pushHistory` / `pushPrebuiltSnapshot`
/ `undo` / `redo` / new-document, so a layer can remain flagged for an
unbounded number of frames. The `|| isDirty` short-circuit in
`syncLayers`' pixel and sparse upload branches unconditionally bypassed
the tracked-version ref-diff, so every rendered frame re-uploaded the
layer's full buffer — 67 MB per layer per frame at 4096×4096.

The fix treats `isDirty` as **"invalidate the tracked version"** rather
than **"force upload"**: it deletes the tracked pixel/sparse version, then
lets the existing ref-diff drive exactly one upload per new data
reference. `syncLayers` also drops the id from `dirtyLayerIds` after
processing so a subsequent frame with the same reference is a no-op
regardless of whether anything else clears the set.

## #701 — whole-layer move grab did a full-resolution GPU readback

`handleMoveDown` called `editorState.expandLayerForEditing` +
`editorState.cropLayerToContent` (JS-side) to figure out the layer's
content bounds so only opaque pixels would move. Those two together did a
`readLayerPixels` GPU→CPU readback (67 MB at 4K), a same-size JS
`ImageData` allocation, and a CPU alpha scan — all on the pointer-down
frame the user starts dragging.

The fix routes through the WASM `cropLayerToContent(engine, layerId)`
instead. It crops the GPU texture in place and returns `[x, y, w, h]`,
which is all the move gesture needs to align the Zustand layer to the
smaller texture. The readback, ImageData allocation, and CPU scan are
gone; the drag itself was already GPU-only.

## Tests

Both regressions come with unit tests that lock the fix in:

- `sync-layers.test.ts` — N frames with a constant dirty set + unchanged
  data reference now produce exactly one `uploadLayerPixels` (dense) and
  one `uploadLayerSparsePixels` (sparse) call, and the first-dirty-frame
  and reference-change cases still upload correctly.
- `move-handlers.test.ts` — `handleMoveDown` on a raster layer calls the
  WASM `cropLayerToContent`, never touches `readLayerPixels` or the JS
  `expandLayerForEditing` / `cropLayerToContent`, updates the layer
  bounds from the crop result, and skips non-raster layers.

Full unit suite: 1711 tests, all passing. Typecheck clean.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run lint` (0 errors; pixel-debt budget bumped by +1 for the
      shared sticky-dirty fixture buffer)
- [ ] Manual: grab a large raster layer with the Move tool and confirm
      the pointer-down frame no longer stalls.
- [ ] Manual: mark a layer dirty (e.g. via Stroke Path), then hover the
      cursor over the canvas and confirm no per-frame bridge traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMbnEqkvVPwLvzvP9Mrmwp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMbnEqkvVPwLvzvP9Mrmwp)_