### PR TITLE
fix(undo): drop leftover float before restoring history snapshot (#706)

### DIFF
--- a/e2e/undo-flip-with-selection.spec.ts
+++ b/e2e/undo-flip-with-selection.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from './fixtures';
+import type { Page } from './fixtures';
+import {
+  waitForStore,
+  createDocument,
+  getEditorState,
+  undo,
+  selectTool,
+  drawRect,
+} from './helpers';
+
+/**
+ * Regression test for #706: after Select All → Move tool → Flip Horizontal
+ * → Undo, the flipped layer's content stayed pinned at (0, 0) rather than
+ * returning to its original position.
+ *
+ * Root cause: `applyGpuTransform` calls `selectLayerAlpha` after dropping
+ * the transform's float; `selectLayerAlpha` schedules a prefloat that
+ * synchronously (setTimeout 0) re-creates a float on the same layer. Undo
+ * did not drop that leftover float, so the engine's `update_layer` kept
+ * preserving the float's expanded (0, 0, doc.w, doc.h) descriptor when
+ * syncLayers pushed the restored (smaller) descriptor after
+ * `restoreFromGpuSnapshot` shrank the texture back.
+ */
+test.describe('Undo after Select All → Flip', () => {
+  test.beforeEach(async ({ page, browserName, isMobile }) => {
+    test.skip(browserName !== 'chromium', 'requires Chromium WebGL (SwiftShader)');
+    test.skip(isMobile, 'options bar transform controls live in a sidebar');
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 400, true);
+    await page.waitForTimeout(300);
+  });
+
+  async function readLayerDims(page: Page, layerId: string) {
+    return page.evaluate((lid) => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: {
+            layers: Array<{ id: string; x: number; y: number; width?: number; height?: number }>;
+          };
+        };
+      };
+      const l = store.getState().document.layers.find((ll) => ll.id === lid);
+      if (!l) return null;
+      return { x: l.x, y: l.y, width: l.width ?? 0, height: l.height ?? 0 };
+    }, layerId);
+  }
+
+  async function readLayerContentCount(page: Page, layerId: string) {
+    return page.evaluate(async (lid) => {
+      const readFn = (window as unknown as Record<string, unknown>).__readLayerPixels as
+        | ((id?: string) => Promise<{ width: number; height: number; pixels: number[] } | null>)
+        | undefined;
+      if (!readFn) return null;
+      const r = await readFn(lid);
+      if (!r || r.width === 0) return null;
+      let opaque = 0;
+      for (let i = 3; i < r.pixels.length; i += 4) {
+        if ((r.pixels[i] ?? 0) > 10) opaque++;
+      }
+      return { texWidth: r.width, texHeight: r.height, opaque };
+    }, layerId);
+  }
+
+  // Find the bounding box of red pixels in the composited canvas.
+  // We use this to detect where the layer's content actually ends up on
+  // screen — the store's descriptor can look fine while the engine's
+  // layer_desc keeps stale expanded coordinates, and only the composited
+  // output tells the truth.
+  async function readCompositedRedBounds(page: Page) {
+    return page.evaluate(async () => {
+      const fn = (window as unknown as Record<string, unknown>).__readCompositedPixels as
+        | (() => Promise<{ width: number; height: number; pixels: number[] }>)
+        | undefined;
+      if (!fn) return null;
+      const r = await fn();
+      let minX = r.width, minY = r.height, maxX = -1, maxY = -1, count = 0;
+      for (let y = 0; y < r.height; y++) {
+        for (let x = 0; x < r.width; x++) {
+          const i = (y * r.width + x) * 4;
+          const rr = r.pixels[i] ?? 0;
+          const gg = r.pixels[i + 1] ?? 0;
+          const bb = r.pixels[i + 2] ?? 0;
+          if (rr > 100 && gg < 60 && bb < 60) {
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+            count++;
+          }
+        }
+      }
+      return { canvasW: r.width, canvasH: r.height, minX, minY, maxX, maxY, count };
+    });
+  }
+
+  test('flip via TransformControls then undo restores layer position', async ({ page }) => {
+    const state = await getEditorState(page);
+    const layerId = state.document.activeLayerId;
+
+    // Draw a small opaque rectangle offset from the origin — this is the
+    // content whose position we expect undo to restore.
+    await drawRect(page, 100, 100, 80, 40, { r: 200, g: 0, b: 0 });
+    await page.waitForTimeout(300);
+
+    const beforeDims = await readLayerDims(page, layerId);
+    const beforeContent = await readLayerContentCount(page, layerId);
+    const beforeRedBounds = await readCompositedRedBounds(page);
+    expect(beforeDims).not.toBeNull();
+    expect(beforeContent).not.toBeNull();
+    expect(beforeContent!.opaque).toBeGreaterThan(0);
+    // Layer should be cropped to content (not doc-sized) or at least
+    // positioned somewhere other than the doc origin.
+    expect(beforeDims!.x).toBeGreaterThan(0);
+    expect(beforeDims!.y).toBeGreaterThan(0);
+    expect(beforeRedBounds).not.toBeNull();
+    expect(beforeRedBounds!.count).toBeGreaterThan(0);
+
+    // Select All so a Flip via the transform controls floats + expands the
+    // layer to the whole doc — this is the code path that leaves a stale
+    // prefloat behind.
+    await page.keyboard.press('Control+a');
+    await page.waitForTimeout(200);
+
+    // Move tool activates the TransformControls flip buttons.
+    await selectTool(page, 'move');
+    await page.waitForTimeout(200);
+
+    // Click the "Flip Horizontal" button from TransformControls (this uses
+    // applyGpuTransform, not the Image-menu flipActiveLayer path).
+    await page.locator('button[aria-label="Flip Horizontal"]').click();
+    // Wait long enough for schedulePrefloat's setTimeout(0) to fire.
+    await page.waitForTimeout(400);
+
+    // Undo the flip.
+    await undo(page);
+    await page.waitForTimeout(400);
+
+    const afterDims = await readLayerDims(page, layerId);
+    const afterContent = await readLayerContentCount(page, layerId);
+    const afterRedBounds = await readCompositedRedBounds(page);
+    expect(afterDims).not.toBeNull();
+    expect(afterContent).not.toBeNull();
+    expect(afterRedBounds).not.toBeNull();
+
+    // Layer position and dimensions must be restored to the pre-flip state.
+    // Before the fix, x/y jumped to (0, 0) and width/height jumped to the
+    // full document size because a leftover float pinned the engine's
+    // descriptor at the expanded values.
+    expect(afterDims!.x).toBe(beforeDims!.x);
+    expect(afterDims!.y).toBe(beforeDims!.y);
+    expect(afterDims!.width).toBe(beforeDims!.width);
+    expect(afterDims!.height).toBe(beforeDims!.height);
+
+    // And the texture on the GPU should be the pre-flip size, not doc-sized.
+    expect(afterContent!.texWidth).toBe(beforeContent!.texWidth);
+    expect(afterContent!.texHeight).toBe(beforeContent!.texHeight);
+    // Opaque pixel count is preserved within a tight tolerance.
+    expect(afterContent!.opaque).toBeGreaterThan(beforeContent!.opaque * 0.9);
+    expect(afterContent!.opaque).toBeLessThan(beforeContent!.opaque * 1.1);
+
+    // Composited output — the user-visible truth. Before the fix, the
+    // stroke rendered at doc (0, 0); with the fix, it stays at its
+    // original doc (100, 99) position. Compare bounding boxes in canvas
+    // pixels — they should match within 1px of the pre-flip bounds.
+    expect(afterRedBounds!.count).toBeGreaterThan(0);
+    expect(Math.abs(afterRedBounds!.minX - beforeRedBounds!.minX)).toBeLessThanOrEqual(1);
+    expect(Math.abs(afterRedBounds!.minY - beforeRedBounds!.minY)).toBeLessThanOrEqual(1);
+    expect(Math.abs(afterRedBounds!.maxX - beforeRedBounds!.maxX)).toBeLessThanOrEqual(1);
+    expect(Math.abs(afterRedBounds!.maxY - beforeRedBounds!.maxY)).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/app/store/history-slice.ts
+++ b/src/app/store/history-slice.ts
@@ -4,10 +4,12 @@ import { getEngine } from '../../engine-wasm/engine-state';
 import {
   endStroke, getLayerTextureDimensions, uploadLayerPixels,
   snapshotLayerGpu, restoreFromGpuSnapshot, releaseGpuSnapshot,
+  hasFloat, dropFloat,
 } from '../../engine-wasm/wasm-bridge';
 import { resetTrackedState, flushLayerSync, syncLayers } from '../../engine-wasm/engine-sync';
 import { pixelDataManager } from '../../engine/pixel-data-manager';
 import { finalizePendingStrokeGlobal } from '../interactions/pending-stroke';
+import { cancelPrefloat } from '../interactions/prefloat';
 
 export interface HistorySlice {
   undoStack: HistorySnapshot[];
@@ -150,6 +152,16 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
 
   undo: () => {
     finalizePendingStrokeGlobal();
+    // Drop any active float (and cancel a scheduled prefloat) before
+    // restoring. A leftover float leaves `float_layer_id` set on the engine,
+    // which makes `update_layer` preserve the float's expanded x/y/w/h in the
+    // layer descriptor. After a restore that shrinks the layer texture back to
+    // its pre-float dimensions, the mismatched descriptor renders the layer
+    // stretched at (0, 0, doc.w, doc.h) instead of at its original position
+    // (issue #706).
+    cancelPrefloat();
+    const eng0 = getEngine();
+    if (eng0 && hasFloat(eng0)) dropFloat(eng0);
     flushPendingSnapshots();
 
     const state = get();
@@ -218,6 +230,11 @@ export const createHistorySlice: SliceCreator<HistorySlice> = (set, get) => ({
   },
 
   redo: () => {
+    // Same reasoning as undo: a stale float would preserve expanded dims in
+    // the engine's layer descriptor and misplace the restored texture.
+    cancelPrefloat();
+    const eng0 = getEngine();
+    if (eng0 && hasFloat(eng0)) dropFloat(eng0);
     flushPendingSnapshots();
     const state = get();
     if (state.redoStack.length === 0) return;


### PR DESCRIPTION
Fixes the "stroke jumps to 0,0" half of #706.

## Root cause

`applyGpuTransform` (the Flip / Rotate buttons in the Move-tool
`TransformControls`) commits its transform and then calls
`selectLayerAlpha`. `selectLayerAlpha` schedules a prefloat via
`setTimeout(0)`; the timer fires and `floatSelection` re-creates a float
on the same layer — setting `float_layer_id` on the engine — with no
user-visible cue that it happened.

When the user then presses Ctrl+Z, `restoreFromGpuSnapshot` shrinks the
layer texture back to the pre-transform dimensions and `syncLayers`
pushes the restored descriptor. But `update_layer` sees
`float_layer_id == desc.id` and (correctly, for the live-transform case
it was written for) **preserves** the float's expanded
`(0, 0, doc.w, doc.h)` position and size. The result: the composited
output paints the layer stretched-and-pinned at `(0, 0)` while the JS
store looks perfectly correct.

Repro path:
1. Draw something offset from the origin.
2. Select All (`⌘A`).
3. Switch to the Move tool (`v`).
4. Click Flip Horizontal in the options bar.
5. Undo.
6. The stroke jumps to `(0, 0)`.

## Fix

Cancel any pending prefloat and drop the active float at the top of
`undo` and `redo`, before `restoreFromGpuSnapshot` runs. That clears
`float_layer_id`, so `update_layer` fully replaces the descriptor with
the restored coordinates.

## Test

`e2e/undo-flip-with-selection.spec.ts` drives the full UI path
(drawRect → `⌘A` → Move tool → click Flip Horizontal → Undo) and
verifies the **composited** output, not just the store — the store
looked correct in both the pass and fail cases; only the compositor
exposed the mismatch. The bounding box of the red pixels on the
composite is compared against the pre-flip bounds within 1px. Without
the fix the bounds shift by ~100px in each dimension.

Unit tests (176 in `src/app/store/**`), the full transform-stray-pixels
suite (13 tests), the paths suite, and the transform suite (19 tests)
all pass with the change.

The second half of #706 ("changing paths isn't recorded in undo") was
already addressed in #709 per the earlier issue comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAVR8ucvqSUtcwGdeTJpnk)_