### PR TITLE
fix(move): option-drag duplicate no longer drags originals (#707 regression) + autofix e2e fixes

### DIFF
--- a/e2e/autofix-706-707-708.spec.ts
+++ b/e2e/autofix-706-707-708.spec.ts
@@ -127,7 +127,10 @@ test.describe('#707 — move tool translates every selected layer', () => {
     // the store rather than the layer panel because layer creation +
     // multi-select via panel clicks is verbose; the move-tool interaction we
     // care about still runs through the real pointer path below.
-    await page.evaluate(() => {
+    // createDocument seeds more than one raster and addLayer appends another,
+    // so identify the two target layers by id — reading them back positionally
+    // (raster[0]/raster[1]) would pick up an unrelated middle layer.
+    const { aId, bId } = await page.evaluate(() => {
       const store = (window as unknown as Record<string, unknown>).__editorStore as {
         getState: () => {
           addLayer: () => void;
@@ -161,19 +164,28 @@ test.describe('#707 — move tool translates every selected layer', () => {
           },
         };
       });
+      return { aId: a.id, bId: b.id };
     });
 
     // Move tool.
     await page.keyboard.press('v');
     await page.waitForTimeout(100);
 
-    const posBefore = await page.evaluate(() => {
-      const store = (window as unknown as Record<string, unknown>).__editorStore as {
-        getState: () => { document: { layers: Array<{ id: string; type: string; x: number; y: number }> } };
-      };
-      const rasters = store.getState().document.layers.filter((l) => l.type === 'raster');
-      return { a: { x: rasters[0]!.x, y: rasters[0]!.y }, b: { x: rasters[1]!.x, y: rasters[1]!.y } };
-    });
+    const readPositions = (): Promise<{ a: { x: number; y: number }; b: { x: number; y: number } }> =>
+      page.evaluate(
+        ({ aId, bId }) => {
+          const store = (window as unknown as Record<string, unknown>).__editorStore as {
+            getState: () => { document: { layers: Array<{ id: string; x: number; y: number }> } };
+          };
+          const layers = store.getState().document.layers;
+          const a = layers.find((l) => l.id === aId)!;
+          const b = layers.find((l) => l.id === bId)!;
+          return { a: { x: a.x, y: a.y }, b: { x: b.x, y: b.y } };
+        },
+        { aId, bId },
+      );
+
+    const posBefore = await readPositions();
 
     // Drag on the active (first) raster — from (70,70) to (100,90) in doc space.
     const start = await docToScreen(page, 70, 70);
@@ -184,13 +196,7 @@ test.describe('#707 — move tool translates every selected layer', () => {
     await page.mouse.up();
     await page.waitForTimeout(150);
 
-    const posAfter = await page.evaluate(() => {
-      const store = (window as unknown as Record<string, unknown>).__editorStore as {
-        getState: () => { document: { layers: Array<{ id: string; type: string; x: number; y: number }> } };
-      };
-      const rasters = store.getState().document.layers.filter((l) => l.type === 'raster');
-      return { a: { x: rasters[0]!.x, y: rasters[0]!.y }, b: { x: rasters[1]!.x, y: rasters[1]!.y } };
-    });
+    const posAfter = await readPositions();
 
     // Both layers should have shifted by roughly the same (dx, dy).
     const dxA = posAfter.a.x - posBefore.a.x;
@@ -231,11 +237,20 @@ test.describe('#708 — Cmd-hover on the ruler snaps guides to fractional stops'
     });
 
     // Pick a doc-X close to (but not exactly on) 1/3 of the 400px width so we
-    // can verify the snap. 1/3 * 400 ≈ 133.33 → rounded to 133.
-    const nearOneThird = await docToScreen(page, 130, 5);
-    // The ruler sits above the canvas — screenY 5 lands on it. Cmd+click.
+    // can verify the snap. 1/3 * 400 ≈ 133.33 → rounded to 133. The guide is
+    // only created when the pointer-down lands on the ruler band itself
+    // (screenY < RULER_SIZE), so click the top ruler strip at the screen-x
+    // that maps to doc-x≈130 — not at docToScreen(130, 5), which is a point
+    // inside the canvas, well below the ruler.
+    const xForDocX = (await docToScreen(page, 130, 0)).x;
+    const containerTop = await page.evaluate(() => {
+      const container = document.querySelector('[data-testid="canvas-container"]');
+      return container ? container.getBoundingClientRect().top : 0;
+    });
+    // RULER_SIZE is 20; +6 keeps the click comfortably inside the horizontal ruler.
+    const rulerY = containerTop + 6;
     await page.keyboard.down('Meta');
-    await page.mouse.click(nearOneThird.x, nearOneThird.y);
+    await page.mouse.click(xForDocX, rulerY);
     await page.keyboard.up('Meta');
     await page.waitForTimeout(150);
 

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -191,7 +191,8 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   }
 
   // Option+drag with no selection: duplicate layer first, then move the copy
-  if (altKey && !(sel.active && sel.mask)) {
+  const didDuplicate = altKey && !(sel.active && sel.mask);
+  if (didDuplicate) {
     editorState.duplicateLayer();
     const newState = useEditorStore.getState();
     activeLayerId = newState.document.activeLayerId ?? activeLayerId;
@@ -307,7 +308,13 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   // the active one and translate every other selected layer by the same
   // delta. Each sibling captures its starting position (after crop) so we
   // can apply identical deltas without re-reading the document each move.
-  const selectedIds = editorState.document.selectedLayerIds ?? [];
+  //
+  // Skip this for an option-drag duplicate: duplicateLayer makes the new copy
+  // active but leaves the pre-duplicate selection (the originals) in
+  // selectedLayerIds, so treating those as siblings would drag the originals
+  // along with the copy (regresses option-drag-duplicate and
+  // delete-inverted-selection).
+  const selectedIds = didDuplicate ? [] : (editorState.document.selectedLayerIds ?? []);
   const siblings: SiblingMoveTarget[] = [];
   for (const sid of selectedIds) {
     if (sid === activeLayerId) continue;


### PR DESCRIPTION
## Summary

Tonight's nightly e2e run (against the origin/main tip, after the `#706`–`#708`
autofix batch merged today) surfaced **8 failures across 4 specs on both
browsers**. One is a real product regression; the other two are bugs in the
brand-new autofix spec. Since the e2e suite isn't part of GitHub CI, all of
this merged without ever running under the nightly.

### Product regression — option-drag duplicate drags the originals

`#707` multi-layer move (merged today) captures every selected layer as a move
"sibling" at pointer-down. On an **option-drag duplicate**, `duplicateLayer()`
makes the new copy active but leaves the pre-duplicate selection (the
originals) in `selectedLayerIds` — so the originals were dragged along with the
new copy.

This regressed two pre-existing specs:
- `option-drag-duplicate.spec.ts:104` — "repeated option-drag does not displace the original layer"
- `delete-inverted-selection.spec.ts:123` — the shifted geometry made the delete probe read the wrong pixels

**Fix** (`handleMoveDown`): skip sibling capture when the drag duplicated the
layer. The new copy moves alone, restoring the pre-`#707` behavior. Multi-layer
move for a genuine multi-selection is unchanged.

### Test bugs in the new `autofix-706-707-708.spec.ts`

- **#707 test**: `createDocument` seeds more than one raster, so `addLayer` +
  reading positions back as `raster[0]`/`raster[1]` picked up an unrelated
  middle layer that was never selected or moved. Now reads the two
  seeded/selected layers by id.
- **#708 test**: a guide is only created when the pointer-down lands on the
  ruler band (`screenY < RULER_SIZE`). The test clicked `docToScreen(130, 5)`
  — a point inside the canvas, below the ruler — so no guide appeared. Now
  clicks the top ruler strip at the screen-x that maps to doc-x≈130.

## Validation

- **Full e2e suite against this branch (both browsers): 1615 passed / 0 failed
  / 1 flaky / 52 skipped (45.1m, exit 0).** The 1 flaky is the known
  environmental `history.spec.ts:134` redo (attempt-1 SwiftShader
  frame-starvation, net-passed on retry) — pre-existing and unrelated.
- All 8 previously-failing tests (4 specs × chromium + firefox) now pass.
- `move-handlers` unit tests 13/13; full unit suite 1734/1734; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
