### PR TITLE
perf(nightly): trim clipboard/fill/navigator round-trips + fix bare-click move history

### DIFF
--- a/e2e/autofix-721-722-723-724.spec.ts
+++ b/e2e/autofix-721-722-723-724.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, type Page } from './fixtures';
+import {
+  waitForStore,
+  createDocument,
+  selectTool,
+  setForegroundColor,
+  drawRect,
+  getPixelAt,
+  getEditorState,
+  docToScreen,
+} from './helpers';
+
+// Coverage for the nightly autofix batch:
+// - #721 (bare click on the move tool must not record a history entry)
+// - #722 (fill tool no longer forces a 134 MB round-trip on tool-down)
+// - #723 (composite-dirty tracks Channels-panel eye-icon toggles)
+// - #724 (paste identity check no longer reads the clipboard texture back)
+
+test.describe('#721 — bare click on move tool records no history', () => {
+  test('click without any drag adds zero entries to the undo stack', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'move tool tests use desktop pointer events');
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 300, false);
+
+    // A single history entry is already on the stack from createDocument.
+    const stackBefore = (await getEditorState(page)).undoStackLength;
+
+    await selectTool(page, 'move');
+
+    // Click and release at the same screen position — zero drag delta.
+    const center = await docToScreen(page, 200, 150);
+    await page.mouse.move(center.x, center.y);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForTimeout(80);
+
+    const stackAfter = (await getEditorState(page)).undoStackLength;
+    expect(stackAfter).toBe(stackBefore);
+  });
+
+  test('an actual drag records exactly one "Move" entry', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'move tool tests use desktop pointer events');
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 300, false);
+
+    // Give the layer some content so the move actually shifts something visible.
+    await drawRect(page, 100, 80, 60, 40, { r: 0, g: 200, b: 255 });
+    await page.waitForTimeout(80);
+
+    const stackBefore = (await getEditorState(page)).undoStackLength;
+
+    await selectTool(page, 'move');
+    const start = await docToScreen(page, 130, 100);
+    const end = await docToScreen(page, 170, 130);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(80);
+
+    const stackAfter = (await getEditorState(page)).undoStackLength;
+    expect(stackAfter).toBe(stackBefore + 1);
+  });
+});
+
+test.describe('#722 — bucket fill on a moved layer still lands at the click point', () => {
+  test('non-contiguous fill on a layer offset by (30, 20) fills the clicked color', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'fill tool tests use desktop pointer events');
+    await page.goto('/');
+    await waitForStore(page);
+    await createDocument(page, 400, 300, true);
+
+    // Paint a red patch, then move the layer so layer.x/y become non-zero.
+    // The regression scenario is a layer whose stored bounds don't line up
+    // with (0, 0) — before the fix, `handleToolDown` forced an
+    // `expandLayerForEditing` that reset those bounds; after the fix, the
+    // fill handler owns its own doc-space coordinate math.
+    await drawRect(page, 40, 40, 80, 60, { r: 220, g: 30, b: 30 });
+    await page.waitForTimeout(80);
+
+    // Nudge the layer with the move tool to force a non-zero layer offset.
+    await selectTool(page, 'move');
+    const start = await docToScreen(page, 80, 70);
+    const end = await docToScreen(page, 110, 100);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(120);
+
+    // Sanity: the active layer should now sit at a non-zero offset.
+    const st = await getEditorState(page);
+    const activeId = st.document.activeLayerId;
+    const active = st.document.layers.find((l) => l.id === activeId)!;
+    expect(active.x !== 0 || active.y !== 0).toBe(true);
+
+    // Fill by color, non-contiguous (the #722 fast path that used to be
+    // silently pre-empted by the 134 MB expandLayerForEditing round-trip).
+    await selectTool(page, 'fill');
+    await page.evaluate(() => {
+      const store = (window as unknown as { __toolSettingsStore: {
+        getState: () => { setFillSetting: (k: string, v: number | boolean) => void };
+      } }).__toolSettingsStore;
+      store.getState().setFillSetting('contiguous', false);
+      store.getState().setFillSetting('tolerance', 10);
+    });
+    await setForegroundColor(page, 20, 220, 60);
+
+    // Click one of the red pixels — after the move, doc-space (80, 70) is
+    // where the red patch's original center now lives.
+    const fillClick = await docToScreen(page, 80, 70);
+    await page.mouse.move(fillClick.x, fillClick.y);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+
+    // The click-target pixel must now be the fill color, not the pre-fill red.
+    const filled = await getPixelAt(page, 80, 70);
+    expect(filled.g).toBeGreaterThan(180);
+    expect(filled.r).toBeLessThan(60);
+  });
+});
+
+// #723 (composite-dirty subscribes to UI-store fields) and #724 (paste
+// identity no longer reads the clipboard texture back) are unit-tested at
+// their layer — see:
+//  - src/panels/NavigatorPanel/composite-dirty.test.ts
+//  - src/app/store/clipboard-image-match.test.ts
+// Both fixes are pure JS-layer behaviour a Playwright browser cannot
+// observe without an instrumented build (the point of the fix is the
+// absence of a call), so the unit coverage carries the regression contract.

--- a/src/app/interactions/move-handlers.test.ts
+++ b/src/app/interactions/move-handlers.test.ts
@@ -501,3 +501,92 @@ describe('handleMoveDown / handleMoveMove — multi-layer move (issue #707)', ()
     expect(state.gesture.siblings).toEqual([]);
   });
 });
+
+describe('handleMoveDown/Up — bare click on the move tool must not record history (#721)', () => {
+  const raster: RasterLayer = {
+    id: 'raster-1',
+    name: 'Raster',
+    type: 'raster',
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blendMode: 'normal',
+    x: 0,
+    y: 0,
+    width: DOC_W,
+    height: DOC_H,
+    clipToBelow: false,
+    effects: DEFAULT_EFFECTS,
+    mask: null,
+  };
+
+  const makeContext = (activeLayer: Layer): InteractionContext => {
+    const canvasPos: Point = { x: 10, y: 10 };
+    return {
+      canvasPos,
+      layerPos: canvasPos,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      activeLayer,
+      activeLayerId: activeLayer.id,
+      clientX: 10,
+      clientY: 10,
+      stateRef: { current: { drawing: false, tool: 'move' } as InteractionState },
+      floatingSelectionRef: { current: null },
+      persistentTransformRef: { current: null },
+      stampSourceRef: { current: null },
+      stampOffsetRef: { current: null },
+      lastPaintPointRef: { current: null as LastPaintPoint | null },
+    };
+  };
+
+  beforeEach(() => {
+    editorState.document.layers = [raster];
+    editorState.document.activeLayerId = raster.id;
+    editorState.document.selectedLayerIds = [raster.id];
+    editorState.selection = { active: false, mask: null, bounds: null, maskWidth: 0, maskHeight: 0 };
+    editorState.pushHistory.mockClear();
+    editorState.updateLayerPosition.mockClear();
+    uiState.maskMode = 'off';
+    uiState.showGrid = false;
+    uiState.snapToGrid = false;
+    uiState.snapToLayers = false;
+    vi.mocked(bridge.cropLayerToContent).mockReset();
+    vi.mocked(bridge.cropLayerToContent).mockImplementation((_engine: unknown, id: string) => {
+      const layer = editorState.document.layers.find((l) => (l as Layer).id === id) as Layer | undefined;
+      if (!layer) return new Float64Array([0, 0, 0, 0]);
+      const w = layer.type === 'raster' ? (layer.width ?? 0) : 0;
+      const h = layer.type === 'raster' ? ((layer as { height?: number }).height ?? 0) : 0;
+      return new Float64Array([layer.x, layer.y, w, h]);
+    });
+  });
+
+  it('click without any pointer movement never calls pushHistory', () => {
+    const ctx = makeContext(raster);
+    const state = handleMoveDown(ctx);
+    // Pointer-up on the same coordinates — zero drag delta.
+    handleMoveUp(state, ctx.canvasPos, ctx.floatingSelectionRef, ctx.persistentTransformRef);
+
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+    expect(editorState.updateLayerPosition).not.toHaveBeenCalled();
+  });
+
+  it('history is pushed exactly once — on the first pointer-move with a non-zero delta', () => {
+    const ctx = makeContext(raster);
+    const state = handleMoveDown(ctx);
+    // A zero-delta move (pointer jitter, no meaningful movement) must not push.
+    handleMoveMove(state, ctx.canvasPos, ctx.floatingSelectionRef);
+    expect(editorState.pushHistory).not.toHaveBeenCalled();
+
+    // First real move — pushHistory fires now.
+    handleMoveMove(state, { x: ctx.canvasPos.x + 3, y: ctx.canvasPos.y }, ctx.floatingSelectionRef);
+    expect(editorState.pushHistory).toHaveBeenCalledTimes(1);
+    expect(editorState.pushHistory).toHaveBeenCalledWith('Move');
+
+    // Subsequent moves do not push again — one history entry per drag.
+    handleMoveMove(state, { x: ctx.canvasPos.x + 7, y: ctx.canvasPos.y + 1 }, ctx.floatingSelectionRef);
+    handleMoveUp(state, { x: ctx.canvasPos.x + 7, y: ctx.canvasPos.y + 1 }, ctx.floatingSelectionRef, ctx.persistentTransformRef);
+    expect(editorState.pushHistory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/interactions/move-handlers.ts
+++ b/src/app/interactions/move-handlers.ts
@@ -142,6 +142,16 @@ export function flushQuickMaskDrag(): void {
   }
 }
 
+/**
+ * Whole-layer moves (no selection, no option-drag) defer their 'Move'
+ * history entry to the first pointer-move that actually shifts the layer
+ * — a bare click on the move tool used to record a no-op Move entry that
+ * later corrupted undo state on longer histories (#721). This holds the
+ * label between down and the first move that consumes it; the flag is
+ * always cleared in handleMoveUp.
+ */
+let pendingWholeLayerMoveLabel: string | null = null;
+
 export function handleMoveDown(ctx: InteractionContext): InteractionState {
   const editorState = useEditorStore.getState();
   const sel = editorState.selection;
@@ -159,8 +169,15 @@ export function handleMoveDown(ctx: InteractionContext): InteractionState {
   const prebuilt = !altKey && sel.active && sel.mask
     ? consumePrefloat(activeLayerId, sel.mask)
     : null;
+  const isWholeLayerMove = !prebuilt && !altKey && !(sel.active && sel.mask) && !isQuickMaskMode;
+  pendingWholeLayerMoveLabel = null;
   if (prebuilt) {
     editorState.pushPrebuiltSnapshot(prebuilt.snapshot);
+  } else if (isWholeLayerMove) {
+    // Defer: only push history if the pointer actually moves. Bare
+    // click-releases on the move tool must not record a Move entry (#721).
+    cancelPrefloat();
+    pendingWholeLayerMoveLabel = 'Move';
   } else {
     cancelPrefloat();
     editorState.pushHistory(altKey && !(sel.active && sel.mask) ? 'Duplicate Layer' : 'Move');
@@ -486,7 +503,14 @@ export function handleMoveMove(
       useUIStore.getState().setTransform(createTransformState(newBounds));
     }
   } else {
-    // No selection: just move the layer position
+    // No selection: just move the layer position. Skip entirely if the
+    // pointer hasn't shifted yet — that keeps a click-and-release from
+    // pushing history / mutating the layer (#721).
+    if (dragDx === 0 && dragDy === 0) return;
+    if (pendingWholeLayerMoveLabel !== null) {
+      useEditorStore.getState().pushHistory(pendingWholeLayerMoveLabel);
+      pendingWholeLayerMoveLabel = null;
+    }
     let newX = state.layerStartX + dragDx;
     let newY = state.layerStartY + dragDy;
     const uiState = useUIStore.getState();
@@ -545,6 +569,9 @@ export function handleMoveUp(
   _persistentTransformRef: MutableRefObject<PersistentTransform | null>,
 ): void {
   useUIStore.getState().clearSnapLines();
+  // Whole-layer down never followed by a move → no history entry, no state
+  // change. Clear the pending label so a subsequent gesture starts fresh.
+  pendingWholeLayerMoveLabel = null;
 
   // Flush any pending quick-mask translate so the final drop position is
   // materialized on the GPU before we clear the drag target.

--- a/src/app/store/clipboard-image-match.test.ts
+++ b/src/app/store/clipboard-image-match.test.ts
@@ -1,81 +1,59 @@
-import { describe, it, expect } from 'vitest';
-import { pixelsLikelySame } from './clipboard-image-match';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  pngBytesMatch,
+  setLastCopyPngBytes,
+  getLastCopyPngBytes,
+} from './clipboard-image-match';
 
-/** Build a solid-color RGBA buffer of `count` pixels. */
-function solid(count: number, r: number, g: number, b: number, a: number): Uint8ClampedArray {
-  const buf = new Uint8ClampedArray(count * 4);
-  for (let i = 0; i < count; i++) {
-    buf[i * 4] = r;
-    buf[i * 4 + 1] = g;
-    buf[i * 4 + 2] = b;
-    buf[i * 4 + 3] = a;
-  }
-  return buf;
-}
-
-describe('pixelsLikelySame', () => {
-  it('returns true for identical opaque buffers', () => {
-    const a = solid(1000, 200, 100, 50, 255);
-    const b = solid(1000, 200, 100, 50, 255);
-    expect(pixelsLikelySame(a, b)).toBe(true);
+describe('pngBytesMatch', () => {
+  it('returns true for byte-identical buffers', () => {
+    const a = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
+    const b = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
+    expect(pngBytesMatch(a, b)).toBe(true);
   });
 
-  it('returns false for buffers of different length', () => {
-    expect(pixelsLikelySame(solid(100, 0, 0, 0, 255), solid(101, 0, 0, 0, 255))).toBe(false);
+  it('returns true for the same buffer instance', () => {
+    const a = new Uint8Array([1, 2, 3]);
+    expect(pngBytesMatch(a, a)).toBe(true);
   });
 
-  it('returns false for empty buffers', () => {
-    expect(pixelsLikelySame(solid(0, 0, 0, 0, 0), solid(0, 0, 0, 0, 0))).toBe(false);
+  it('returns false for different-length buffers', () => {
+    expect(pngBytesMatch(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3, 4]))).toBe(false);
   });
 
-  it('returns false when opaque colors clearly differ', () => {
-    const red = solid(1000, 255, 0, 0, 255);
-    const blue = solid(1000, 0, 0, 255, 255);
-    expect(pixelsLikelySame(red, blue)).toBe(false);
+  it('returns false for empty buffers (no bytes means nothing to trust)', () => {
+    expect(pngBytesMatch(new Uint8Array(), new Uint8Array())).toBe(false);
   });
 
-  it('tolerates small RGB noise on opaque pixels (round-trip rounding)', () => {
-    const a = solid(1000, 128, 128, 128, 255);
-    const b = solid(1000, 128, 128, 128, 255);
-    // Nudge every channel by <= the 6-unit tolerance.
-    for (let i = 0; i < 1000; i++) {
-      b[i * 4] = 132;
-      b[i * 4 + 1] = 123;
-      b[i * 4 + 2] = 130;
-    }
-    expect(pixelsLikelySame(a, b)).toBe(true);
+  it('returns false when a single byte differs', () => {
+    const a = new Uint8Array([1, 2, 3, 4, 5]);
+    const b = new Uint8Array([1, 2, 3, 4, 6]);
+    expect(pngBytesMatch(a, b)).toBe(false);
+  });
+});
+
+describe('lastCopyPngBytes storage (#724)', () => {
+  beforeEach(() => {
+    setLastCopyPngBytes(null);
   });
 
-  it('rejects RGB differences beyond tolerance on opaque pixels', () => {
-    const a = solid(1000, 100, 100, 100, 255);
-    const b = solid(1000, 120, 100, 100, 255); // +20 on red, well past tolerance
-    expect(pixelsLikelySame(a, b)).toBe(false);
+  it('starts null before any copy — tryPasteInternalCopy must decline in that case', () => {
+    expect(getLastCopyPngBytes()).toBeNull();
   });
 
-  it('returns false when the alpha shape differs', () => {
-    const opaque = solid(1000, 50, 50, 50, 255);
-    const transparent = solid(1000, 50, 50, 50, 0);
-    expect(pixelsLikelySame(opaque, transparent)).toBe(false);
+  it('round-trips a byte array through set/get', () => {
+    const bytes = new Uint8Array([137, 80, 78, 71, 0, 42, 99]);
+    setLastCopyPngBytes(bytes);
+    expect(getLastCopyPngBytes()).toBe(bytes);
   });
 
-  it('ignores RGB under partial/low alpha (premultiplied round-trip is unreliable there)', () => {
-    // Same alpha shape (semi-transparent), wildly different RGB — should still
-    // match because RGB is only compared where both alphas are near-opaque.
-    const a = solid(1000, 10, 20, 30, 100);
-    const b = solid(1000, 200, 180, 160, 100);
-    expect(pixelsLikelySame(a, b)).toBe(true);
-  });
-
-  it('detects a differing region within otherwise-matching content', () => {
-    const a = solid(1000, 0, 0, 0, 255);
-    const b = solid(1000, 0, 0, 0, 255);
-    // Flip a large fraction of pixels to a very different color — well past the
-    // 2% mismatch threshold.
-    for (let i = 0; i < 500; i++) {
-      b[i * 4] = 255;
-      b[i * 4 + 1] = 255;
-      b[i * 4 + 2] = 255;
-    }
-    expect(pixelsLikelySame(a, b)).toBe(false);
+  it('a second copy replaces the stored bytes (old paste-back becomes external)', () => {
+    const first = new Uint8Array([1, 2, 3]);
+    const second = new Uint8Array([9, 8, 7, 6]);
+    setLastCopyPngBytes(first);
+    setLastCopyPngBytes(second);
+    expect(getLastCopyPngBytes()).toBe(second);
+    expect(pngBytesMatch(getLastCopyPngBytes()!, first)).toBe(false);
+    expect(pngBytesMatch(getLastCopyPngBytes()!, second)).toBe(true);
   });
 });

--- a/src/app/store/clipboard-image-match.ts
+++ b/src/app/store/clipboard-image-match.ts
@@ -1,73 +1,37 @@
 /**
  * Helpers for deciding whether an image pasted from the system clipboard is a
  * paste-back of content that was copied inside the app. Kept free of engine /
- * store imports so the pixel-matching logic stays pure and unit-testable.
+ * store imports so the matching logic stays pure and unit-testable.
+ *
+ * The decision is made by comparing the incoming PNG blob's bytes against the
+ * bytes the app last handed to `navigator.clipboard.write`. This avoids
+ * reading the clipboard texture back from the GPU on every paste (#724) —
+ * the OS clipboard delivers whatever bytes we wrote, so identical bytes are
+ * proof it is still our own copy.
  */
 
-/** Decode an image blob to straight (non-premultiplied) RGBA bytes. */
-export async function decodeBlobToRgba(
-  blob: Blob,
-): Promise<{ data: Uint8ClampedArray; width: number; height: number } | null> {
-  try {
-    // No color-space conversion / premultiplication so the decoded bytes match
-    // the raw GPU pixels the clipboard PNG was written from — otherwise a
-    // wide-gamut (Display-P3) round-trip could shift RGB past the match
-    // tolerance and drop a legitimate paste-back back to 0,0.
-    const bitmap = await createImageBitmap(blob, {
-      colorSpaceConversion: 'none',
-      premultiplyAlpha: 'none',
-    });
-    const { width, height } = bitmap;
-    const canvas = new OffscreenCanvas(width, height);
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      bitmap.close();
-      return null;
-    }
-    ctx.drawImage(bitmap, 0, 0);
-    bitmap.close();
-    return { data: ctx.getImageData(0, 0, width, height).data, width, height };
-  } catch {
-    return null;
-  }
+let lastCopyPngBytes: Uint8Array | null = null;
+
+/** Record the PNG bytes the app just wrote to the system clipboard. */
+export function setLastCopyPngBytes(bytes: Uint8Array | null): void {
+  lastCopyPngBytes = bytes;
+}
+
+/** The PNG bytes of the last app-authored copy, or null before the first copy. */
+export function getLastCopyPngBytes(): Uint8Array | null {
+  return lastCopyPngBytes;
 }
 
 /**
- * Whether two equal-length RGBA buffers hold (near-)identical content.
- *
- * A system-clipboard round-trip can nudge RGB values under partial alpha
- * (canvas premultiplied-alpha decoding), so RGB is only compared where the
- * pixel is near-opaque and alpha is compared everywhere with a small
- * tolerance. Content is sampled — a few thousand pixels is plenty to tell our
- * own copy apart from an unrelated image of the same dimensions.
+ * Whether two PNG-blob byte streams are identical. The system clipboard
+ * preserves exact bytes across major platforms, so exact equality is a
+ * definitive "still our own copy" signal — no GPU readback required.
  */
-export function pixelsLikelySame(
-  a: Uint8Array | Uint8ClampedArray,
-  b: Uint8Array | Uint8ClampedArray,
-): boolean {
+export function pngBytesMatch(a: Uint8Array, b: Uint8Array): boolean {
+  if (a === b) return true;
   if (a.length !== b.length || a.length === 0) return false;
-  const pixelCount = a.length / 4;
-  const step = Math.max(1, Math.floor(pixelCount / 4096));
-  let checked = 0;
-  let mismatches = 0;
-  for (let p = 0; p < pixelCount; p += step) {
-    const i = p * 4;
-    checked++;
-    const aAlpha = a[i + 3]!;
-    const bAlpha = b[i + 3]!;
-    if (Math.abs(aAlpha - bAlpha) > 4) {
-      mismatches++;
-      continue;
-    }
-    if (aAlpha > 250 && bAlpha > 250) {
-      if (
-        Math.abs(a[i]! - b[i]!) > 6 ||
-        Math.abs(a[i + 1]! - b[i + 1]!) > 6 ||
-        Math.abs(a[i + 2]! - b[i + 2]!) > 6
-      ) {
-        mismatches++;
-      }
-    }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
   }
-  return checked > 0 && mismatches / checked < 0.02;
+  return true;
 }

--- a/src/app/store/clipboard-slice.ts
+++ b/src/app/store/clipboard-slice.ts
@@ -12,7 +12,7 @@ import {
   uploadClipboardPixels,
   compositeForExport,
 } from '../../engine-wasm/wasm-bridge';
-import { decodeBlobToRgba, pixelsLikelySame } from './clipboard-image-match';
+import { pngBytesMatch, setLastCopyPngBytes, getLastCopyPngBytes } from './clipboard-image-match';
 import type { ClipboardData, SliceCreator } from './types';
 
 function writeToSystemClipboard(width: number, height: number): void {
@@ -29,6 +29,12 @@ function writeToSystemClipboard(width: number, height: number): void {
     const imageData = new ImageData(clamped, width, height);
     ctx.putImageData(imageData, 0, 0);
     canvas.convertToBlob({ type: 'image/png' }).then((blob) => {
+      // Remember exactly what bytes we handed the OS. `tryPasteInternalCopy`
+      // compares an incoming clipboard blob against this to decide whether the
+      // OS still holds our copy, without any GPU readback (#724).
+      blob.arrayBuffer().then((buf) => {
+        setLastCopyPngBytes(new Uint8Array(buf));
+      }).catch(() => {});
       if (typeof navigator.clipboard?.write !== 'function') return;
       const item = new ClipboardItem({ 'image/png': blob });
       navigator.clipboard.write([item]).catch(() => {});
@@ -231,19 +237,18 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
     const engine = getEngine();
     if (!engine) return false;
 
-    const decoded = await decodeBlobToRgba(blob);
-    if (!decoded || decoded.width !== clip.width || decoded.height !== clip.height) return false;
-
-    // read_clipboard_pixels throws when the GPU clipboard texture is gone
-    // (e.g. after the engine was reset by File > New), which also guards
-    // paste() below from operating on a released clipboard.
-    let clipPixels: Uint8Array;
-    try {
-      clipPixels = readClipboardPixels(engine);
-    } catch {
-      return false;
-    }
-    if (!pixelsLikelySame(clipPixels, decoded.data)) return false;
+    // The OS clipboard delivers the exact PNG bytes we handed to
+    // `navigator.clipboard.write` when the app copied. Comparing those
+    // bytes directly avoids the ~35 MB GPU readback the old pixel-sample
+    // path used to force on every paste (#724). If the bytes don't
+    // match, the system clipboard has been replaced by another app —
+    // treat it as an external image.
+    const ownBytes = getLastCopyPngBytes();
+    if (!ownBytes) return false;
+    const incomingBuf = await blob.arrayBuffer().catch(() => null);
+    if (!incomingBuf) return false;
+    const incoming = new Uint8Array(incomingBuf);
+    if (!pngBytesMatch(ownBytes, incoming)) return false;
 
     get().paste();
     return true;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -244,14 +244,18 @@ export function useCanvasInteraction(
 
         // Only expand the active layer's pixel data for tools that actually
         // read/write it via JS. Tools like text, crop, path, eyedropper,
-        // and selection tools don't need pixel data and expanding would
-        // destructively change layer bounds before pushHistory captures
-        // them — causing undo to restore the wrong positions.
+        // fill, and selection tools don't need pixel data and expanding
+        // would destructively change layer bounds before pushHistory
+        // captures them — causing undo to restore the wrong positions.
         // Move is excluded: selection moves use the float system (GPU-only)
         // and non-selection moves call expandLayerForEditing in the handler.
+        // Fill is excluded: handleFillDown chooses between two GPU fast
+        // paths (empty layer, non-contiguous) and a JS path that sources
+        // its own pixels via readLayerPixelsForFill — none of them read
+        // from the painting canvas.
         // Quick Mask Mode paints on the quick mask buffer (not the layer), so
         // no pixel data expansion is needed — same as non-paint tools.
-        const needsPixelData = (isPaintTool && !isQuickMaskMode) || activeTool === 'fill';
+        const needsPixelData = isPaintTool && !isQuickMaskMode;
         if (needsPixelData) {
           const imageData = editorState.expandLayerForEditing(activeLayerId);
           expandedLayer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId)!;

--- a/src/panels/NavigatorPanel/composite-dirty.test.ts
+++ b/src/panels/NavigatorPanel/composite-dirty.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect } from 'vitest';
 import { getCompositeInputVersion } from './composite-dirty';
 import { useEditorStore } from '../../app/editor-store';
+import { useUIStore } from '../../app/ui-store';
+import { DEFAULT_ADJUSTMENTS } from '../../filters/image-adjustments';
 import { pixelDataManager } from '../../engine/pixel-data-manager';
 
 describe('composite-dirty (getCompositeInputVersion)', () => {
@@ -30,5 +32,45 @@ describe('composite-dirty (getCompositeInputVersion)', () => {
     useEditorStore.getState().setPan(-30, 200);
 
     expect(getCompositeInputVersion()).toBe(before);
+  });
+
+  it('bumps when a Channels-panel eye icon toggles channel visibility (#723)', () => {
+    // Prime the tracker so subscriptions are installed.
+    getCompositeInputVersion();
+    const before = getCompositeInputVersion();
+
+    useUIStore.getState().toggleChannelVisibility('r');
+    expect(getCompositeInputVersion()).toBeGreaterThan(before);
+
+    const afterOne = getCompositeInputVersion();
+    useUIStore.getState().toggleChannelVisibility('r');
+    expect(getCompositeInputVersion()).toBeGreaterThan(afterOne);
+  });
+
+  it('bumps when maskMode changes (layerMask overlay / quickMask) (#723)', () => {
+    getCompositeInputVersion();
+    // Reset to a known baseline mode.
+    useUIStore.setState({ maskMode: 'off' });
+    const before = getCompositeInputVersion();
+
+    useUIStore.setState({ maskMode: 'layerMask' });
+    expect(getCompositeInputVersion()).toBeGreaterThan(before);
+
+    const afterOne = getCompositeInputVersion();
+    useUIStore.setState({ maskMode: 'quickMask' });
+    expect(getCompositeInputVersion()).toBeGreaterThan(afterOne);
+  });
+
+  it('bumps when image adjustments change (#723)', () => {
+    getCompositeInputVersion();
+    useUIStore.getState().setAdjustments({ ...DEFAULT_ADJUSTMENTS });
+    const before = getCompositeInputVersion();
+
+    useUIStore.getState().setAdjustments({ ...DEFAULT_ADJUSTMENTS, exposure: 0.5 });
+    expect(getCompositeInputVersion()).toBeGreaterThan(before);
+
+    const afterOne = getCompositeInputVersion();
+    useUIStore.getState().setAdjustmentsEnabled(false);
+    expect(getCompositeInputVersion()).toBeGreaterThan(afterOne);
   });
 });

--- a/src/panels/NavigatorPanel/composite-dirty.ts
+++ b/src/panels/NavigatorPanel/composite-dirty.ts
@@ -10,20 +10,22 @@
  * every 200 ms forever, stalling the GPU pipeline five times per second on
  * a document that has not changed a single pixel.
  *
- * Two signals compose here:
+ * Signals composed here:
  *   - `pixelDataManager.version()` — bumps on every pixel edit.
  *   - `useEditorStore.getState().document` reference identity — a new
  *     reference on any layer property change (visibility, opacity, blend,
  *     effects, mask, order, position, add/remove), document resize,
  *     background, colorMode, and adjustment-node edits.
- *
- * UI-store fields that also affect the composite (image adjustments,
- * channel visibility, mask edit mode) are not explicitly tracked here —
- * they are always changed via a pointer gesture, so the scheduler's
- * `isInteracting` catch-up fires the next read regardless.
+ *   - `useUIStore` fields that reach the compositor: `channelVisibility`
+ *     (Channels panel eye icons), `maskMode` (layerMask overlay,
+ *     quickMask), and image `adjustments` / `adjustmentsEnabled`. These
+ *     can be changed via panel clicks that never go through the canvas
+ *     pointer path, so the scheduler's `isInteracting` catch-up does not
+ *     cover them (#723).
  */
 
 import { useEditorStore } from '../../app/editor-store';
+import { useUIStore } from '../../app/ui-store';
 import { pixelDataManager } from '../../engine/pixel-data-manager';
 
 let version = 0;
@@ -37,6 +39,26 @@ function ensureSubscribed(): void {
   useEditorStore.subscribe((state) => {
     if (state.document !== prevDoc) {
       prevDoc = state.document;
+      version++;
+    }
+  });
+
+  const uiInitial = useUIStore.getState();
+  let prevChannels = uiInitial.channelVisibility;
+  let prevMaskMode = uiInitial.maskMode;
+  let prevAdjustments = uiInitial.adjustments;
+  let prevAdjustmentsEnabled = uiInitial.adjustmentsEnabled;
+  useUIStore.subscribe((state) => {
+    if (
+      state.channelVisibility !== prevChannels ||
+      state.maskMode !== prevMaskMode ||
+      state.adjustments !== prevAdjustments ||
+      state.adjustmentsEnabled !== prevAdjustmentsEnabled
+    ) {
+      prevChannels = state.channelVisibility;
+      prevMaskMode = state.maskMode;
+      prevAdjustments = state.adjustments;
+      prevAdjustmentsEnabled = state.adjustmentsEnabled;
       version++;
     }
   });

--- a/src/panels/NavigatorPanel/navigator-scheduler.test.ts
+++ b/src/panels/NavigatorPanel/navigator-scheduler.test.ts
@@ -133,7 +133,7 @@ describe('createNavigatorScheduler', () => {
     sched.stop();
   });
 
-  it('catch-up read fires unconditionally even when content version is unchanged — #711', () => {
+  it('catch-up respects the content-version gate — does not read when nothing changed (#723)', () => {
     const read = vi.fn();
     let version = 0;
     const sched = createNavigatorScheduler({
@@ -146,18 +146,21 @@ describe('createNavigatorScheduler', () => {
     vi.advanceTimersByTime(200);
     expect(read).toHaveBeenCalledTimes(1);
 
-    // Interaction with no doc change (e.g. adjustment-slider drag on a
-    // UI-store field the content-version tracker doesn't observe).
+    // Interaction with no observable composite change (e.g. wheel burst
+    // that only pans the viewport). Content version unchanged.
     sched.setInteracting(true);
     vi.advanceTimersByTime(1000);
     expect(read).toHaveBeenCalledTimes(1);
 
     sched.setInteracting(false);
-    vi.advanceTimersByTime(0); // catch-up
-    expect(read).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(0); // catch-up runs through tick()
+    expect(read).toHaveBeenCalledTimes(1);
 
-    // Idle again: version still matches, so no polling.
-    vi.advanceTimersByTime(2000);
+    // If something did change during the gesture, the next catch-up fires.
+    version++;
+    sched.setInteracting(true);
+    sched.setInteracting(false);
+    vi.advanceTimersByTime(0);
     expect(read).toHaveBeenCalledTimes(2);
 
     sched.stop();

--- a/src/panels/NavigatorPanel/navigator-scheduler.ts
+++ b/src/panels/NavigatorPanel/navigator-scheduler.ts
@@ -74,15 +74,15 @@ export function createNavigatorScheduler(hooks: SchedulerHooks): NavigatorSchedu
     const wasInteracting = interacting;
     interacting = next;
     if (wasInteracting && !next) {
-      // Interaction just ended — schedule one catch-up read so the thumbnail
-      // reflects the final pixels without waiting up to intervalMs. This
-      // runs unconditionally (bypasses the content-version gate) because
-      // some interactions — image-adjustment sliders, mask-mode toggle —
-      // change composite inputs the version tracker does not observe.
+      // Interaction just ended — schedule one catch-up on the next
+      // event-loop turn so the thumbnail reflects the final pixels
+      // without waiting up to intervalMs. This runs through the gate so
+      // gestures that changed nothing (e.g. a wheel burst that only
+      // panned the viewport) don't re-read the composite (#723).
       if (catchUpId !== null) clearT(catchUpId);
       catchUpId = setT(() => {
         catchUpId = null;
-        if (!interacting) readAndRecord();
+        if (!interacting) tick();
       }, 0);
     }
   };


### PR DESCRIPTION
Nightly autofix batch — resolves #722, #723, #724, and a slice of #721.

## Summary

- **#722** (`perf(fill)`) — Drops `activeTool === 'fill'` from the
  `needsPixelData` guard in `handleToolDown`. `handleFillDown` sources
  its own pixels for the JS contiguous path (`readLayerPixelsForFill`)
  and needs none for the two GPU fast paths added in #667. The
  pre-tool `expandLayerForEditing` was forcing a 134 MB
  GPU→CPU→GPU round-trip per bucket-fill click on a 4K non-empty
  layer with **zero** downstream consumers — the round-trip silently
  defeated #667.
- **#723** (`perf(navigator)`) — `composite-dirty` now subscribes to
  the `useUIStore` fields that reach the compositor:
  `channelVisibility`, `maskMode`, `adjustments`, `adjustmentsEnabled`.
  The Navigator scheduler's post-gesture catch-up read is routed
  through `tick()` instead of `readAndRecord()` so a wheel burst that
  only pans the viewport no longer forces a readback when the content
  hasn't changed. Fixes the stale minimap after a Channels-panel
  eye-icon toggle and removes the per-burst-end readback under load.
- **#724** (`perf(clipboard)`) — `tryPasteInternalCopy` now compares
  the incoming clipboard blob's PNG bytes directly against the bytes
  the app last handed to `navigator.clipboard.write`. Replaces the
  ~35 MB `readClipboardPixels` GPU readback (used only to sample
  4096 pixels for an identity check) that ran on every Cmd+V.
- **#721** (partial) — Bare click on the move tool no longer records
  a no-op "Move" history entry. `handleMoveDown` defers `pushHistory`
  for whole-layer moves (no selection, no option-drag) to the first
  pointer-move that actually shifts the layer. This is the sub-bug
  driving the "undo eventually restores a distorted state" chain the
  issue describes. Other #721 sub-bugs (fit-layer distortion, marquee
  not reshaping, cmd+a giving a wrong selection after multi-undo,
  gradient letterboxing after undo-to-empty) need more repro work and
  stay open on the issue.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 154 files / 1746 tests pass (adds unit
  coverage in `composite-dirty.test.ts`, `navigator-scheduler.test.ts`,
  `clipboard-image-match.test.ts`, `move-handlers.test.ts`)
- [x] New e2e: `e2e/autofix-721-722-723-724.spec.ts` covers the two
  behavioural sub-fixes (bare-click move records nothing; fill on a
  moved layer lands at the click point)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfPQzw5un8vjkWqnD64Lgm)_