### PR TITLE
test(composition-painting): close effects drawer before clone stamp

### DIFF
--- a/e2e/composition-painting.spec.ts
+++ b/e2e/composition-painting.spec.ts
@@ -472,6 +472,11 @@ test.describe('Composition 1: Painted Landscape', () => {
     // =====================================================================
     // PHASE 9: CLONE STAMP — Duplicate a mountain feature
     // =====================================================================
+    // The effects drawer opened while building layers earlier now anchors to
+    // the Layers panel (PR #719) and floats over the mid-canvas clone target,
+    // so its blend-mode <select> would swallow the stamp stroke. Close it so
+    // the stroke reaches the canvas.
+    await closeEffectsPanel(page);
     await page.keyboard.press('s');
     expect(await getActiveTool(page)).toBe('stamp');
 


### PR DESCRIPTION
## What

The nightly e2e run flagged `composition-painting.spec.ts` ("Composition 1: Painted Landscape") failing on **both chromium and firefox** at Phase 9 (Clone Stamp):

```
expect(pixelDiff(beforeStamp, afterStamp)).toBeGreaterThan(10)
Expected: > 10
Received:   0
```

The clone stamp painted nothing.

## Root cause

Bisected against the aug14 nightly baseline: the test **passes at `691fd80e`** and **fails at `03a6eb8c`**, with only **#719** as a product change in range.

The test opens the layer effects drawer as a side effect of its earlier layer-panel interactions (it's `false` at test start, `true` by Phase 9) and leaves it open. Instrumenting the failing run showed the clone-stamp **target** landing on a `<select class="blendModeSelect">` — the drawer's blend-mode dropdown — floating **over the canvas**:

| commit | drawer rect | target (582,432) | result |
|---|---|---|---|
| `691fd80e` (pass) | l:504, **t:68**, y:68–317 | below drawer → hits CANVAS | pixelDiff 1722 ✓ |
| `03a6eb8c` (fail) | l:504, **t:384**, y:384–633 | inside drawer → hits `<select>` | pixelDiff 0 ✗ |

#719 (#718) intentionally re-anchored the effects drawer from the top of the sidebar area to the **top edge of the Layers panel** (`--effects-drawer-top`), which is an improvement with its own passing coverage in `autofix-717-718.spec.ts`. That change moved the drawer's top from y≈68 down to y≈384 — directly over this test's mid-canvas clone target — so the stroke's pointer events were swallowed by the drawer instead of reaching the canvas. Being pure DOM hit-testing, it reproduced identically on chromium and firefox.

This is an isolated spatial collision in one test — no other test across the suite was affected — so the fix belongs in the test (per `CLAUDE.md`: *"When we make UI changes, we update the test for the new UI."*), not in #719.

## Fix

Close the effects drawer at the start of Phase 9 so the clone stamp operates on an unobstructed canvas. `closeEffectsPanel` is a no-op when the drawer is already closed.

## Verification

- Full `composition-painting.spec.ts:267` (all 18 phases) passes on **chromium + firefox** with the fix (`2 passed`).
- Confirmed the failure reproduces without the fix and disappears with it, in an isolated worktree (main nightly suite undisturbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)