### PR TITLE
fix(engine-sync): keep dirtyLayerIds intact so undo snapshots the live texture

### DIFF
--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -291,6 +291,7 @@ describe('syncLayers — tracked-state cleanup on layer removal', () => {
     expect(tracked.layerPassThroughOpacity.has('r1')).toBe(true);
     expect(tracked.masksOnEngine.has('r1')).toBe(true);
     expect(tracked.maskDataRefs.has('r1')).toBe(true);
+    expect(tracked.processedDirty.has('r1')).toBe(true);
 
     // Seed pathTextKeys directly so the invariant covers it even though
     // we don't have a path-text layer in this fixture.
@@ -310,6 +311,7 @@ describe('syncLayers — tracked-state cleanup on layer removal', () => {
     expect(tracked.maskDataRefs.has('r1')).toBe(false);
     expect(tracked.pixelDataVersions.has('r1')).toBe(false);
     expect(tracked.sparseVersions.has('r1')).toBe(false);
+    expect(tracked.processedDirty.has('r1')).toBe(false);
     expect(tracked.pathTextKeys?.has('r1')).toBe(false);
   });
 });
@@ -617,6 +619,29 @@ describe('syncLayers — sticky dirtyLayerIds (#700)', () => {
     imageData.data.fill(200);
     syncLayers(engine, [layer], [layer.id], new Set([layer.id]));
     expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not mutate the caller dirtyLayerIds Set (#704)', async () => {
+    // Regression: syncLayers used to delete each processed id from the passed
+    // Set to stop sticky re-uploads. But that Set is the store's own object,
+    // shared by reference with pushHistory / undo / redo — emptying it during
+    // rendering made just-edited layers look clean to pushHistory, which then
+    // reused a stale GPU snapshot handle and broke undo/redo. The dirty flag
+    // must survive the render so history snapshots the right texture.
+    const { pixelDataManager } = await import('../engine/pixel-data-manager');
+    const engine = makeFakeEngine();
+    const layer: RasterLayer = { ...baseRasterLayer, id: 'sticky' };
+    pixelDataManager.setDense(layer.id, makeImageData(0, 16 * 16 * 4, 16, 16));
+
+    const dirty = new Set([layer.id]);
+    for (let i = 0; i < 3; i++) {
+      syncLayers(engine, [layer], [layer.id], dirty);
+    }
+
+    // Still exactly one upload (perf win preserved) ...
+    expect(vi.mocked(bridge.uploadLayerPixels)).toHaveBeenCalledTimes(1);
+    // ... and the caller's Set is untouched, so pushHistory still sees it dirty.
+    expect(dirty.has(layer.id)).toBe(true);
   });
 });
 

--- a/src/engine-wasm/sync-layers.ts
+++ b/src/engine-wasm/sync-layers.ts
@@ -278,6 +278,7 @@ export function syncLayers(
       tracked.maskDataRefs.delete(id);
       tracked.pixelDataVersions.delete(id);
       tracked.sparseVersions.delete(id);
+      tracked.processedDirty.delete(id);
       tracked.pathTextKeys?.delete(id);
       tracked.uploadFailures.delete(`${id}:pixels`);
       tracked.uploadFailures.delete(`${id}:sparse`);
@@ -342,16 +343,32 @@ export function syncLayers(
     const data = pixelDataManager.get(layer.id);
     const sparseEntry = pixelDataManager.getSparse(layer.id);
     const isDirty = dirtyLayerIds.has(layer.id);
-    // Treat isDirty as "invalidate the tracked version" rather than "force
-    // upload". Otherwise a sticky dirty flag (dirtyLayerIds is only cleared
-    // by pushHistory / undo / redo) makes the ref-diff below unconditional,
-    // and every rendered frame re-uploads the full layer buffer even when
-    // the data reference hasn't changed. Once the tracked version is stale,
-    // the ref-diff drives exactly one upload per new data reference. See
-    // issue #700.
+    // Treat isDirty as "invalidate the tracked version once" rather than
+    // "force upload". A sticky dirty flag (dirtyLayerIds is only cleared by
+    // pushHistory / undo / redo) would otherwise make the ref-diff below
+    // unconditional, re-uploading the full layer buffer every rendered frame
+    // even when the data reference hasn't changed — 67 MB/frame per layer at
+    // 4096×4096 (issue #700). Invalidate the tracked version on the first
+    // frame of a dirty episode so the ref-diff drives exactly one upload;
+    // later frames leave it alone, and a genuinely new data reference still
+    // re-uploads via the ref-diff.
+    //
+    // The "already reconciled" bookkeeping lives in tracked.processedDirty
+    // (engine-sync's private per-engine state) — NOT by deleting from the
+    // caller's dirtyLayerIds Set. That Set is the store's own object, shared
+    // by reference with pushHistory / undo / redo, which read it to decide
+    // which layers need a fresh GPU history snapshot. Clearing it here made
+    // just-edited layers look clean to pushHistory, so its snapshotGpuLayers
+    // reused a stale texture handle and undo/redo restored the wrong pixels
+    // (issue #704).
     if (isDirty) {
-      tracked.pixelDataVersions.delete(layer.id);
-      tracked.sparseVersions.delete(layer.id);
+      if (!tracked.processedDirty.has(layer.id)) {
+        tracked.pixelDataVersions.delete(layer.id);
+        tracked.sparseVersions.delete(layer.id);
+        tracked.processedDirty.add(layer.id);
+      }
+    } else {
+      tracked.processedDirty.delete(layer.id);
     }
     const pixelChanged = tracked.pixelDataVersions.get(layer.id) !== data;
     const sparseChanged = tracked.sparseVersions.get(layer.id) !== sparseEntry;
@@ -397,21 +414,10 @@ export function syncLayers(
       }
     } else if (!data && !sparseEntry) {
       // No JS data — GPU texture is source of truth (GPU paint or undo restore).
-      // isDirty already cleared tracked pixel/sparse versions above; nothing
-      // more to do here. Previously this branch re-set the tracked entries
-      // to undefined so a subsequent frame with the same missing-data state
-      // wouldn't re-enter; deletion has the same effect for the ref-diff.
-    }
-
-    // Drop the dirty flag for this layer once we've processed it — see the
-    // isDirty gate above. Without this the sticky set (only cleared by
-    // pushHistory / undo / redo) would force us to invalidate + re-upload
-    // on every rendered frame, which at 4K works out to 67 MB/frame per
-    // layer across the WASM bridge (issue #700). Mutating the caller's Set
-    // is fine: dirtyLayerIds is not React-selected, only engine-sync reads
-    // it, and syncLayers is the sole consumer per frame.
-    if (isDirty) {
-      dirtyLayerIds.delete(layer.id);
+      // On the first dirty frame the isDirty gate above already dropped the
+      // tracked pixel/sparse versions; nothing more to do here. The dirty flag
+      // is deliberately left on the store's Set so pushHistory still sees this
+      // layer as changed and captures a fresh GPU snapshot for undo (#704).
     }
 
     // Upload mask — only when the JS-side data reference actually changes,

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -42,6 +42,15 @@ export interface TrackedState {
   maskDataRefs: Map<string, Uint8ClampedArray>;
   pixelDataVersions: Map<string, ImageData | undefined>;
   sparseVersions: Map<string, SparseLayerEntry | undefined>;
+  /** Layer ids whose current dirtyLayerIds episode has already been reconciled
+   *  into the GPU this session. A layer stays in the store's dirtyLayerIds
+   *  until pushHistory / undo / redo clears it, so the flag is sticky across
+   *  many rendered frames. This set lets syncLayers invalidate the tracked
+   *  pixel/sparse version exactly once per episode (driving one upload via the
+   *  ref-diff) instead of every frame — without mutating the store's
+   *  dirtyLayerIds Set, which pushHistory / undo / redo read to decide which
+   *  layers need a fresh GPU history snapshot. See #700 (perf) and #704 (undo). */
+  processedDirty: Set<string>;
   layerOrder: string;
   selectionActive: boolean;
   selectionMask: Uint8ClampedArray | null;
@@ -148,6 +157,7 @@ function createTrackedState(): TrackedState {
     maskDataRefs: new Map(),
     pixelDataVersions: new Map(),
     sparseVersions: new Map(),
+    processedDirty: new Set(),
     layerOrder: '',
     selectionActive: false,
     selectionMask: null,


### PR DESCRIPTION
## Summary

Nightly e2e caught a regression introduced by #702 (`perf(engine-sync): stop sticky dirtyLayerIds and JS-side move-grab readback`): **undo/redo stopped reverting GPU-backed edits**. Every filter's "can be undone" test and the undo/redo stress tests fail on `main` — auto-tone, bloom, emboss, chromatic-aberration, color-lut, fibers, pixelate, `history` multi-step/complex sequences, and `composition-painting`.

## Root cause

To stop a sticky dirty flag from re-uploading a layer's full buffer every frame (#700, 67 MB/frame at 4096×4096), #702 had `syncLayers` **delete each processed layer id from the `dirtyLayerIds` Set**. Its comment asserted "syncLayers is the sole consumer" — but that Set is the store's own object, passed **by reference** (`main.tsx`, `useCanvasRendering.ts`), and `pushHistory` / `undo` / `redo` read it via `snapshotGpuLayers` to decide which layers still need a **fresh** GPU history snapshot:

```ts
// history-slice.ts – snapshotGpuLayers
if (!dirtyIds.has(layerId) && previous?.gpuSnapshots.has(layerId) && posMatch && !dimsChanged) {
  gpuSnapshots.set(layerId, previous.gpuSnapshots.get(layerId)!); // reuse stale handle
  continue;
}
```

The render loop emptied the Set before `pushHistory` ran, so a just-edited layer looked *clean*, its snapshot reused the **previous** (pre-edit) texture handle, and undo/redo restored the wrong pixels.

Bisect: the failing tests **pass at `a7f63518`** (pre-#702) and **fail at `8e7d4bd0`** (#702 merged).

## Fix

Move the "already reconciled this dirty episode" bookkeeping out of the shared store Set and into engine-sync's private per-engine `tracked.processedDirty`. `syncLayers` now invalidates the tracked pixel/sparse version **once** per dirty episode (driving exactly one upload via the ref-diff) **without ever mutating `dirtyLayerIds`**. The Set again means "changed since the last history snapshot," owned by `pushHistory` — restoring the pre-#702 contract while keeping #702's one-upload-per-episode perf win.

## Tests

- New regression test: `syncLayers` must not mutate the caller's `dirtyLayerIds` Set (would have caught #702).
- `processedDirty` added to the per-layer drain-invariant test.
- The #700 sticky-upload tests still pass (one upload across N frames; re-upload only on a genuinely new data reference).
- **Full e2e suite green against this branch: 1607 passed, 52 pre-existing env/fixture skips, 1 known-flaky (`history:134`, net-passes on retry), exit 0, 45 min.**
- `npm run typecheck`, `npm run lint`, and the full unit suite (1712 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
