### PR TITLE
fix: revert two broken #726 optimizations (bucket fill + clipboard paste)

### DIFF
--- a/src/app/store/clipboard-image-match.test.ts
+++ b/src/app/store/clipboard-image-match.test.ts
@@ -1,59 +1,81 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  pngBytesMatch,
-  setLastCopyPngBytes,
-  getLastCopyPngBytes,
-} from './clipboard-image-match';
+import { describe, it, expect } from 'vitest';
+import { pixelsLikelySame } from './clipboard-image-match';
 
-describe('pngBytesMatch', () => {
-  it('returns true for byte-identical buffers', () => {
-    const a = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
-    const b = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3, 4]);
-    expect(pngBytesMatch(a, b)).toBe(true);
+/** Build a solid-color RGBA buffer of `count` pixels. */
+function solid(count: number, r: number, g: number, b: number, a: number): Uint8ClampedArray {
+  const buf = new Uint8ClampedArray(count * 4);
+  for (let i = 0; i < count; i++) {
+    buf[i * 4] = r;
+    buf[i * 4 + 1] = g;
+    buf[i * 4 + 2] = b;
+    buf[i * 4 + 3] = a;
+  }
+  return buf;
+}
+
+describe('pixelsLikelySame', () => {
+  it('returns true for identical opaque buffers', () => {
+    const a = solid(1000, 200, 100, 50, 255);
+    const b = solid(1000, 200, 100, 50, 255);
+    expect(pixelsLikelySame(a, b)).toBe(true);
   });
 
-  it('returns true for the same buffer instance', () => {
-    const a = new Uint8Array([1, 2, 3]);
-    expect(pngBytesMatch(a, a)).toBe(true);
+  it('returns false for buffers of different length', () => {
+    expect(pixelsLikelySame(solid(100, 0, 0, 0, 255), solid(101, 0, 0, 0, 255))).toBe(false);
   });
 
-  it('returns false for different-length buffers', () => {
-    expect(pngBytesMatch(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3, 4]))).toBe(false);
+  it('returns false for empty buffers', () => {
+    expect(pixelsLikelySame(solid(0, 0, 0, 0, 0), solid(0, 0, 0, 0, 0))).toBe(false);
   });
 
-  it('returns false for empty buffers (no bytes means nothing to trust)', () => {
-    expect(pngBytesMatch(new Uint8Array(), new Uint8Array())).toBe(false);
+  it('returns false when opaque colors clearly differ', () => {
+    const red = solid(1000, 255, 0, 0, 255);
+    const blue = solid(1000, 0, 0, 255, 255);
+    expect(pixelsLikelySame(red, blue)).toBe(false);
   });
 
-  it('returns false when a single byte differs', () => {
-    const a = new Uint8Array([1, 2, 3, 4, 5]);
-    const b = new Uint8Array([1, 2, 3, 4, 6]);
-    expect(pngBytesMatch(a, b)).toBe(false);
-  });
-});
-
-describe('lastCopyPngBytes storage (#724)', () => {
-  beforeEach(() => {
-    setLastCopyPngBytes(null);
-  });
-
-  it('starts null before any copy — tryPasteInternalCopy must decline in that case', () => {
-    expect(getLastCopyPngBytes()).toBeNull();
+  it('tolerates small RGB noise on opaque pixels (round-trip rounding)', () => {
+    const a = solid(1000, 128, 128, 128, 255);
+    const b = solid(1000, 128, 128, 128, 255);
+    // Nudge every channel by <= the 6-unit tolerance.
+    for (let i = 0; i < 1000; i++) {
+      b[i * 4] = 132;
+      b[i * 4 + 1] = 123;
+      b[i * 4 + 2] = 130;
+    }
+    expect(pixelsLikelySame(a, b)).toBe(true);
   });
 
-  it('round-trips a byte array through set/get', () => {
-    const bytes = new Uint8Array([137, 80, 78, 71, 0, 42, 99]);
-    setLastCopyPngBytes(bytes);
-    expect(getLastCopyPngBytes()).toBe(bytes);
+  it('rejects RGB differences beyond tolerance on opaque pixels', () => {
+    const a = solid(1000, 100, 100, 100, 255);
+    const b = solid(1000, 120, 100, 100, 255); // +20 on red, well past tolerance
+    expect(pixelsLikelySame(a, b)).toBe(false);
   });
 
-  it('a second copy replaces the stored bytes (old paste-back becomes external)', () => {
-    const first = new Uint8Array([1, 2, 3]);
-    const second = new Uint8Array([9, 8, 7, 6]);
-    setLastCopyPngBytes(first);
-    setLastCopyPngBytes(second);
-    expect(getLastCopyPngBytes()).toBe(second);
-    expect(pngBytesMatch(getLastCopyPngBytes()!, first)).toBe(false);
-    expect(pngBytesMatch(getLastCopyPngBytes()!, second)).toBe(true);
+  it('returns false when the alpha shape differs', () => {
+    const opaque = solid(1000, 50, 50, 50, 255);
+    const transparent = solid(1000, 50, 50, 50, 0);
+    expect(pixelsLikelySame(opaque, transparent)).toBe(false);
+  });
+
+  it('ignores RGB under partial/low alpha (premultiplied round-trip is unreliable there)', () => {
+    // Same alpha shape (semi-transparent), wildly different RGB — should still
+    // match because RGB is only compared where both alphas are near-opaque.
+    const a = solid(1000, 10, 20, 30, 100);
+    const b = solid(1000, 200, 180, 160, 100);
+    expect(pixelsLikelySame(a, b)).toBe(true);
+  });
+
+  it('detects a differing region within otherwise-matching content', () => {
+    const a = solid(1000, 0, 0, 0, 255);
+    const b = solid(1000, 0, 0, 0, 255);
+    // Flip a large fraction of pixels to a very different color — well past the
+    // 2% mismatch threshold.
+    for (let i = 0; i < 500; i++) {
+      b[i * 4] = 255;
+      b[i * 4 + 1] = 255;
+      b[i * 4 + 2] = 255;
+    }
+    expect(pixelsLikelySame(a, b)).toBe(false);
   });
 });

--- a/src/app/store/clipboard-image-match.ts
+++ b/src/app/store/clipboard-image-match.ts
@@ -1,37 +1,73 @@
 /**
  * Helpers for deciding whether an image pasted from the system clipboard is a
  * paste-back of content that was copied inside the app. Kept free of engine /
- * store imports so the matching logic stays pure and unit-testable.
- *
- * The decision is made by comparing the incoming PNG blob's bytes against the
- * bytes the app last handed to `navigator.clipboard.write`. This avoids
- * reading the clipboard texture back from the GPU on every paste (#724) —
- * the OS clipboard delivers whatever bytes we wrote, so identical bytes are
- * proof it is still our own copy.
+ * store imports so the pixel-matching logic stays pure and unit-testable.
  */
 
-let lastCopyPngBytes: Uint8Array | null = null;
-
-/** Record the PNG bytes the app just wrote to the system clipboard. */
-export function setLastCopyPngBytes(bytes: Uint8Array | null): void {
-  lastCopyPngBytes = bytes;
-}
-
-/** The PNG bytes of the last app-authored copy, or null before the first copy. */
-export function getLastCopyPngBytes(): Uint8Array | null {
-  return lastCopyPngBytes;
+/** Decode an image blob to straight (non-premultiplied) RGBA bytes. */
+export async function decodeBlobToRgba(
+  blob: Blob,
+): Promise<{ data: Uint8ClampedArray; width: number; height: number } | null> {
+  try {
+    // No color-space conversion / premultiplication so the decoded bytes match
+    // the raw GPU pixels the clipboard PNG was written from — otherwise a
+    // wide-gamut (Display-P3) round-trip could shift RGB past the match
+    // tolerance and drop a legitimate paste-back back to 0,0.
+    const bitmap = await createImageBitmap(blob, {
+      colorSpaceConversion: 'none',
+      premultiplyAlpha: 'none',
+    });
+    const { width, height } = bitmap;
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      bitmap.close();
+      return null;
+    }
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close();
+    return { data: ctx.getImageData(0, 0, width, height).data, width, height };
+  } catch {
+    return null;
+  }
 }
 
 /**
- * Whether two PNG-blob byte streams are identical. The system clipboard
- * preserves exact bytes across major platforms, so exact equality is a
- * definitive "still our own copy" signal — no GPU readback required.
+ * Whether two equal-length RGBA buffers hold (near-)identical content.
+ *
+ * A system-clipboard round-trip can nudge RGB values under partial alpha
+ * (canvas premultiplied-alpha decoding), so RGB is only compared where the
+ * pixel is near-opaque and alpha is compared everywhere with a small
+ * tolerance. Content is sampled — a few thousand pixels is plenty to tell our
+ * own copy apart from an unrelated image of the same dimensions.
  */
-export function pngBytesMatch(a: Uint8Array, b: Uint8Array): boolean {
-  if (a === b) return true;
+export function pixelsLikelySame(
+  a: Uint8Array | Uint8ClampedArray,
+  b: Uint8Array | Uint8ClampedArray,
+): boolean {
   if (a.length !== b.length || a.length === 0) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
+  const pixelCount = a.length / 4;
+  const step = Math.max(1, Math.floor(pixelCount / 4096));
+  let checked = 0;
+  let mismatches = 0;
+  for (let p = 0; p < pixelCount; p += step) {
+    const i = p * 4;
+    checked++;
+    const aAlpha = a[i + 3]!;
+    const bAlpha = b[i + 3]!;
+    if (Math.abs(aAlpha - bAlpha) > 4) {
+      mismatches++;
+      continue;
+    }
+    if (aAlpha > 250 && bAlpha > 250) {
+      if (
+        Math.abs(a[i]! - b[i]!) > 6 ||
+        Math.abs(a[i + 1]! - b[i + 1]!) > 6 ||
+        Math.abs(a[i + 2]! - b[i + 2]!) > 6
+      ) {
+        mismatches++;
+      }
+    }
   }
-  return true;
+  return checked > 0 && mismatches / checked < 0.02;
 }

--- a/src/app/store/clipboard-slice.ts
+++ b/src/app/store/clipboard-slice.ts
@@ -12,7 +12,7 @@ import {
   uploadClipboardPixels,
   compositeForExport,
 } from '../../engine-wasm/wasm-bridge';
-import { pngBytesMatch, setLastCopyPngBytes, getLastCopyPngBytes } from './clipboard-image-match';
+import { decodeBlobToRgba, pixelsLikelySame } from './clipboard-image-match';
 import type { ClipboardData, SliceCreator } from './types';
 
 function writeToSystemClipboard(width: number, height: number): void {
@@ -29,12 +29,6 @@ function writeToSystemClipboard(width: number, height: number): void {
     const imageData = new ImageData(clamped, width, height);
     ctx.putImageData(imageData, 0, 0);
     canvas.convertToBlob({ type: 'image/png' }).then((blob) => {
-      // Remember exactly what bytes we handed the OS. `tryPasteInternalCopy`
-      // compares an incoming clipboard blob against this to decide whether the
-      // OS still holds our copy, without any GPU readback (#724).
-      blob.arrayBuffer().then((buf) => {
-        setLastCopyPngBytes(new Uint8Array(buf));
-      }).catch(() => {});
       if (typeof navigator.clipboard?.write !== 'function') return;
       const item = new ClipboardItem({ 'image/png': blob });
       navigator.clipboard.write([item]).catch(() => {});
@@ -237,18 +231,19 @@ export const createClipboardSlice: SliceCreator<ClipboardSlice> = (set, get) => 
     const engine = getEngine();
     if (!engine) return false;
 
-    // The OS clipboard delivers the exact PNG bytes we handed to
-    // `navigator.clipboard.write` when the app copied. Comparing those
-    // bytes directly avoids the ~35 MB GPU readback the old pixel-sample
-    // path used to force on every paste (#724). If the bytes don't
-    // match, the system clipboard has been replaced by another app —
-    // treat it as an external image.
-    const ownBytes = getLastCopyPngBytes();
-    if (!ownBytes) return false;
-    const incomingBuf = await blob.arrayBuffer().catch(() => null);
-    if (!incomingBuf) return false;
-    const incoming = new Uint8Array(incomingBuf);
-    if (!pngBytesMatch(ownBytes, incoming)) return false;
+    const decoded = await decodeBlobToRgba(blob);
+    if (!decoded || decoded.width !== clip.width || decoded.height !== clip.height) return false;
+
+    // read_clipboard_pixels throws when the GPU clipboard texture is gone
+    // (e.g. after the engine was reset by File > New), which also guards
+    // paste() below from operating on a released clipboard.
+    let clipPixels: Uint8Array;
+    try {
+      clipPixels = readClipboardPixels(engine);
+    } catch {
+      return false;
+    }
+    if (!pixelsLikelySame(clipPixels, decoded.data)) return false;
 
     get().paste();
     return true;

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -244,21 +244,23 @@ export function useCanvasInteraction(
 
         // Only expand the active layer's pixel data for tools that actually
         // read/write it via JS. Tools like text, crop, path, eyedropper,
-        // fill, and selection tools don't need pixel data and expanding
-        // would destructively change layer bounds before pushHistory
-        // captures them — causing undo to restore the wrong positions.
+        // and selection tools don't need pixel data and expanding would
+        // destructively change layer bounds before pushHistory captures
+        // them — causing undo to restore the wrong positions.
         // Move is excluded: selection moves use the float system (GPU-only)
         // and non-selection moves call expandLayerForEditing in the handler.
-        // Fill is excluded: handleFillDown chooses between two GPU fast
-        // paths (empty layer, non-contiguous) and a JS path that sources
-        // its own pixels via readLayerPixelsForFill — none of them read
-        // from the painting canvas.
+        // Fill is included: its GPU fast paths call the engine's
+        // ensure_layer_full_size internally, which resets the engine layer
+        // descriptor to a doc-sized texture at the origin. expandLayerForEditing
+        // performs the matching Zustand reconciliation (x/y AND width/height via
+        // withLayerBounds); without it the store keeps the pre-fill offset and
+        // engine-sync re-applies it, double-offsetting the filled content (#722).
         // Quick Mask Mode paints on the quick mask buffer (not the layer), so
         // no pixel data expansion is needed — same as non-paint tools.
         // Layer-mask edit mode paints on the mask texture via gpuMaskDabBatch
         // and never reads the layer's own RGBA, so expanding + uploading the
         // full-res layer buffer is pure waste (71.64 MB / stroke at 4K, #733).
-        const needsPixelData = isPaintTool && !isQuickMaskMode && !maskEditMode;
+        const needsPixelData = (isPaintTool && !isQuickMaskMode && !maskEditMode) || activeTool === 'fill';
         if (needsPixelData) {
           const imageData = editorState.expandLayerForEditing(activeLayerId);
           expandedLayer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId)!;


### PR DESCRIPTION
## What

The nightly e2e run on `origin/main` (`b9162653`) surfaced **5 real
failures**, all traced by bisection to **#726** (the "nightly autofix
batch", `39aefe5e`). #726's e2e specs were never run in CI (e2e isn't in
GitHub CI), so two of its four bundled optimizations shipped broken. This
PR reverts **only those two** (#722 fill, #724 clipboard) and keeps the
working ones (#721 bare-click move history, #723 navigator minimap).

| failing spec | root cause | fixed by |
|---|---|---|
| `autofix-721-722-723-724.spec.ts:69` (#722) | fill | fill revert |
| `fill-bucket-perf.spec.ts:54` (#667) | fill | fill revert |
| `rendering.spec.ts:3137` (multi-step undo) | fill | fill revert |
| `composition-export-roundtrip.spec.ts:393` (Neon City) | fill | fill revert |
| `cut-paste-position.spec.ts:625` (undo/redo stress) | clipboard | clipboard revert |

(`history.spec.ts:134` also flickered — it is the known standing flaky
and net-passed on retry.)

## Root causes

**#722 (fill).** The optimization dropped `expandLayerForEditing` for the
fill tool. But the GPU fast-path fills call the engine's
`ensure_layer_full_size` internally, which resets the engine layer
descriptor to a doc-sized texture at the origin **without touching the
Zustand store**. The store keeps the pre-fill offset, `engine-sync`
re-applies it next frame, and the filled content composites at **double**
the layer offset. Any bucket fill on a layer whose content is offset from
the origin (moved, or content-cropped) lands in the wrong place.

**#724 (clipboard).** The optimization replaced the GPU-pixel-sample
paste-identity check with a direct **PNG-byte** comparison against the
bytes handed to `navigator.clipboard.write`. The OS clipboard round-trip
re-encodes the PNG, so our own internal copy fails the byte match, is
misidentified as an external image, and is pasted at **(0, 0)**. In a
multi-step flow that leaves a stale selection over (0, 0); a following
whole-canvas marquee that starts at doc (0, 0) lands inside it and *moves*
it instead of creating a new one (pre-existing marquee behaviour), so the
final whole-canvas fill is rejected as outside the selection.

## Verification

- `npm run typecheck` clean; `npm run lint` 0 errors; vitest fill +
  clipboard unit tests green (25/25).
- All 5 failing specs now pass on **chromium** and (where they run)
  **firefox**, `--retries=0`.
- Full `cut-paste-position.spec.ts` re-run green on both projects (no
  regression from the clipboard revert).

## Follow-up

Both reverts reintroduce the readback each optimization aimed to remove.
To re-land safely later:
- **#722**: skip the pre-fill pixel readback but still reconcile the
  store bounds (position **and** dimensions) after the GPU fill — a
  position-only sync causes the descriptor drift documented in
  `fitActiveLayerToCanvas` (#721).
- **#724**: byte-equality is the wrong identity signal (clipboard
  re-encodes PNGs); a content hash of the decoded pixels, or keeping the
  readback, is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
