### PR TITLE
fix: record path edits in undo, snap ruler guides, multi-layer move

### DIFF
--- a/e2e/autofix-706-707-708.spec.ts
+++ b/e2e/autofix-706-707-708.spec.ts
@@ -1,0 +1,253 @@
+import { test, expect, type Page } from './fixtures';
+
+// Coverage for the nightly autofix batch:
+// - issue #706 (path anchor edits recorded in undo history)
+// - issue #707 (move tool moves every selected layer)
+// - issue #708 (Cmd+drag from ruler snaps guide to fractional layout stops)
+
+async function createDocument(page: Page, w = 400, h = 400) {
+  await page.evaluate(
+    ({ w, h }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { createDocument: (w: number, h: number, t: boolean) => void };
+      };
+      store.getState().createDocument(w, h, false);
+    },
+    { w, h },
+  );
+  await page.waitForFunction(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { document: { layers: unknown[] }; undoStack: unknown[] };
+    } | undefined;
+    if (!store) return false;
+    const s = store.getState();
+    return s.document.layers.length > 0 && s.undoStack.length > 0;
+  });
+}
+
+async function docToScreen(page: Page, docX: number, docY: number) {
+  return page.evaluate(
+    ({ docX, docY }) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: { width: number; height: number };
+          viewport: { zoom: number; panX: number; panY: number };
+        };
+      };
+      const state = store.getState();
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      if (!container) return { x: 0, y: 0 };
+      const rect = container.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      const sx = (docX - state.document.width / 2) * state.viewport.zoom + state.viewport.panX + cx;
+      const sy = (docY - state.document.height / 2) * state.viewport.zoom + state.viewport.panY + cy;
+      return { x: rect.left + sx, y: rect.top + sy };
+    },
+    { docX, docY },
+  );
+}
+
+async function clickAtDoc(page: Page, x: number, y: number) {
+  const pos = await docToScreen(page, x, y);
+  await page.mouse.click(pos.x, pos.y);
+  await page.waitForTimeout(50);
+}
+
+test.describe('#706 — path edits are recorded in undo history', () => {
+  test('dragging an anchor pushes an undo entry that restores the old position', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'requires desktop pen-tool UI');
+    await page.goto('/');
+    await page.waitForFunction(() => !!(window as unknown as Record<string, unknown>).__editorStore);
+    await createDocument(page);
+    await page.waitForSelector('[data-testid="canvas-container"]');
+    await page.keyboard.press('p');
+    await page.waitForTimeout(100);
+
+    // Draw a two-anchor open path, commit with Enter.
+    await clickAtDoc(page, 100, 100);
+    await clickAtDoc(page, 200, 100);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(200);
+
+    // Confirm the path exists and grab its ID for selection.
+    const pathId = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { paths: Array<{ id: string }>; selectPath: (id: string) => void };
+      };
+      const p = store.getState().paths[0];
+      if (p) store.getState().selectPath(p.id);
+      return p?.id ?? null;
+    });
+    expect(pathId).not.toBeNull();
+
+    // Drag the second anchor from (200, 100) down to (200, 180).
+    const start = await docToScreen(page, 200, 100);
+    const end = await docToScreen(page, 200, 180);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(100);
+
+    const anchorAfterDrag = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { paths: Array<{ anchors: Array<{ point: { x: number; y: number } }> }> };
+      };
+      return store.getState().paths[0]!.anchors[1]!.point;
+    });
+    // Rough — anchor may not land exactly on (200,180) due to zoom rounding,
+    // but should be far from the original (200,100).
+    expect(anchorAfterDrag.y).toBeGreaterThan(150);
+
+    // Undo — anchor must go back to y≈100.
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+z' : 'Control+z');
+    await page.waitForTimeout(100);
+
+    const anchorAfterUndo = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { paths: Array<{ anchors: Array<{ point: { x: number; y: number } }> }> };
+      };
+      return store.getState().paths[0]!.anchors[1]!.point;
+    });
+    expect(Math.abs(anchorAfterUndo.y - 100)).toBeLessThan(5);
+    expect(Math.abs(anchorAfterUndo.x - 200)).toBeLessThan(5);
+  });
+});
+
+test.describe('#707 — move tool translates every selected layer', () => {
+  test('dragging with two layers selected moves both', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'requires desktop layer panel interactions');
+    await page.goto('/');
+    await page.waitForFunction(() => !!(window as unknown as Record<string, unknown>).__editorStore);
+    await createDocument(page);
+    await page.waitForSelector('[data-testid="canvas-container"]');
+
+    // Two raster layers at known positions, both selected. We seed them via
+    // the store rather than the layer panel because layer creation +
+    // multi-select via panel clicks is verbose; the move-tool interaction we
+    // care about still runs through the real pointer path below.
+    await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          addLayer: () => void;
+          document: {
+            layers: Array<{ id: string; type: string; x: number; y: number; width?: number; height?: number }>;
+            activeLayerId: string | null;
+            selectedLayerIds: readonly string[];
+          };
+        };
+        setState: (updater: (s: unknown) => unknown) => void;
+      };
+      store.getState().addLayer();
+      const layers = store.getState().document.layers;
+      const raster = layers.filter((l) => l.type === 'raster');
+      const a = raster[0]!;
+      const b = raster[raster.length - 1]!;
+      // Give each layer distinct bounds so the test can distinguish them
+      // when reading positions back.
+      store.setState((s: unknown) => {
+        const state = s as { document: { layers: unknown[] } };
+        return {
+          document: {
+            ...state.document,
+            layers: (state.document.layers as Array<{ id: string; type: string; x?: number; y?: number; width?: number; height?: number }>).map((l) => {
+              if (l.id === a.id) return { ...l, x: 40, y: 40, width: 60, height: 60 };
+              if (l.id === b.id) return { ...l, x: 200, y: 200, width: 60, height: 60 };
+              return l;
+            }),
+            activeLayerId: a.id,
+            selectedLayerIds: [a.id, b.id],
+          },
+        };
+      });
+    });
+
+    // Move tool.
+    await page.keyboard.press('v');
+    await page.waitForTimeout(100);
+
+    const posBefore = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { layers: Array<{ id: string; type: string; x: number; y: number }> } };
+      };
+      const rasters = store.getState().document.layers.filter((l) => l.type === 'raster');
+      return { a: { x: rasters[0]!.x, y: rasters[0]!.y }, b: { x: rasters[1]!.x, y: rasters[1]!.y } };
+    });
+
+    // Drag on the active (first) raster — from (70,70) to (100,90) in doc space.
+    const start = await docToScreen(page, 70, 70);
+    const end = await docToScreen(page, 100, 90);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+
+    const posAfter = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => { document: { layers: Array<{ id: string; type: string; x: number; y: number }> } };
+      };
+      const rasters = store.getState().document.layers.filter((l) => l.type === 'raster');
+      return { a: { x: rasters[0]!.x, y: rasters[0]!.y }, b: { x: rasters[1]!.x, y: rasters[1]!.y } };
+    });
+
+    // Both layers should have shifted by roughly the same (dx, dy).
+    const dxA = posAfter.a.x - posBefore.a.x;
+    const dyA = posAfter.a.y - posBefore.a.y;
+    const dxB = posAfter.b.x - posBefore.b.x;
+    const dyB = posAfter.b.y - posBefore.b.y;
+
+    expect(Math.abs(dxA)).toBeGreaterThan(5);
+    expect(Math.abs(dyA)).toBeGreaterThan(5);
+    // Sibling matches the active layer's translation exactly.
+    expect(dxB).toBe(dxA);
+    expect(dyB).toBe(dyA);
+  });
+});
+
+test.describe('#708 — Cmd-hover on the ruler snaps guides to fractional stops', () => {
+  test('Cmd-click on the horizontal ruler places a guide at a clean fraction', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'rulers hidden on touch UIs');
+    await page.goto('/');
+    await page.waitForFunction(() => !!(window as unknown as Record<string, unknown>).__editorStore);
+    await createDocument(page, 400, 300);
+    await page.waitForSelector('[data-testid="canvas-container"]');
+
+    // Ensure rulers + guides are on so the click on the ruler creates a guide.
+    await page.evaluate(() => {
+      const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => {
+          showRulers: boolean; showGuides: boolean;
+          setShowRulers?: (v: boolean) => void; setShowGuides?: (v: boolean) => void;
+        };
+        setState?: (updater: unknown) => void;
+      };
+      const s = ui.getState();
+      if (!s.showRulers && s.setShowRulers) s.setShowRulers(true);
+      else if (!s.showRulers && ui.setState) ui.setState({ showRulers: true });
+      if (!s.showGuides && s.setShowGuides) s.setShowGuides(true);
+      else if (!s.showGuides && ui.setState) ui.setState({ showGuides: true });
+    });
+
+    // Pick a doc-X close to (but not exactly on) 1/3 of the 400px width so we
+    // can verify the snap. 1/3 * 400 ≈ 133.33 → rounded to 133.
+    const nearOneThird = await docToScreen(page, 130, 5);
+    // The ruler sits above the canvas — screenY 5 lands on it. Cmd+click.
+    await page.keyboard.down('Meta');
+    await page.mouse.click(nearOneThird.x, nearOneThird.y);
+    await page.keyboard.up('Meta');
+    await page.waitForTimeout(150);
+
+    const guides = await page.evaluate(() => {
+      const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { guides: Array<{ orientation: 'horizontal' | 'vertical'; position: number }> };
+      };
+      return ui.getState().guides;
+    });
+    // Expect a vertical guide snapped to ~133 (1/3 of 400).
+    const vertical = guides.filter((g) => g.orientation === 'vertical');
+    expect(vertical.length).toBeGreaterThan(0);
+    expect(vertical.some((g) => Math.abs(g.position - 133) <= 1)).toBe(true);
+  });
+});

--- a/src/app/editor-store.test.ts
+++ b/src/app/editor-store.test.ts
@@ -244,6 +244,77 @@ describe('adjustment node actions — dynamic AdjustmentNode list on groups', ()
     expect(group2.adjustments[0]?.enabled).toBe(true);
   });
 
+  describe('paths in undo history (issue #706)', () => {
+    beforeEach(() => {
+      // createDocument doesn't reset the paths slice, so leftover paths
+      // from a prior test would offset the indexing here. Reset explicitly.
+      useEditorStore.setState({ paths: [], selectedPathId: null });
+    });
+
+    it('undo restores paths after an anchor was moved', () => {
+      const state = useEditorStore.getState();
+      // Seed a stored path.
+      state.addPath([
+        { point: { x: 0, y: 0 }, handleIn: null, handleOut: null },
+        { point: { x: 10, y: 10 }, handleIn: null, handleOut: null },
+      ], false);
+      const pathId = useEditorStore.getState().paths[0]!.id;
+
+      // Push metadata history for the anchor drag, then mutate.
+      state.pushHistoryMetadata('Move Path Anchor');
+      state.updatePathAnchors(pathId, [
+        { point: { x: 0, y: 0 }, handleIn: null, handleOut: null },
+        { point: { x: 100, y: 100 }, handleIn: null, handleOut: null },
+      ], false);
+
+      expect(useEditorStore.getState().paths[0]!.anchors[1]!.point).toEqual({ x: 100, y: 100 });
+
+      // Undo should roll the anchor back to (10, 10) — path anchors are
+      // captured in the history snapshot alongside document state.
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().paths[0]!.anchors[1]!.point).toEqual({ x: 10, y: 10 });
+
+      // Redo should reapply the change.
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().paths[0]!.anchors[1]!.point).toEqual({ x: 100, y: 100 });
+    });
+
+    it('undo restores paths after a path was added', () => {
+      const state = useEditorStore.getState();
+      state.pushHistoryMetadata('Add Path');
+      state.addPath([
+        { point: { x: 5, y: 5 }, handleIn: null, handleOut: null },
+        { point: { x: 15, y: 15 }, handleIn: null, handleOut: null },
+      ], false);
+
+      expect(useEditorStore.getState().paths).toHaveLength(1);
+
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().paths).toHaveLength(0);
+
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().paths).toHaveLength(1);
+    });
+
+    it('selectedPathId is restored through undo/redo', () => {
+      const state = useEditorStore.getState();
+      state.addPath([
+        { point: { x: 0, y: 0 }, handleIn: null, handleOut: null },
+        { point: { x: 10, y: 10 }, handleIn: null, handleOut: null },
+      ], false);
+      const pathId = useEditorStore.getState().paths[0]!.id;
+      // addPath auto-selects the new path.
+      expect(useEditorStore.getState().selectedPathId).toBe(pathId);
+
+      state.pushHistoryMetadata('Deselect Path');
+      state.selectPath(null);
+      expect(useEditorStore.getState().selectedPathId).toBeNull();
+
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().selectedPathId).toBe(pathId);
+    });
+  });
+
   it('reorderAdjustmentNodes reorders nodes to the requested sequence', () => {
     const state = useEditorStore.getState();
     state.addGroup('Test Group');

--- a/src/app/hooks/useCanvasPointerHandlers.ts
+++ b/src/app/hooks/useCanvasPointerHandlers.ts
@@ -4,6 +4,7 @@ import { useEditorStore } from '../editor-store';
 import { useUIStore } from '../ui-store';
 import { isPanning, POINTER_IDLE, type PointerMode } from '../pointer-mode';
 import { RULER_SIZE } from '../rendering/ruler-constants';
+import { snapGuideToFraction } from '../rendering/guide-snap';
 import { updatePaintLinePreview } from '../interactions/paint-line-preview';
 
 interface Point {
@@ -244,9 +245,17 @@ export function useCanvasPointerHandlers({
           if (guideId) {
             useUIStore.getState().removeGuide(guideId);
           } else if (isOnHorizontalRuler) {
-            deps.addGuide('vertical', canvasPos.x);
+            const doc = useEditorStore.getState().document;
+            const pos = e.metaKey || e.ctrlKey
+              ? snapGuideToFraction(canvasPos.x, doc.width)
+              : canvasPos.x;
+            deps.addGuide('vertical', pos);
           } else {
-            deps.addGuide('horizontal', canvasPos.y);
+            const doc = useEditorStore.getState().document;
+            const pos = e.metaKey || e.ctrlKey
+              ? snapGuideToFraction(canvasPos.y, doc.height)
+              : canvasPos.y;
+            deps.addGuide('horizontal', pos);
           }
           deps.setRulerHover(null);
           return;
@@ -309,12 +318,17 @@ export function useCanvasPointerHandlers({
       if (deps.showRulers && deps.showGuides && !panning && inside) {
         const isOnHorizontalRuler = screenY < RULER_SIZE && screenX > RULER_SIZE;
         const isOnVerticalRuler = screenX < RULER_SIZE && screenY > RULER_SIZE;
+        const snap = e.metaKey || e.ctrlKey;
 
         if (isOnHorizontalRuler) {
-          deps.setRulerHover({ orientation: 'vertical', position: canvasPos.x, screenX, screenY });
+          const doc = useEditorStore.getState().document;
+          const pos = snap ? snapGuideToFraction(canvasPos.x, doc.width) : canvasPos.x;
+          deps.setRulerHover({ orientation: 'vertical', position: pos, screenX, screenY });
           return;
         } else if (isOnVerticalRuler) {
-          deps.setRulerHover({ orientation: 'horizontal', position: canvasPos.y, screenX, screenY });
+          const doc = useEditorStore.getState().document;
+          const pos = snap ? snapGuideToFraction(canvasPos.y, doc.height) : canvasPos.y;
+          deps.setRulerHover({ orientation: 'horizontal', position: pos, screenX, screenY });
           return;
         } else {
           deps.setRulerHover(null);

--- a/src/app/interactions/interaction-types.ts
+++ b/src/app/interactions/interaction-types.ts
@@ -14,6 +14,14 @@ import type { TransformHandle, TransformState } from '../../tools/transform/tran
  * narrow on `kind` and drop the `!` non-null assertions that the old
  * bag-of-flags shape forced (see transform-handlers.ts).
  */
+/** Per-layer starting position captured at move-drag start for each
+ *  additional selected layer beyond the active one (issue #707). */
+export interface SiblingMoveTarget {
+  readonly id: string;
+  readonly startX: number;
+  readonly startY: number;
+}
+
 export type CanvasGesture =
   | { kind: 'idle' }
   | { kind: 'paint'; usedGpuStroke: boolean }
@@ -33,6 +41,10 @@ export type CanvasGesture =
       quickMaskOriginalPixels: Uint8Array | null;
       quickMaskOriginalWidth: number;
       quickMaskOriginalHeight: number;
+      /** Other selected layers to translate alongside the active one when
+       *  the user drags with multiple layers selected (issue #707). Empty
+       *  for single-layer moves; only populated on whole-layer moves. */
+      siblings: readonly SiblingMoveTarget[];
     }
   | { kind: 'tool' }
   | { kind: 'liquify'; lastPoint: Point }
@@ -93,6 +105,7 @@ export function withMoveGesture(
     quickMaskOriginalPixels?: Uint8Array | null;
     quickMaskOriginalWidth?: number;
     quickMaskOriginalHeight?: number;
+    siblings?: readonly SiblingMoveTarget[];
   },
 ): InteractionState {
   return {
@@ -104,6 +117,7 @@ export function withMoveGesture(
       quickMaskOriginalPixels: payload.quickMaskOriginalPixels ?? null,
       quickMaskOriginalWidth: payload.quickMaskOriginalWidth ?? 0,
       quickMaskOriginalHeight: payload.quickMaskOriginalHeight ?? 0,
+      siblings: payload.siblings ?? [],
     },
   };
 }

--- a/src/app/interactions/move-handlers.test.ts
+++ b/src/app/interactions/move-handlers.test.ts
@@ -61,7 +61,13 @@ const DOC_W = 32;
 const DOC_H = 32;
 
 const editorState = {
-  document: { width: DOC_W, height: DOC_H, layers: [] as unknown[] },
+  document: {
+    width: DOC_W,
+    height: DOC_H,
+    layers: [] as unknown[],
+    activeLayerId: null as string | null,
+    selectedLayerIds: [] as string[],
+  },
   selection: {
     active: false,
     mask: null as Uint8ClampedArray | null,
@@ -403,5 +409,95 @@ describe('handleMoveDown — whole-layer move grab (issue #701)', () => {
     handleMoveDown(makeContext(shape));
 
     expect(vi.mocked(bridge.cropLayerToContent)).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleMoveDown / handleMoveMove — multi-layer move (issue #707)', () => {
+  const baseRaster: RasterLayer = {
+    id: 'raster-1',
+    name: 'Raster',
+    type: 'raster',
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blendMode: 'normal',
+    x: 0,
+    y: 0,
+    width: DOC_W,
+    height: DOC_H,
+    clipToBelow: false,
+    effects: DEFAULT_EFFECTS,
+    mask: null,
+  };
+
+  const sibling: RasterLayer = { ...baseRaster, id: 'raster-2', x: 50, y: 40 };
+  const lockedSibling: RasterLayer = { ...baseRaster, id: 'raster-3', x: 90, y: 90, locked: true };
+
+  const makeContext = (activeLayer: Layer): InteractionContext => {
+    const canvasPos: Point = { x: 10, y: 10 };
+    return {
+      canvasPos,
+      layerPos: canvasPos,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      activeLayer,
+      activeLayerId: activeLayer.id,
+      clientX: 10,
+      clientY: 10,
+      stateRef: { current: { drawing: false, tool: 'move' } as InteractionState },
+      floatingSelectionRef: { current: null },
+      persistentTransformRef: { current: null },
+      stampSourceRef: { current: null },
+      stampOffsetRef: { current: null },
+      lastPaintPointRef: { current: null as LastPaintPoint | null },
+    };
+  };
+
+  beforeEach(() => {
+    editorState.document.layers = [baseRaster, sibling, lockedSibling];
+    editorState.document.activeLayerId = baseRaster.id;
+    editorState.document.selectedLayerIds = [baseRaster.id, sibling.id, lockedSibling.id];
+    editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+    editorState.pushHistory.mockClear();
+    editorState.updateLayerPosition.mockClear();
+    uiState.maskMode = 'off';
+    uiState.showGrid = false;
+    uiState.snapToGrid = false;
+    uiState.snapToLayers = false;
+    vi.mocked(bridge.cropLayerToContent).mockReset();
+    vi.mocked(bridge.cropLayerToContent).mockImplementation((_engine: unknown, id: string) => {
+      const layer = editorState.document.layers.find((l) => (l as Layer).id === id) as Layer | undefined;
+      if (!layer) return new Float64Array([0, 0, 0, 0]);
+      const w = layer.type === 'raster' ? (layer.width ?? 0) : 0;
+      const h = layer.type === 'raster' ? ((layer as { height?: number }).height ?? 0) : 0;
+      return new Float64Array([layer.x, layer.y, w, h]);
+    });
+  });
+
+  it('captures sibling starting positions for every other selected, unlocked layer', () => {
+    const state = handleMoveDown(makeContext(baseRaster));
+    expect(state.gesture.kind).toBe('move');
+    if (state.gesture.kind !== 'move') return;
+    // Locked sibling is excluded — moving a locked layer would be surprising.
+    expect(state.gesture.siblings).toEqual([{ id: 'raster-2', startX: 50, startY: 40 }]);
+  });
+
+  it('applies the same delta to the active layer and every sibling on move', () => {
+    const state = handleMoveDown(makeContext(baseRaster));
+    // Simulate a drag of (+8, +6) from the start point (10, 10).
+    handleMoveMove(state, { x: 18, y: 16 }, makeFloatRef());
+
+    expect(editorState.updateLayerPosition).toHaveBeenCalledWith('raster-1', 8, 6);
+    expect(editorState.updateLayerPosition).toHaveBeenCalledWith('raster-2', 58, 46);
+    // Locked layer never moves.
+    expect(editorState.updateLayerPosition).not.toHaveBeenCalledWith('raster-3', expect.anything(), expect.anything());
+  });
+
+  it('single-layer selection does not populate siblings', () => {
+    editorState.document.selectedLayerIds = [baseRaster.id];
+    const state = handleMoveDown(makeContext(baseRaster));
+    if (state.gesture.kind !== 'move') throw new Error('expected move gesture');
+    expect(state.gesture.siblings).toEqual([]);
   });
 });

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -22,6 +22,7 @@ import type {
   InteractionContext,
   FloatingSelection,
   PersistentTransform,
+  SiblingMoveTarget,
 } from './interaction-types';
 import { DEFAULT_TRANSFORM_FIELDS, withMoveGesture } from './interaction-types';
 import { translateSelectionMask, translateQuickMaskContent } from './quick-mask-move';
@@ -300,39 +301,20 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   // returns the new bounds so the Zustand layer can be aligned to match.
   // Raster-only: text/shape/group layers have no crop-to-content concept
   // and their GPU textures aren't managed the same way.
-  let croppedX = activeLayer.x;
-  let croppedY = activeLayer.y;
-  const engineForCrop = getEngine();
-  if (engineForCrop && activeLayer.type === 'raster') {
-    const bounds = cropLayerToContentGpu(engineForCrop, activeLayerId);
-    if (bounds.length === 4 && (bounds[2] ?? 0) > 0) {
-      const newX = bounds[0]!;
-      const newY = bounds[1]!;
-      const newW = bounds[2]!;
-      const newH = bounds[3]!;
-      const boundsChanged =
-        newX !== activeLayer.x || newY !== activeLayer.y ||
-        newW !== (activeLayer.width ?? 0) || newH !== (activeLayer.height ?? 0);
-      if (boundsChanged) {
-        useEditorStore.setState((s) => ({
-          document: {
-            ...s.document,
-            layers: s.document.layers.map((l) =>
-              l.id === activeLayerId
-                ? { ...l, x: newX, y: newY, width: newW, height: newH }
-                : l,
-            ),
-          },
-          renderVersion: s.renderVersion + 1,
-        }));
-        // The GPU texture is now the smaller cropped version. Any cached JS
-        // pixel data has stale dimensions; drop it so syncLayers doesn't
-        // re-expand the texture to the old size on the next frame.
-        clearJsPixelData(activeLayerId);
-      }
-      croppedX = newX;
-      croppedY = newY;
-    }
+  const { x: croppedX, y: croppedY } = cropLayerAndReadPosition(activeLayer, activeLayerId);
+
+  // Multi-layer move (issue #707): when several layers are selected, drag
+  // the active one and translate every other selected layer by the same
+  // delta. Each sibling captures its starting position (after crop) so we
+  // can apply identical deltas without re-reading the document each move.
+  const selectedIds = editorState.document.selectedLayerIds ?? [];
+  const siblings: SiblingMoveTarget[] = [];
+  for (const sid of selectedIds) {
+    if (sid === activeLayerId) continue;
+    const layer = useEditorStore.getState().document.layers.find((l) => l.id === sid);
+    if (!layer || layer.locked) continue;
+    const { x, y } = cropLayerAndReadPosition(layer, sid);
+    siblings.push({ id: sid, startX: x, startY: y });
   }
 
   const baseWholeLayer: InteractionState = {
@@ -349,7 +331,45 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   // "no snapshot needed" state so consumers can pattern-match on
   // `state.gesture.kind === 'move'` regardless of whether pixels or a
   // marquee are being translated.
-  return withMoveGesture(baseWholeLayer, {});
+  return withMoveGesture(baseWholeLayer, { siblings });
+}
+
+function cropLayerAndReadPosition(
+  layer: { id: string; type: string; x: number; y: number },
+  layerId: string,
+): { x: number; y: number } {
+  let x = layer.x;
+  let y = layer.y;
+  const engine = getEngine();
+  if (!engine || layer.type !== 'raster') return { x, y };
+  const bounds = cropLayerToContentGpu(engine, layerId);
+  if (bounds.length !== 4 || (bounds[2] ?? 0) <= 0) return { x, y };
+  const newX = bounds[0]!;
+  const newY = bounds[1]!;
+  const newW = bounds[2]!;
+  const newH = bounds[3]!;
+  const width = (layer as { width?: number | null }).width ?? 0;
+  const height = (layer as { height?: number | null }).height ?? 0;
+  const boundsChanged =
+    newX !== layer.x || newY !== layer.y ||
+    newW !== width || newH !== height;
+  if (boundsChanged) {
+    useEditorStore.setState((s) => ({
+      document: {
+        ...s.document,
+        layers: s.document.layers.map((l) =>
+          l.id === layerId
+            ? { ...l, x: newX, y: newY, width: newW, height: newH }
+            : l,
+        ),
+      },
+      renderVersion: s.renderVersion + 1,
+    }));
+    clearJsPixelData(layerId);
+  }
+  x = newX;
+  y = newY;
+  return { x, y };
 }
 
 export function handleMoveMove(
@@ -469,11 +489,12 @@ export function handleMoveMove(
       newX = snapped.x;
       newY = snapped.y;
     }
+    const siblingIds = new Set<string>(move?.siblings?.map((s) => s.id) ?? []);
     if (uiState.snapToLayers) {
       const edState = useEditorStore.getState();
       const movingLayer = edState.document.layers.find((l) => l.id === state.layerId);
       const otherLayers = edState.document.layers.filter(
-        (l) => l.id !== state.layerId && l.visible,
+        (l) => l.id !== state.layerId && !siblingIds.has(l.id) && l.visible,
       );
       const movingWidth = movingLayer && movingLayer.type !== 'group' ? (movingLayer.width ?? 0) : 0;
       const movingHeight = movingLayer && movingLayer.type !== 'group' ? ((movingLayer as { height?: number }).height ?? 0) : 0;
@@ -495,11 +516,18 @@ export function handleMoveMove(
     } else {
       uiState.clearSnapLines();
     }
-    useEditorStore.getState().updateLayerPosition(
-      state.layerId!,
-      newX,
-      newY,
-    );
+    // Compute the actual delta applied to the active layer (may differ
+    // from dragDx/Dy after snap) and use it for the siblings so they stay
+    // rigidly in-formation with the active one.
+    const appliedDx = newX - state.layerStartX;
+    const appliedDy = newY - state.layerStartY;
+    const editor = useEditorStore.getState();
+    editor.updateLayerPosition(state.layerId!, newX, newY);
+    if (move?.siblings) {
+      for (const sib of move.siblings) {
+        editor.updateLayerPosition(sib.id, sib.startX + appliedDx, sib.startY + appliedDy);
+      }
+    }
   }
 }
 
@@ -704,5 +732,15 @@ export function handleNudgeMove(
     editor.notifyRender();
   } else {
     editor.updateLayerPosition(activeId, layer.x + dx, layer.y + dy);
+    // Multi-layer nudge (issue #707) — every other selected, unlocked
+    // layer shifts by the same delta so keyboard nudging matches the
+    // drag semantics.
+    const selectedIds = editor.document.selectedLayerIds ?? [];
+    for (const sid of selectedIds) {
+      if (sid === activeId) continue;
+      const l = editor.document.layers.find((x) => x.id === sid);
+      if (!l || l.locked) continue;
+      editor.updateLayerPosition(sid, l.x + dx, l.y + dy);
+    }
   }
 }

--- a/src/app/interactions/path-stroke.ts
+++ b/src/app/interactions/path-stroke.ts
@@ -69,6 +69,7 @@ export function commitCurrentPath(): void {
       : null,
   }));
 
+  editorState.pushHistoryMetadata('Add Path');
   editorState.addPath(docAnchors, draft.closed);
   uiState.clearPath();
 }

--- a/src/app/interactions/prefloat.ts
+++ b/src/app/interactions/prefloat.ts
@@ -54,6 +54,8 @@ function executePrefloat(layerId: string, mask: Uint8ClampedArray, bounds: Rect)
     selection: state.selection,
     gpuSnapshots,
     label: 'Move',
+    paths: state.paths,
+    selectedPathId: state.selectedPathId,
   };
 
   // Now float the selection

--- a/src/app/rendering/guide-snap.test.ts
+++ b/src/app/rendering/guide-snap.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { snapGuideToFraction, _GUIDE_SNAP_FRACTIONS_FOR_TEST } from './guide-snap';
+
+describe('snapGuideToFraction', () => {
+  it('snaps to 1/2 near the midpoint', () => {
+    expect(snapGuideToFraction(500, 1000)).toBe(500);
+    expect(snapGuideToFraction(498, 1000)).toBe(500);
+    expect(snapGuideToFraction(502, 1000)).toBe(500);
+  });
+
+  it('snaps to thirds', () => {
+    expect(snapGuideToFraction(333, 1000)).toBe(333);
+    expect(snapGuideToFraction(340, 1000)).toBe(333);
+    expect(snapGuideToFraction(666, 1000)).toBe(667);
+  });
+
+  it('snaps to 1/16 for finer positions', () => {
+    // 1/16 of 1600 = 100
+    expect(snapGuideToFraction(105, 1600)).toBe(100);
+    // 3/16 of 1600 = 300
+    expect(snapGuideToFraction(298, 1600)).toBe(300);
+    // 15/16 of 1600 = 1500
+    expect(snapGuideToFraction(1495, 1600)).toBe(1500);
+  });
+
+  it('snaps to canvas edges (0 and docSize)', () => {
+    expect(snapGuideToFraction(5, 1000)).toBe(0);
+    expect(snapGuideToFraction(995, 1000)).toBe(1000);
+    expect(snapGuideToFraction(-3, 1000)).toBe(0);
+  });
+
+  it('snaps to 1/4 and 3/4', () => {
+    expect(snapGuideToFraction(255, 1000)).toBe(250);
+    expect(snapGuideToFraction(748, 1000)).toBe(750);
+  });
+
+  it('returns rounded integer positions', () => {
+    // 1/3 of 100 = 33.333...
+    const result = snapGuideToFraction(33, 100);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('handles docSize of 0 by returning rounded position', () => {
+    expect(snapGuideToFraction(42.7, 0)).toBe(43);
+  });
+
+  it('fraction table includes thirds', () => {
+    expect(_GUIDE_SNAP_FRACTIONS_FOR_TEST).toContain(1 / 3);
+    expect(_GUIDE_SNAP_FRACTIONS_FOR_TEST).toContain(2 / 3);
+  });
+
+  it('fraction table includes 1/16 steps', () => {
+    for (let n = 1; n < 16; n += 2) {
+      expect(_GUIDE_SNAP_FRACTIONS_FOR_TEST).toContain(n / 16);
+    }
+  });
+
+  it('fraction table starts at 0 and ends at 1', () => {
+    expect(_GUIDE_SNAP_FRACTIONS_FOR_TEST[0]).toBe(0);
+    expect(_GUIDE_SNAP_FRACTIONS_FOR_TEST[_GUIDE_SNAP_FRACTIONS_FOR_TEST.length - 1]).toBe(1);
+  });
+});

--- a/src/app/rendering/guide-snap.ts
+++ b/src/app/rendering/guide-snap.ts
@@ -1,0 +1,58 @@
+/**
+ * Fractional snap positions for guides. When the user holds Cmd while
+ * dragging a guide out of the ruler, the guide's position is quantized
+ * to reasonable layout fractions of the document dimension — the ones a
+ * designer would actually use to line things up (halves, quarters,
+ * eighths, sixteenths) plus thirds and sixths. Deliberately does NOT
+ * include fifths, sevenths, ninths, elevenths, thirteenths — those never
+ * come up in real layout and would compete with the useful fractions.
+ */
+
+const RATIONAL_DENOMINATORS = [2, 3, 4, 6, 8, 16] as const;
+
+function gcd(a: number, b: number): number {
+  while (b !== 0) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+function buildFractions(): readonly number[] {
+  const set = new Set<number>();
+  set.add(0);
+  set.add(1);
+  for (const d of RATIONAL_DENOMINATORS) {
+    for (let n = 1; n < d; n++) {
+      if (gcd(n, d) === 1) {
+        set.add(n / d);
+      }
+    }
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+const FRACTIONS = buildFractions();
+
+/**
+ * Snap `position` to the nearest fractional multiple of `docSize`. Uses
+ * reduced fractions up to 1/16 plus thirds — i.e. the same set every
+ * layout guide reaches for. Returns the snapped integer position.
+ */
+export function snapGuideToFraction(position: number, docSize: number): number {
+  if (docSize <= 0) return Math.round(position);
+  const t = position / docSize;
+  let best = FRACTIONS[0]!;
+  let bestDist = Math.abs(t - best);
+  for (const f of FRACTIONS) {
+    const d = Math.abs(t - f);
+    if (d < bestDist) {
+      bestDist = d;
+      best = f;
+    }
+  }
+  return Math.round(best * docSize);
+}
+
+export const _GUIDE_SNAP_FRACTIONS_FOR_TEST = FRACTIONS;

--- a/src/app/store/history-slice.ts
+++ b/src/app/store/history-slice.ts
@@ -164,6 +164,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         document: state.document,
         selection: state.selection,
         label: previous.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     } else if (lastRestoredSnapshot && lastRestoredSnapshot.kind === 'pixels') {
       currentSnapshot = {
@@ -172,6 +174,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         selection: state.selection,
         gpuSnapshots: lastRestoredSnapshot.gpuSnapshots,
         label: previous.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     } else {
       const gpuSnapshots = snapshotGpuLayers(
@@ -186,6 +190,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         selection: state.selection,
         gpuSnapshots,
         label: previous.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     }
 
@@ -200,6 +206,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
       redoStack: [...state.redoStack, currentSnapshot],
       document: previous.document,
       selection: previous.selection,
+      paths: [...previous.paths],
+      selectedPathId: previous.selectedPathId,
       dirtyLayerIds: new Set(previous.document.layerOrder),
       renderVersion: state.renderVersion + 1,
     });
@@ -223,6 +231,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         document: state.document,
         selection: state.selection,
         label: next.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     } else if (lastRestoredSnapshot && lastRestoredSnapshot.kind === 'pixels') {
       currentSnapshot = {
@@ -231,6 +241,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         selection: state.selection,
         gpuSnapshots: lastRestoredSnapshot.gpuSnapshots,
         label: next.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     } else {
       const gpuSnapshots = snapshotGpuLayers(
@@ -245,6 +257,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
         selection: state.selection,
         gpuSnapshots,
         label: next.label,
+        paths: state.paths,
+        selectedPathId: state.selectedPathId,
       };
     }
 
@@ -259,6 +273,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
       undoStack: [...state.undoStack, currentSnapshot],
       document: next.document,
       selection: next.selection,
+      paths: [...next.paths],
+      selectedPathId: next.selectedPathId,
       dirtyLayerIds: new Set(next.document.layerOrder),
       renderVersion: state.renderVersion + 1,
     });
@@ -289,6 +305,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
       selection: state.selection,
       gpuSnapshots,
       label,
+      paths: state.paths,
+      selectedPathId: state.selectedPathId,
     };
     set({
       undoStack: [...state.undoStack.slice(-49), snapshot],
@@ -320,6 +338,8 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
       document: state.document,
       selection: state.selection,
       label,
+      paths: state.paths,
+      selectedPathId: state.selectedPathId,
     };
     set({
       undoStack: [...state.undoStack.slice(-49), snapshot],

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -50,13 +50,22 @@ export interface SparseLayerEntry {
  *   live on the GPU — snapshots are just blits (~1ms), no readback.
  */
 export type HistorySnapshot =
-  | { readonly kind: 'metadata'; document: DocumentState; selection: SelectionData; label: string }
+  | {
+      readonly kind: 'metadata';
+      document: DocumentState;
+      selection: SelectionData;
+      label: string;
+      paths: readonly StoredPath[];
+      selectedPathId: string | null;
+    }
   | {
       readonly kind: 'pixels';
       document: DocumentState;
       selection: SelectionData;
       label: string;
       gpuSnapshots: Map<string, number>;
+      paths: readonly StoredPath[];
+      selectedPathId: string | null;
     };
 
 export interface ClipboardData {

--- a/src/tools/path/path-interaction.test.ts
+++ b/src/tools/path/path-interaction.test.ts
@@ -26,6 +26,7 @@ const editorState = {
   }),
   selectPath: vi.fn((id: string | null) => { editorState.selectedPathId = id; }),
   notifyRender: vi.fn(),
+  pushHistoryMetadata: vi.fn(),
 };
 vi.mock('../../app/editor-store', () => ({
   useEditorStore: { getState: () => editorState },
@@ -116,6 +117,7 @@ beforeEach(() => {
   editorState.viewport = { zoom: 1 };
   editorState.updatePathAnchors.mockClear();
   editorState.selectPath.mockClear();
+  editorState.pushHistoryMetadata.mockClear();
   uiState.pathDraft = null;
   uiState.addPathAnchor.mockClear();
   uiState.updateLastPathAnchor.mockClear();

--- a/src/tools/path/path-interaction.ts
+++ b/src/tools/path/path-interaction.ts
@@ -20,6 +20,7 @@ function toggleAnchorSpline(
 
   const anchor = path.anchors[anchorIdx]!;
   if (anchor.handleIn || anchor.handleOut) {
+    editorState.pushHistoryMetadata('Straighten Path Anchor');
     const updated = [...path.anchors];
     updated[anchorIdx] = { point: anchor.point, handleIn: null, handleOut: null };
     editorState.updatePathAnchors(selectedPathId, updated, path.closed);
@@ -46,6 +47,9 @@ export function handlePathDown(ctx: InteractionContext): InteractionState | unde
     // Check handle hit first (handles are smaller targets drawn on top)
     const handleHit = hitTestHandle(path.anchors, canvasPos, hitThreshold);
     if (handleHit) {
+      // Snapshot the pre-drag path so undo restores the anchor + handle
+      // positions from before this handle drag (issue #706).
+      editorState.pushHistoryMetadata('Edit Path Handle');
       uiState.setDraggingHandle(handleHit);
       uiState.setEditingAnchorIndex(handleHit.anchorIndex);
       return {
@@ -72,6 +76,10 @@ export function handlePathDown(ctx: InteractionContext): InteractionState | unde
 
       if (shouldConvert) {
         toggleAnchorSpline(anchorIdx, selectedPathId);
+      } else {
+        // Snapshot for the anchor drag / convert-to-spline about to begin
+        // so undo restores the pre-drag anchor positions (issue #706).
+        editorState.pushHistoryMetadata('Move Path Anchor');
       }
       uiState.setConvertingAnchorToSpline(shouldConvert);
       uiState.setEditingAnchorIndex(anchorIdx);
@@ -89,6 +97,7 @@ export function handlePathDown(ctx: InteractionContext): InteractionState | unde
 
     const segIdx = hitTestSegment(path.anchors, path.closed, canvasPos, hitThreshold);
     if (segIdx >= 0) {
+      editorState.pushHistoryMetadata('Split Path Segment');
       const newAnchors = splitSegmentAt(path.anchors, segIdx);
       editorState.updatePathAnchors(selectedPathId, newAnchors, path.closed);
       editorState.notifyRender();


### PR DESCRIPTION
## Summary

Batches three unrelated fixes reported in the nightly issue queue.

### #706 — path edits and paths panel now roundtrip through undo/redo
The `paths` slice was never included in `HistorySnapshot` and no path-edit
call site pushed history, so dragging an anchor or handle, splitting a
segment, converting an anchor to a spline, or committing a new path were
all invisible to undo. Added `paths` + `selectedPathId` to both
snapshot variants and threaded them through `undo`, `redo`,
`pushHistory`, `pushHistoryMetadata`, and `pushPrebuiltSnapshot`. Each
mutating path interaction (`handlePathDown`, `toggleAnchorSpline`,
`splitSegmentAt`, `commitCurrentPath`) now calls `pushHistoryMetadata`
with a descriptive label.

### #707 — the move tool translates every selected layer
`handleMoveDown` used to only capture the active layer's starting
position. Now, on a whole-layer move (no marquee), it collects each
unlocked layer in `selectedLayerIds`, snapshots its post-crop starting
position on the `move` gesture variant (new `siblings` field), and
translates every sibling by the same delta on each `handleMoveMove`
call and on keyboard nudge. Locked siblings are intentionally excluded.
Snap-to-layers ignores siblings as candidates so moving the group
doesn't snap to itself.

### #708 — Cmd on the ruler snaps guides to fractional stops
Holding Cmd (or Ctrl) while hovering or clicking on the ruler now snaps
the new guide to the closest reasonable layout fraction of the doc
dimension. The set is halves, thirds, quarters, sixths, eighths, and
sixteenths — the fractions a designer would actually use. Fifths,
sevenths, ninths, elevenths, and thirteenths are deliberately omitted
because they'd compete with the useful stops without being useful
themselves. The `RulerHover` preview and the click both snap.

## Test plan

- [x] `npx vitest run` — 1727 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] New unit tests: `src/app/rendering/guide-snap.test.ts` (10 cases),
      multi-layer move cases in `move-handlers.test.ts` (3 cases),
      path undo/redo cases in `editor-store.test.ts` (3 cases)
- [x] New e2e coverage in `e2e/autofix-706-707-708.spec.ts` — one spec
      per issue, all driving the real UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NG71LbKymbGwTU91auZRVM
---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG71LbKymbGwTU91auZRVM)_