### PR TITLE
perf(nightly): kill three wasm-bridge round-trips per stroke

### DIFF
--- a/e2e/autofix-732-733-734.spec.ts
+++ b/e2e/autofix-732-733-734.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type Page } from './fixtures';
+import { waitForStore, createDocument, selectTool, docToScreen } from './helpers';
+
+// Coverage for the nightly autofix batch:
+// - #733 (mask-edit paint no longer materializes the layer's own RGBA
+//   pixel buffer, which was a 71.64 MB round-trip per stroke at 4K)
+//
+// #732 (shape/gradient per-move pixel-version bump) and #734
+// (stroke-end mask readback echoed straight back on the next frame) are
+// unit-tested at their layer — see:
+//  - src/tools/shape/shape-interaction.test.ts
+//  - src/tools/gradient/gradient-interaction.test.ts
+//  - src/engine-wasm/sync-state.test.ts
+//  - src/engine-wasm/sync-layers.test.ts
+// Both fixes are pure JS-layer behaviour a Playwright browser cannot
+// observe without an instrumented build (the point of the fix is the
+// absence of a call), so the unit coverage carries the regression
+// contract there.
+
+async function addMaskToActiveLayer(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => {
+        document: { activeLayerId: string | null };
+        addLayerMask: (id: string) => void;
+      };
+    };
+    const state = store.getState();
+    state.addLayerMask(state.document.activeLayerId!);
+  });
+  await page.waitForTimeout(200);
+}
+
+async function activeLayerPixelDataPresent(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const editorStore = (window as unknown as Record<string, unknown>).__editorStore as {
+      getState: () => { document: { activeLayerId: string | null } };
+    };
+    const pxManager = (window as unknown as Record<string, unknown>).__pixelData as {
+      get: (id: string) => unknown;
+    };
+    const id = editorStore.getState().document.activeLayerId;
+    if (!id) return false;
+    return pxManager.get(id) !== undefined;
+  });
+}
+
+test.describe('#733 — mask-edit paint no longer round-trips the layer RGBA', () => {
+  test('a brush stroke on a layer mask leaves the layer\'s JS pixel cache empty', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'layer panel requires sidebar, hidden on touch devices');
+    test.setTimeout(600_000);
+    await page.goto('/');
+    await waitForStore(page);
+
+    // Big enough that any accidental `expandLayerForEditing` shows up as
+    // a huge JS heap allocation (the regression populated a 4096-byte
+    // buffer times 800x600 = 1.92 MB per stroke at this size).
+    await createDocument(page, 800, 600, false);
+    await addMaskToActiveLayer(page);
+
+    // Baseline: the layer starts with no dense JS pixel data cached —
+    // the engine's GPU texture is source of truth.
+    expect(await activeLayerPixelDataPresent(page)).toBe(false);
+
+    // Enter mask edit mode via the mask thumbnail so the interaction
+    // dispatcher sets maskMode='layerMask'.
+    await page.getByRole('button', { name: /Edit mask for/ }).click();
+    await page.waitForTimeout(150);
+    const maskMode = await page.evaluate(() => {
+      const ui = (window as unknown as Record<string, unknown>).__uiStore as {
+        getState: () => { maskMode: string };
+      };
+      return ui.getState().maskMode;
+    });
+    expect(maskMode).toBe('layerMask');
+
+    // Paint on the mask. Before #733, handleToolDown's needsPixelData
+    // gate fired for `isPaintTool && !isQuickMaskMode`, which is TRUE
+    // in mask-edit mode too — so `expandLayerForEditing` ran and
+    // populated the JS pixel cache for the *layer* even though only
+    // the mask texture was being written.
+    await selectTool(page, 'brush');
+    const start = await docToScreen(page, 100, 300);
+    const end = await docToScreen(page, 700, 300);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 20 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    // Post-condition: the layer's JS pixel cache is still empty. If the
+    // regression returns, `expandLayerForEditing` will have stored an
+    // ImageData for the active layer here.
+    expect(await activeLayerPixelDataPresent(page)).toBe(false);
+
+    // Sanity: the mask actually got painted. Values drop from 255
+    // (fully reveal) toward 0 (hide) where the brush ran.
+    const paintedZeros = await page.evaluate(() => {
+      const store = (window as unknown as Record<string, unknown>).__editorStore as {
+        getState: () => {
+          document: {
+            activeLayerId: string | null;
+            layers: Array<{ id: string; mask: { data: Uint8ClampedArray } | null }>;
+          };
+        };
+      };
+      const state = store.getState();
+      const layer = state.document.layers.find((l) => l.id === state.document.activeLayerId);
+      if (!layer?.mask) return -1;
+      let dark = 0;
+      for (const v of layer.mask.data) if (v < 200) dark++;
+      return dark;
+    });
+    expect(paintedZeros).toBeGreaterThan(500);
+  });
+});

--- a/scripts/check-pixel-debt.mjs
+++ b/scripts/check-pixel-debt.mjs
@@ -50,7 +50,8 @@ const ALLOWLIST = {
   'src/app/store/actions/resize-image.test.ts': 1,
   'src/app/store/clipboard-image-match.test.ts': 1,
   'src/engine-wasm/engine-sync.test.ts': 3,
-  'src/engine-wasm/sync-layers.test.ts': 8,            // +1: shared sticky-dirty fixture buffer for #700 regression tests
+  'src/engine-wasm/sync-layers.test.ts': 11,           // +3: fixture buffers for #734 mask-readback seed tests
+  'src/engine-wasm/sync-state.test.ts': 7,             // #734 seedMaskDataRef fixtures
   'src/engine/pixel-data-manager.test.ts': 2,
   'src/engine/pixel-data.test.ts': 1,
   'src/filters/auto-enhance.test.ts': 1,
@@ -67,7 +68,7 @@ const ALLOWLIST = {
   'src/tools/crop/perspective-crop-interaction.test.ts': 1,
   'src/tools/crop/perspective-crop.test.ts': 3,             // see #441 (delete with prod file)
   'src/tools/fill/fill-interaction.test.ts': 3,
-  'src/tools/gradient/gradient-interaction.test.ts': 2,
+  'src/tools/gradient/gradient-interaction.test.ts': 3,        // #732 mask-mode fixture buffer
   'src/tools/magnetic-lasso/magnetic-lasso-strategy.test.ts': 4,
   'src/tools/magnetic-lasso/magnetic-lasso.test.ts': 2,
   'src/tools/marquee/marquee-strategy.test.ts': 8,

--- a/src/app/useCanvasInteraction.ts
+++ b/src/app/useCanvasInteraction.ts
@@ -11,7 +11,7 @@ import {
   readMaskTexture,
   restoreFromGpuSnapshot,
 } from '../engine-wasm/wasm-bridge';
-import { flushLayerSync, resetTrackedState, syncDocumentSize, syncSelection } from '../engine-wasm/engine-sync';
+import { flushLayerSync, resetTrackedState, seedMaskDataRef, syncDocumentSize, syncSelection } from '../engine-wasm/engine-sync';
 import { smoothStroke, HOLD_TIMEOUT_MS } from '../tools/smooth-line/smooth-line';
 import { mirrorBatchPoints } from '../tools/symmetry';
 import { useToolSettingsStore } from './tool-settings-store';
@@ -255,7 +255,10 @@ export function useCanvasInteraction(
         // from the painting canvas.
         // Quick Mask Mode paints on the quick mask buffer (not the layer), so
         // no pixel data expansion is needed — same as non-paint tools.
-        const needsPixelData = isPaintTool && !isQuickMaskMode;
+        // Layer-mask edit mode paints on the mask texture via gpuMaskDabBatch
+        // and never reads the layer's own RGBA, so expanding + uploading the
+        // full-res layer buffer is pure waste (71.64 MB / stroke at 4K, #733).
+        const needsPixelData = isPaintTool && !isQuickMaskMode && !maskEditMode;
         if (needsPixelData) {
           const imageData = editorState.expandLayerForEditing(activeLayerId);
           expandedLayer = useEditorStore.getState().document.layers.find((l) => l.id === activeLayerId)!;
@@ -606,7 +609,12 @@ export function useCanvasInteraction(
           if (maskData) {
             const layer = useEditorStore.getState().document.layers.find((l) => l.id === state.layerId);
             if (layer?.mask) {
-              useEditorStore.getState().updateLayerMaskData(state.layerId, new Uint8ClampedArray(maskData));
+              const seeded = new Uint8ClampedArray(maskData);
+              useEditorStore.getState().updateLayerMaskData(state.layerId, seeded);
+              // These bytes just came *from* the GPU — record the readback's
+              // reference as the tracked one so the next frame's syncLayers
+              // doesn't upload them straight back (#734).
+              seedMaskDataRef(engine, state.layerId, seeded);
             }
           }
         }

--- a/src/engine-wasm/engine-sync.ts
+++ b/src/engine-wasm/engine-sync.ts
@@ -107,7 +107,7 @@ import { renderTextOnPath } from '../tools/text/render-text-on-path';
 import { getTracked } from './sync-state';
 import { syncLayers } from './sync-layers';
 
-export { resetTrackedState } from './sync-state';
+export { resetTrackedState, seedMaskDataRef } from './sync-state';
 export { syncLayers } from './sync-layers';
 
 function buildGradientMapLut(

--- a/src/engine-wasm/sync-layers.test.ts
+++ b/src/engine-wasm/sync-layers.test.ts
@@ -259,6 +259,46 @@ describe('syncLayers — group mask upload', () => {
     syncLayers(engine, [group], [group.id], new Set());
     expect(vi.mocked(bridge.uploadLayerMask)).not.toHaveBeenCalled();
   });
+
+  // Issue #734 — the stroke-end readback writes a freshly allocated
+  // Uint8ClampedArray into the store. Without a seed, sync-layers sees a
+  // new reference and re-uploads bytes the GPU already holds (17.91 MB
+  // per mask stroke at 4K). seedMaskDataRef records the readback's own
+  // array so the next sync short-circuits the upload.
+  it('does not re-upload the mask when seedMaskDataRef pre-registers the readback array', async () => {
+    const { seedMaskDataRef } = await import('./sync-state');
+    const engine = makeFakeEngine();
+    const readback = new Uint8ClampedArray(64 * 64).fill(200);
+    const raster: RasterLayer = {
+      ...baseRasterLayer,
+      id: 'r1',
+      mask: { id: 'm1', enabled: true, data: readback, width: 64, height: 64 },
+    };
+
+    // Simulate the useCanvasInteraction flow: readMaskTexture returns bytes,
+    // the store stores them, and seedMaskDataRef records the reference.
+    seedMaskDataRef(engine, 'r1', readback);
+
+    syncLayers(engine, [raster], [raster.id], new Set());
+    expect(vi.mocked(bridge.uploadLayerMask)).not.toHaveBeenCalled();
+  });
+
+  it('still uploads when the mask data array is a different reference than the seed', async () => {
+    const { seedMaskDataRef } = await import('./sync-state');
+    const engine = makeFakeEngine();
+    const seeded = new Uint8ClampedArray(64 * 64).fill(100);
+    // A later paint replaces the mask data with a distinct reference.
+    const updated = new Uint8ClampedArray(64 * 64).fill(150);
+    const raster: RasterLayer = {
+      ...baseRasterLayer,
+      id: 'r1',
+      mask: { id: 'm1', enabled: true, data: updated, width: 64, height: 64 },
+    };
+
+    seedMaskDataRef(engine, 'r1', seeded);
+    syncLayers(engine, [raster], [raster.id], new Set());
+    expect(vi.mocked(bridge.uploadLayerMask)).toHaveBeenCalledOnce();
+  });
 });
 
 describe('syncLayers — tracked-state cleanup on layer removal', () => {

--- a/src/engine-wasm/sync-state.test.ts
+++ b/src/engine-wasm/sync-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { Engine } from './wasm-bridge';
+import { getTracked, resetTrackedState, seedMaskDataRef } from './sync-state';
+
+const makeFakeEngine = () => ({}) as unknown as Engine;
+
+describe('seedMaskDataRef — issue #734', () => {
+  it('records the given array as the tracked mask ref so syncLayers treats it as already-uploaded', () => {
+    const engine = makeFakeEngine();
+    resetTrackedState(engine);
+
+    const bytes = new Uint8ClampedArray(64 * 64).fill(200);
+    seedMaskDataRef(engine, 'layer-1', bytes);
+
+    const tracked = getTracked(engine);
+    // Reference equality is what the mask upload gate in sync-layers uses.
+    expect(tracked.maskDataRefs.get('layer-1')).toBe(bytes);
+  });
+
+  it('replaces any prior tracked ref for the same layer', () => {
+    const engine = makeFakeEngine();
+    resetTrackedState(engine);
+    const older = new Uint8ClampedArray(16);
+    const newer = new Uint8ClampedArray(16);
+    seedMaskDataRef(engine, 'layer-1', older);
+    seedMaskDataRef(engine, 'layer-1', newer);
+
+    const tracked = getTracked(engine);
+    expect(tracked.maskDataRefs.get('layer-1')).toBe(newer);
+    expect(tracked.maskDataRefs.get('layer-1')).not.toBe(older);
+  });
+
+  it('clears the prior mask upload-failure entry so a genuinely new ref retries cleanly', () => {
+    const engine = makeFakeEngine();
+    resetTrackedState(engine);
+    const tracked = getTracked(engine);
+    const failedRef = new Uint8ClampedArray(4);
+    tracked.uploadFailures.set('layer-1:mask', { count: 5, dataRef: failedRef });
+
+    seedMaskDataRef(engine, 'layer-1', new Uint8ClampedArray(4));
+
+    expect(tracked.uploadFailures.has('layer-1:mask')).toBe(false);
+  });
+
+  it('does not touch other layers', () => {
+    const engine = makeFakeEngine();
+    resetTrackedState(engine);
+    const other = new Uint8ClampedArray(4);
+    seedMaskDataRef(engine, 'other', other);
+    seedMaskDataRef(engine, 'layer-1', new Uint8ClampedArray(4));
+
+    const tracked = getTracked(engine);
+    expect(tracked.maskDataRefs.get('other')).toBe(other);
+  });
+});

--- a/src/engine-wasm/sync-state.ts
+++ b/src/engine-wasm/sync-state.ts
@@ -207,3 +207,22 @@ export function resetTrackedState(engine: Engine): void {
   trackedByEngine.set(engine, createTrackedState());
 }
 
+/**
+ * Record the mask array `syncLayers` should treat as already-uploaded.
+ *
+ * The mask upload gate is reference-equality on `layer.mask.data`. When the
+ * app reads the mask back from the GPU at stroke end (`readMaskTexture` in
+ * `useCanvasInteraction`) and writes a freshly allocated `Uint8ClampedArray`
+ * into the store via `updateLayerMaskData`, that new object identity would
+ * otherwise trip the gate on the next frame and the render loop would echo
+ * the bytes straight back to the GPU — 17.91 MB of pure re-upload per mask
+ * stroke at 4K (#734). Seeding the tracked ref with the readback's own array
+ * short-circuits that echo. Also drops any prior upload-failure entry so
+ * genuinely new data still retries cleanly.
+ */
+export function seedMaskDataRef(engine: Engine, layerId: string, data: Uint8ClampedArray): void {
+  const tracked = getTracked(engine);
+  tracked.maskDataRefs.set(layerId, data);
+  tracked.uploadFailures.delete(`${layerId}:mask`);
+}
+

--- a/src/tools/gradient/gradient-interaction.test.ts
+++ b/src/tools/gradient/gradient-interaction.test.ts
@@ -29,8 +29,9 @@ vi.mock('../../engine-wasm/engine-state', () => ({
   getEngine: () => ({ __engine: 'mock' }),
 }));
 
+const clearJsPixelData = vi.fn();
 vi.mock('../../app/store/clear-js-pixel-data', () => ({
-  clearJsPixelData: vi.fn(),
+  clearJsPixelData: (...args: unknown[]) => clearJsPixelData(...args),
 }));
 
 const syncLayerAfterFullSize = vi.fn();
@@ -154,6 +155,45 @@ describe('gradient drag lifecycle (issue #338)', () => {
     const state = handleGradientDown(makeCtx());
     handleGradientUp(state);
     expect(endGradientPreview).toHaveBeenCalledTimes(1);
+  });
+
+  // Issue #732 — the pixel-version bump moved from move to up. Bumping on
+  // every move stalls the pipeline via glReadPixels for each thumbnail
+  // subscriber; the drag preview stays visible via the GPU preview path.
+  it('does not bump the pixel version per move; bumps once on up', () => {
+    clearJsPixelData.mockClear();
+    const state = handleGradientDown(makeCtx());
+    handleGradientMove(state, { x: 50, y: 50 });
+    handleGradientMove(state, { x: 60, y: 60 });
+    handleGradientMove(state, { x: 70, y: 70 });
+    expect(clearJsPixelData).not.toHaveBeenCalled();
+    handleGradientUp(state);
+    expect(clearJsPixelData).toHaveBeenCalledTimes(1);
+    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
+  });
+
+  it('does not bump the layer pixel version on up in mask-edit mode', () => {
+    clearJsPixelData.mockClear();
+    uiStateValues.maskEditMode = true;
+    const ctx = makeCtx();
+    (ctx.activeLayer as unknown as { mask: { data: Uint8ClampedArray; width: number; height: number } }).mask = {
+      data: new Uint8ClampedArray(4),
+      width: 2,
+      height: 2,
+    };
+    const state = handleGradientDown(ctx);
+    handleGradientMove(state, { x: 50, y: 50 });
+    handleGradientUp(state);
+    expect(clearJsPixelData).not.toHaveBeenCalled();
+  });
+
+  it('does not bump the layer pixel version on up in quick-mask mode', () => {
+    clearJsPixelData.mockClear();
+    uiStateValues.isQuickMaskMode = true;
+    const state = handleGradientDown(makeCtx());
+    handleGradientMove(state, { x: 50, y: 50 });
+    handleGradientUp(state);
+    expect(clearJsPixelData).not.toHaveBeenCalled();
   });
 
   it('clears the gradient preview line on up', () => {

--- a/src/tools/gradient/gradient-interaction.ts
+++ b/src/tools/gradient/gradient-interaction.ts
@@ -96,6 +96,10 @@ export function handleGradientUp(state: InteractionState): void {
         }));
       }
     }
+    // The per-move renders skip clearJsPixelData (#732) so thumbnails don't
+    // stall the pipeline every frame — bump once here so LayerThumbnail /
+    // ChannelsPanel refresh from the committed GPU texture.
+    clearJsPixelData(state.layerId);
   }
 }
 
@@ -165,7 +169,10 @@ export function handleGradientMove(state: InteractionState, layerLocalPos: Point
       const radius = Math.sqrt(dx * dx + dy * dy);
       gpuRenderRadialGradient(engine, state.layerId, startX, startY, radius, stopsJson);
     }
-    clearJsPixelData(state.layerId);
+    // Do not bump the pixel version per pointer-move: LayerThumbnail /
+    // ChannelsPanel subscribe to it, so a per-move bump forces a synchronous
+    // glReadPixels each frame that stalls the whole pipeline at 4K. The bump
+    // happens once from handleGradientUp when the gradient commits (#732).
   }
 
   useEditorStore.getState().notifyRender();

--- a/src/tools/shape/shape-interaction.test.ts
+++ b/src/tools/shape/shape-interaction.test.ts
@@ -228,7 +228,10 @@ describe('shape move', () => {
     expect(args[15]).toBe(2); // stroke width
     expect(args[16]).toBe(5); // sides
     expect(args[17]).toBe(0); // corner radius
-    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
+    // Issue #732 — move must NOT bump the pixel version. That triggers a
+    // full pipeline-stalling glReadPixels for every thumbnail subscriber
+    // (LayerThumbnail, ChannelsPanel) on every pointer-move.
+    expect(clearJsPixelData).not.toHaveBeenCalled();
     expect(editorState.notifyRender).toHaveBeenCalled();
   });
 
@@ -340,6 +343,8 @@ describe('shape up — committing pixels', () => {
     expect(renderShapeExpanded).not.toHaveBeenCalled();
     expect(getLayerEngineBounds).toHaveBeenCalledWith(expect.anything(), 'layer-1');
     expect(uiState.setPendingShapeClick).not.toHaveBeenCalled();
+    // Issue #732 — the pixel-version bump moved from move to up.
+    expect(clearJsPixelData).toHaveBeenCalledWith('layer-1');
   });
 
   it('re-renders expanded when the shape overflows the document bounds', () => {

--- a/src/tools/shape/shape-interaction.ts
+++ b/src/tools/shape/shape-interaction.ts
@@ -127,7 +127,10 @@ export function handleShapeMove(state: InteractionState, layerLocalPos: Point, m
     shape.strokeWidth, shape.polygonSides,
     Math.min(shape.cornerRadius, Math.min(rx * 2, ry * 2) / 2),
   );
-  clearJsPixelData(state.layerId);
+  // Do not bump the pixel version per pointer-move: LayerThumbnail /
+  // ChannelsPanel subscribe to it, so a per-move bump forces a synchronous
+  // glReadPixels each frame that stalls the whole pipeline at 4K. The bump
+  // happens once from handleShapeUp when the shape commits (#732).
   useEditorStore.getState().notifyRender();
 }
 
@@ -216,6 +219,7 @@ export function handleShapeUp(state: InteractionState, layerLocalPos: Point, met
       );
     }
     syncLayerBoundsFromEngine(engine, state.layerId);
+    clearJsPixelData(state.layerId);
   }
 
   if (shape.output === 'path') {


### PR DESCRIPTION
Three fixes for wasm-bridge waste on the paint/mask/shape/gradient
paths, all reported by the wasm-bridge-evaluation watchdog.

## Fixes

### #732 — shape/gradient drags fire a GPU readback per pointer-move

Shape and gradient tools called `clearJsPixelData()` from their
pointer-move handlers, bumping the layer's pixel version on every
mouse event. `LayerThumbnail` / `ChannelsPanel` subscribe to that
version, so each bump forced a synchronous `glReadPixels` — 98% of a
4K shape drag's wall clock was spent inside these readbacks (issue
#732 has the profile). Move the bump into `handleShapeUp` /
`handleGradientUp`; the live preview stays on the GPU preview path
so the user still sees the shape/gradient follow the cursor.

Files: `src/tools/shape/shape-interaction.ts`,
`src/tools/gradient/gradient-interaction.ts`.

### #733 — mask-edit paint round-trips the full layer RGBA

`useCanvasInteraction`'s `useGpu` gate forces the CPU fallback in
mask-edit mode (`useGpu = engine && isGpuTool && !maskEditMode &&
!isQuickMaskMode`), and the `needsPixelData` guard on that fallback
only excluded quick-mask mode. So every mask brush stroke ran
`expandLayerForEditing` on the layer's own RGBA — 71.64 MB uploaded
per stroke at 4K — for a stroke that only writes the mask texture.
Exclude `maskEditMode` from the guard the same way quick-mask
already is.

File: `src/app/useCanvasInteraction.ts`.

### #734 — mask stroke-end readback echoed straight back on next frame

At the end of a layer-mask stroke, `readMaskTexture` returned bytes
that were stored on the layer as a freshly allocated
`Uint8ClampedArray`. The mask upload gate in `sync-layers` uses
reference equality (`prevMaskData !== layer.mask.data`) to decide
whether to re-upload — the fresh reference tripped it and the render
loop echoed the same 17.91 MB back to the GPU on the very next frame.
Add a `seedMaskDataRef` helper to `sync-state` and call it after
`updateLayerMaskData` so the sync gate recognises the GPU as already
holding those bytes.

Files: `src/engine-wasm/sync-state.ts`,
`src/engine-wasm/engine-sync.ts`,
`src/app/useCanvasInteraction.ts`.

## Test coverage

- `src/tools/shape/shape-interaction.test.ts` — asserts move does
  NOT bump the pixel version; up DOES (once).
- `src/tools/gradient/gradient-interaction.test.ts` — same, plus
  mask-mode / quick-mask-mode branches do not touch the layer's
  pixel version.
- `src/engine-wasm/sync-state.test.ts` — covers `seedMaskDataRef`
  semantics (records the ref, replaces on repeat, clears any prior
  upload-failure entry, does not touch other layers).
- `src/engine-wasm/sync-layers.test.ts` — asserts a seeded ref
  suppresses the mask upload, and a genuinely different ref still
  triggers one.
- `e2e/autofix-732-733-734.spec.ts` — drives the mask brush stroke
  through the real UI and asserts `pixelDataManager` holds no dense
  entry for the layer afterward.

## Housekeeping

- `scripts/check-pixel-debt.mjs` budget lines refreshed for the two
  test files that gained a small fixture buffer and the new
  `sync-state.test.ts` fixture file. All allocations remain in the
  "test fixtures" category.

Closes #732.
Closes #733.
Closes #734.

---
_Generated by [Claude Code](https://claude.ai/code/session_015izfduWsbD7ogv9TjCx7Bq)_